### PR TITLE
feat(rewards): add reward timing local variation (LV) metric + bundle export/plotting

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -87,6 +87,7 @@ from src.exporting.lgturn_startdist_sli_bundle import export_lgturn_startdist_sl
 from src.exporting.reward_lgturn_pathlen_sli_bundle import (
     export_reward_lgturn_pathlen_sli_bundle,
 )
+from src.exporting.reward_lv_sli_bundle import export_reward_lv_sli_bundle
 from src.exporting.turnback_sli_bundle import export_turnback_sli_bundle
 from src.exporting.wallpct_sli_bundle import export_wallpct_sli_bundle
 from src.exporting.wall_contacts_per_sync_bkt import save_wall_contacts_per_sync_bkt_npz
@@ -677,6 +678,12 @@ g.add_argument(
     type=str,
     default="imgs/reward_raster.png",
     help="Output path for the reward raster image.",
+)
+g.add_argument(
+    "--reward-lv",
+    action="store_true",
+    help="Compute per-sync-bucket local variation (LV) of reward timing "
+    "(LV≈1: Poisson-like; >1: more clustered). Stores results in va.syncRewardLV.",
 )
 g.add_argument(
     "--btw-rwd-trn",
@@ -2265,6 +2272,12 @@ g.add_argument(
     help="Write an .npz bundle with reward-anchored large-turn path length + SLI for multi-group overlays.",
 )
 g.add_argument(
+    "--export-reward-lv-sli-bundle",
+    type=str,
+    default=None,
+    help="Write an .npz bundle with reward timing local variation + SLI for multi-group overlays.",
+)
+g.add_argument(
     "--reward-lgturn-pathlen-sli-debug",
     action="store_true",
     help="Debug export of reward-lgturn-pathlen+SLI bundle.",
@@ -2813,6 +2826,7 @@ def bucketLenForType(tp):
             "rpid",
             "rpd",
             "rpd_exp_min_yok",
+            "rlv",
             "max_ctr_d_no_contact",
             "psc_conc",
             "psc_shift",
@@ -6571,6 +6585,9 @@ def postAnalyze(vas):
             vas, opts, gls, opts.export_reward_lgturn_pathlen_sli_bundle
         )
 
+    if getattr(opts, "export_reward_lv_sli_bundle", None):
+        export_reward_lv_sli_bundle(vas, opts, gls, opts.export_reward_lv_sli_bundle)
+
     if getattr(opts, "export_agarose_sli_bundle", None):
         export_agarose_sli_bundle(vas, opts, gls, opts.export_agarose_sli_bundle)
 
@@ -8855,6 +8872,9 @@ if __name__ == "__main__":
                 "because --export-wall-contacts-per-sync-bkt-npz was set"
             )
             opts.wall = WALL_CONTACT_DEFAULT_THRESH_STR
+
+    if getattr(opts, "export_reward_lv_sli_bundle", None):
+        opts.reward_lv = True
 
     if opts.turn_prob_by_dist:
         opts.turn_prob_by_dist = parse_distances(opts.turn_prob_by_dist)

--- a/scripts/plot_com_sli_bundles.py
+++ b/scripts/plot_com_sli_bundles.py
@@ -22,13 +22,14 @@ def main():
             "lgturn_startdist",
             "reward_lgturn_pathlen",
             "reward_lgturn_prevalence",
