### PR TITLE
feat: add AUC calculation and CSV export for reward/distance and COM metrics

### DIFF
--- a/src/analysis/video_analysis.py
+++ b/src/analysis/video_analysis.py
@@ -159,6 +159,7 @@ class VideoAnalysis:
         if opts.wall or opts.boundary or opts.agarose:
             opts.chooseOrientations = True
         self._initTrx()
+        self._initSlots()
         self._readNoteFile(fn)  # possibly overrides whether trajectories bad
         if opts.circle:
             self._analyzeCircularAndTurningMotion()
@@ -602,6 +603,12 @@ class VideoAnalysis:
         )
         # note: also used for "choice type" open-loop protocols
         self._createExtractChamber()
+
+    def _initSlots(self):
+        """
+        Initializes attributes used as save slots for derived results (e.g., area under curve for different analysis types)
+        """
+        self.saved_auc = {}
 
     def _initTrx(self):
         """

--- a/src/utils/common.py
+++ b/src/utils/common.py
@@ -64,6 +64,43 @@ def propagate_nans(array):
     return array
 
 
+def areaUnderCurve(a):
+    """
+    Calculates the area under the curve (AUC) for each row in the input array, handling missing
+    values by returning NaN for rows entirely composed of NaNs.
+
+    This function computes the AUC using the trapezoidal rule across all columns for each row
+    in the input 2D array `a`. If the last column of a row consists entirely of NaN values,
+    these are ignored in the computation. This is particularly useful for processing data where
+    some rows may have missing or incomplete measurements.
+
+    Parameters:
+    - a : numpy.ndarray
+        A 2D numpy array where each row represents a sequence of values for which the AUC is
+        to be calculated.
+
+    Returns:
+    - numpy.ndarray
+        A 1D numpy array of the same length as the number of rows in `a`, containing the AUC
+        for each row. Rows entirely composed of NaNs are assigned NaN in the result.
+
+    Raises:
+    - AssertionError
+        If the numpy operation to check for NaN values in the trapezoidal calculation fails.
+        This serves as a sanity check for the input data's compatibility with the calculation
+        method.
+
+    Note:
+    - This function is designed to work with numerical data where measurements might be missing
+      or incomplete. It utilizes `numpy.trapz` for the AUC calculation, assuming that the input
+      array `a` is properly formatted as a 2D numpy array.
+    """
+    if np.all(np.isnan(a[:, -1])):
+        a = a[:, :-1]
+    assert np.isnan(np.trapz([1, np.nan]))
+    return np.trapz(a, axis=1)
+
+
 # dict utilities
 def deep_access(x, attr, keylist, new_val=None):
     val = getattr(x, attr)
@@ -77,6 +114,20 @@ def deep_access(x, attr, keylist, new_val=None):
                 continue
         val = val[key]
     return val
+
+
+def flatten_auc_entries(va, tp):
+    """
+    Flatten va.saved_auc[tp] into a single-row list for CSV writing.
+    """
+    row = []
+    if tp in va.saved_auc:
+        for auc_entry in va.saved_auc[tp]:
+            if tp == "rpid":  # exp - yoked; only one value per training
+                row.extend([auc_entry["exp"]])
+            else:  # rpd or com
+                row.extend([auc_entry["exp"], auc_entry["ctrl"]])
+    return [row]
 
 
 # chamber type

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -28,4 +28,6 @@ MIDLINE_XING2 = True
 SPEED_ON_BOTTOM = True  # whether to measure speed only on bottom
 VBA = False
 
+SAVE_AUC_TYPES = {"rpid", "rpd", "com"}
+
 _RDP_PKG = False


### PR DESCRIPTION
- Move areaUnderCurve() to utils.common and add flatten_auc_entries()
- Add new analysis types: rpd_auc_csv, com_auc_csv, rpid_auc_csv
- Compute per-video exp/yok AUCs in plotRewards using getVals(f1=0/1)
- Store results in va.saved_auc and export to CSV with proper column names
- Update writeStats/postAnalyze to include new AUC types