+            "reward_lv",
         ],
     )
     p.add_argument(
         "--turnback-mode",
         default="exp",
         choices=["exp", "ctrl", "exp_minus_ctrl"],
-        help="For metric in {turnback, agarose}: which curve to plot.",
+        help="For metrics with exp/ctrl variants (e.g. turnback, agarose, reward_lgturn_*, reward_lv): which curve to plot.",
     )
     p.add_argument(
         "--labels",

--- a/src/exporting/bundle_utils.py
+++ b/src/exporting/bundle_utils.py
@@ -1,0 +1,122 @@
+# src/exporting/bundle_utils.py
+from __future__ import annotations
+
+import os
+import numpy as np
+
+from src.exporting.com_sli_bundle import (
+    _safe_group_label,
+    _compute_sli_scalar_and_timeseries_from_rpid,
+)
+
+
+def save_metric_plus_sli_bundle(
+    vas,
+    opts,
+    gls,
+    out_fn,
+    *,
+    extract_metric_arrays,  # callable: (vas_ok) -> dict[str, np.ndarray]
+    bucket_type: str,  # passed to bucketLenForType
+    print_label: str,  # for logs
+    require_3d: bool = True,
+):
+    from analyze import bucketLenForType
+
+    if not out_fn.lower().endswith(".npz"):
+        out_fn += ".npz"
+
+    vas_ok = [va for va in vas if not getattr(va, "_skipped", False)]
+    if len(vas_ok) == 0:
+        print(f"[export] No non-skipped VideoAnalysis instances; not writing {out_fn}")
+        return
+
+    va0 = vas_ok[0]
+    group_label = _safe_group_label(opts, gls)
+
+    # ---- metric extraction happens here, after filtering ----
+    metric_arrays = extract_metric_arrays(vas_ok)
+    if not isinstance(metric_arrays, dict) or len(metric_arrays) == 0:
+        raise ValueError(
+            f"{print_label}: extract_metric_arrays returned empty/invalid dict"
+        )
+
+    # Infer (n_trn, nb) from the first metric array and sanity-check shapes
+    any_arr = next(iter(metric_arrays.values()))
+    any_arr = np.asarray(any_arr)
+
+    if require_3d and any_arr.ndim != 3:
+        raise ValueError(
+            f"{print_label}: expected 3D metric arrays (n_videos,n_trn,nb); got {any_arr.shape}"
+        )
+
+    n_videos = len(vas_ok)
+    if any_arr.shape[0] != n_videos:
+        raise ValueError(
+            f"{print_label}: metric first dim {any_arr.shape[0]} != n_videos {n_videos}"
+        )
+
+    n_trn = int(any_arr.shape[1]) if any_arr.ndim >= 2 else 0
+    nb = int(any_arr.shape[2]) if any_arr.ndim >= 3 else 0
+
+    for k, v in metric_arrays.items():
+        v = np.asarray(v)
+        if v.shape[0] != n_videos:
+            raise ValueError(
+                f"{print_label}: metric '{k}' first dim {v.shape[0]} != n_videos {n_videos}"
+            )
+        if require_3d and v.ndim != 3:
+            raise ValueError(f"{print_label}: metric '{k}' expected 3D, got {v.shape}")
+        # optional: enforce same (n_trn, nb) across keys
+        if require_3d and (v.shape[1] != n_trn or v.shape[2] != nb):
+            raise ValueError(
+                f"{print_label}: metric '{k}' shape {v.shape} != ({n_videos},{n_trn},{nb})"
+            )
+
+    # ---- SLI ----
+    try:
+        sli, sli_ts = _compute_sli_scalar_and_timeseries_from_rpid(vas_ok, opts)
+    except Exception as e:
+        print(f"[export] WARNING: failed to compute SLI for {print_label} bundle: {e}")
+        sli = np.full((n_videos,), np.nan, dtype=float)
+        sli_ts = np.full((n_videos, n_trn, nb), np.nan, dtype=float)
+
+    # ---- metadata ----
+    try:
+        bl, _blf = bucketLenForType(bucket_type)
+        bucket_len_min = float(bl)
+    except Exception:
+        bucket_len_min = np.nan
+
+    try:
+        training_names = np.array([t.name() for t in va0.trns], dtype=object)
+    except Exception:
+        training_names = np.array([], dtype=object)
+
+    try:
+        video_ids = np.array(
+            [getattr(va, "fn", f"va_{i}") for i, va in enumerate(vas_ok)],
+            dtype=object,
+        )
+    except Exception:
+        video_ids = np.array([f"va_{i}" for i in range(n_videos)], dtype=object)
+
+    os.makedirs(os.path.dirname(out_fn) or ".", exist_ok=True)
+
+    payload = dict(
+        sli=np.asarray(sli, dtype=float),
+        sli_ts=np.asarray(sli_ts, dtype=float),
+        group_label=np.array(group_label, dtype=object),
+        bucket_len_min=np.array(bucket_len_min, dtype=float),
+        training_names=training_names,
+        video_ids=video_ids,
+        sli_training_idx=np.array(getattr(opts, "best_worst_trn", 1) - 1, dtype=int),
+        sli_use_training_mean=np.array(
+            bool(getattr(opts, "sli_use_training_mean", False))
+        ),
+    )
+
+    payload.update({k: np.asarray(v) for k, v in metric_arrays.items()})
+
+    np.savez_compressed(out_fn, **payload)
+    print(f"[export] Wrote {print_label}+SLI bundle: {out_fn} (n={n_videos})")

--- a/src/exporting/reward_lv_sli_bundle.py
+++ b/src/exporting/reward_lv_sli_bundle.py
@@ -1,0 +1,115 @@
+# src/exporting/reward_lv_sli_bundle.py
+from __future__ import annotations
+
+import numpy as np
+
+from src.exporting.bundle_utils import save_metric_plus_sli_bundle
+
+
+def _extract_reward_lv_arrays(vas):
+    """
+    Returns:
+      reward_lv_exp: (n_videos, n_trains, nb) float with NaNs allowed
+      reward_lv_ctrl: (n_videos, n_trains, nb) float with NaNs allowed (all-NaN if absent)
+    """
+    n_videos = len(vas)
+
+    # Find a reference VA that actually has syncRewardLV
+    ref = None
+    for va in vas:
+        srlv = getattr(va, "syncRewardLV", None)
+        if (
+            srlv is not None
+            and isinstance(srlv, (list, tuple))
+            and len(srlv)
+            and isinstance(srlv[0], dict)
+        ):
+            ref = va
+            break
+
+    if ref is None:
+        return (
+            np.full((n_videos, 0, 0), np.nan, dtype=float),
+            np.full((n_videos, 0, 0), np.nan, dtype=float),
+        )
+
+    srlv_ref = getattr(ref, "syncRewardLV", []) or []
+    n_trains = len(srlv_ref)
+
+    # Infer nb by scanning for the first non-empty exp list.
+    nb = 0
+    for ti in range(n_trains):
+        trn_dict = srlv_ref[ti] if isinstance(srlv_ref[ti], dict) else {}
+        exp_vals = trn_dict.get("exp", None)
+        if exp_vals is not None:
+            try:
+                nb = len(exp_vals)
+            except Exception:
+                nb = 0
+        if nb > 0:
+            break
+
+    # Defensive fallback: scan other VAs in case ref has no full buckets
+    if nb == 0:
+        for va in vas:
+            srlv = getattr(va, "syncRewardLV", None)
+            if srlv is None or len(srlv) != n_trains:
+                continue
+            for ti in range(n_trains):
+                trn_dict = srlv[ti] if isinstance(srlv[ti], dict) else {}
+                exp_vals = trn_dict.get("exp", None)
+                if exp_vals is None:
+                    continue
+                try:
+                    nb = len(exp_vals)
+                except Exception:
+                    nb = 0
+                if nb > 0:
+                    break
+            if nb > 0:
+                break
+
+    reward_lv_exp = np.full((n_videos, n_trains, nb), np.nan, dtype=float)
+    reward_lv_ctrl = np.full((n_videos, n_trains, nb), np.nan, dtype=float)
+
+    if nb == 0 or n_trains == 0:
+        return reward_lv_exp, reward_lv_ctrl
+
+    for vi, va in enumerate(vas):
+        srlv = getattr(va, "syncRewardLV", None)
+        if srlv is None or len(srlv) != n_trains:
+            continue
+
+        for ti in range(n_trains):
+            trn_dict = srlv[ti] if isinstance(srlv[ti], dict) else {}
+
+            exp_vals = trn_dict.get("exp", None)
+            if exp_vals is not None:
+                exp_vals = np.asarray(exp_vals, dtype=float).reshape(-1)
+                reward_lv_exp[vi, ti, : min(nb, exp_vals.size)] = exp_vals[:nb]
+
+            ctrl_vals = trn_dict.get("ctrl", None)
+            if ctrl_vals is not None:
+                ctrl_vals = np.asarray(ctrl_vals, dtype=float).reshape(-1)
+                reward_lv_ctrl[vi, ti, : min(nb, ctrl_vals.size)] = ctrl_vals[:nb]
+
+    return reward_lv_exp, reward_lv_ctrl
+
+
+def export_reward_lv_sli_bundle(vas, opts, gls, out_fn):
+    def _extractor(vas_ok):
+        exp, ctrl = _extract_reward_lv_arrays(vas_ok)
+        return {
+            "reward_lv_exp": exp,
+            "reward_lv_ctrl": ctrl,
+        }
+
+    save_metric_plus_sli_bundle(
+        vas,
+        opts,
+        gls,
+        out_fn,
+        extract_metric_arrays=_extractor,
+        bucket_type="rlv",
+        print_label="reward_lv",
+    )


### PR DESCRIPTION
- Adds per-sync-bucket **local variation (LV)** of reward timing (`VideoAnalysis.bySyncBucketRewardLV`, stored in `va.syncRewardLV`).
- Adds export path `--export-reward-lv-sli-bundle` (NPZ bundle includes `reward_lv_exp/ctrl`, SLI + metadata); export implies compute.
- Adds generic bundle helper `save_metric_plus_sli_bundle()` to DRY up metric+SLI bundle exports.
- Extends bundle plotting to support `--metric reward_lv` (exp/ctrl/exp-minus-ctrl via `--turnback-mode`).