### PR TITLE
Add correctness checks for between-reward distance metrics

### DIFF
--- a/src/analysis/sli_bundle_utils.py
+++ b/src/analysis/sli_bundle_utils.py
@@ -38,6 +38,20 @@ RETURN_PROB_EXCURSION_BIN_KEYS = (
     "return_prob_excursion_bin_edges_mm",
 )
 
+BETWEEN_REWARD_MAXDIST_KEYS = (
+    "between_reward_maxdist_exp",
+    "between_reward_maxdist_ctrl",
+    "between_reward_maxdistN_exp",
+    "between_reward_maxdistN_ctrl",
+)
+
+BETWEEN_REWARD_RETURN_LEG_DIST_KEYS = (
+    "between_reward_return_leg_dist_exp",
+    "between_reward_return_leg_dist_ctrl",
+    "between_reward_return_leg_distN_exp",
+    "between_reward_return_leg_distN_ctrl",
+)
+
 
 def as_scalar(x):
     if isinstance(x, np.ndarray) and x.shape == ():
@@ -168,6 +182,137 @@ def _validate_return_prob_count_array(
     if np.any(arr != np.floor(arr)):
         raise ValueError(f"Bundle {where} has non-integer values in {key}")
     return arr.astype(int, copy=False)
+
+
+def _validate_3d_distance_metric_array(
+    bundle: dict,
+    key: str,
+    *,
+    where: str,
+    expected_shape: tuple[int, int, int],
+) -> np.ndarray:
+    arr = np.asarray(bundle[key], dtype=float)
+    if arr.ndim != 3:
+        raise ValueError(f"Bundle {where} has non-3D {key} shape {arr.shape}")
+    if arr.shape != expected_shape:
+        raise ValueError(
+            f"Bundle {where} has {key}.shape={arr.shape} "
+            f"but expected {expected_shape}"
+        )
+    if np.any(np.isinf(arr)):
+        raise ValueError(f"Bundle {where} has infinite values in {key}")
+    finite = np.isfinite(arr)
+    if np.any(arr[finite] < 0.0):
+        raise ValueError(f"Bundle {where} has negative values in {key}")
+    return arr
+
+
+def _validate_3d_distance_count_array(
+    bundle: dict,
+    key: str,
+    *,
+    where: str,
+    expected_shape: tuple[int, int, int],
+) -> np.ndarray:
+    arr = np.asarray(bundle[key])
+    if arr.ndim != 3:
+        raise ValueError(f"Bundle {where} has non-3D {key} shape {arr.shape}")
+    if arr.shape != expected_shape:
+        raise ValueError(
+            f"Bundle {where} has {key}.shape={arr.shape} "
+            f"but expected {expected_shape}"
+        )
+    arr_float = arr.astype(float)
+    if np.any(~np.isfinite(arr_float)):
+        raise ValueError(f"Bundle {where} has non-finite values in {key}")
+    if np.any(arr_float < 0):
+        raise ValueError(f"Bundle {where} has negative values in {key}")
+    if np.any(arr_float != np.floor(arr_float)):
+        raise ValueError(f"Bundle {where} has non-integer values in {key}")
+    return arr.astype(int, copy=False)
+
+
+def _expected_sync_bucket_metric_shape(
+    bundle: dict,
+    *,
+    where: str,
+) -> tuple[int, int, int]:
+    sli = np.asarray(bundle["sli"], dtype=float)
+    n_videos = int(sli.shape[0])
+    if "sli_ts" not in bundle:
+        raise ValueError(
+            f"Bundle {where} is missing sli_ts needed to validate sync-bucket metrics"
+        )
+    sli_ts = np.asarray(bundle["sli_ts"], dtype=float)
+    if sli_ts.ndim != 3:
+        raise ValueError(f"Bundle {where} has non-3D sli_ts shape: {sli_ts.shape}")
+    return (n_videos, int(sli_ts.shape[1]), int(sli_ts.shape[2]))
+
+
+def validate_between_reward_sync_bucket_distance_bundle(
+    bundle: dict,
+    *,
+    metric_name: str,
+    value_exp_key: str,
+    value_ctrl_key: str,
+    count_exp_key: str,
+    count_ctrl_key: str,
+    path: str | None = None,
+) -> None:
+    where = _bundle_label(bundle, path)
+    keys = (value_exp_key, value_ctrl_key, count_exp_key, count_ctrl_key)
+    missing = [k for k in keys if k not in bundle]
+    if missing:
+        raise ValueError(f"Bundle {where} is missing {metric_name} keys: {missing}")
+
+    expected_shape = _expected_sync_bucket_metric_shape(bundle, where=where)
+    value_exp = _validate_3d_distance_metric_array(
+        bundle, value_exp_key, where=where, expected_shape=expected_shape
+    )
+    value_ctrl = _validate_3d_distance_metric_array(
+        bundle, value_ctrl_key, where=where, expected_shape=expected_shape
+    )
+    count_exp = _validate_3d_distance_count_array(
+        bundle, count_exp_key, where=where, expected_shape=expected_shape
+    )
+    count_ctrl = _validate_3d_distance_count_array(
+        bundle, count_ctrl_key, where=where, expected_shape=expected_shape
+    )
+
+    for key, values, counts in (
+        (value_exp_key, value_exp, count_exp),
+        (value_ctrl_key, value_ctrl, count_ctrl),
+    ):
+        if np.any(np.isfinite(values[counts == 0])):
+            raise ValueError(f"Bundle {where} has finite {key} where count == 0")
+
+
+def validate_between_reward_maxdist_bundle(
+    bundle: dict, *, path: str | None = None
+) -> None:
+    validate_between_reward_sync_bucket_distance_bundle(
+        bundle,
+        metric_name="between-reward max-distance",
+        value_exp_key="between_reward_maxdist_exp",
+        value_ctrl_key="between_reward_maxdist_ctrl",
+        count_exp_key="between_reward_maxdistN_exp",
+        count_ctrl_key="between_reward_maxdistN_ctrl",
+        path=path,
+    )
+
+
+def validate_between_reward_return_leg_dist_bundle(
+    bundle: dict, *, path: str | None = None
+) -> None:
+    validate_between_reward_sync_bucket_distance_bundle(
+        bundle,
+        metric_name="between-reward return-leg distance",
+        value_exp_key="between_reward_return_leg_dist_exp",
+        value_ctrl_key="between_reward_return_leg_dist_ctrl",
+        count_exp_key="between_reward_return_leg_distN_exp",
+        count_ctrl_key="between_reward_return_leg_distN_ctrl",
+        path=path,
+    )
 
 
 def validate_return_prob_excursion_bin_bundle(
@@ -356,6 +501,10 @@ def normalize_sli_bundle(bundle: dict, *, path: str | None = None) -> dict:
     validate_sli_bundle(out, path=path)
     if any(k in out for k in RETURN_PROB_EXCURSION_BIN_KEYS):
         validate_return_prob_excursion_bin_bundle(out, path=path)
+    if any(k in out for k in BETWEEN_REWARD_MAXDIST_KEYS):
+        validate_between_reward_maxdist_bundle(out, path=path)
+    if any(k in out for k in BETWEEN_REWARD_RETURN_LEG_DIST_KEYS):
+        validate_between_reward_return_leg_dist_bundle(out, path=path)
     return out
 
 

--- a/src/plotting/between_reward_conditioned_disttrav.py
+++ b/src/plotting/between_reward_conditioned_disttrav.py
@@ -340,12 +340,20 @@ class BetweenRewardConditionedDistTravResult:
         edges = np.asarray(self.x_edges, dtype=float)
         if edges.ndim != 1 or edges.size < 2:
             raise ValueError("x_edges must be 1D with >= 2 entries")
+        if not np.all(np.isfinite(edges)):
+            raise ValueError("x_edges must contain only finite values")
+        if np.any(np.diff(edges) <= 0):
+            raise ValueError("x_edges must be strictly increasing")
         B = int(edges.size - 1)
 
         def _check_1d(name: str) -> None:
             arr = np.asarray(getattr(self, name))
             if arr.ndim != 1 or arr.size != B:
                 raise ValueError(f"{name} must be 1D with length {B}")
+
+        def _as_float_1d(name: str) -> np.ndarray:
+            _check_1d(name)
+            return np.asarray(getattr(self, name), dtype=float)
 
         for nm in (
             "x_centers",
@@ -359,26 +367,91 @@ class BetweenRewardConditionedDistTravResult:
         ):
             _check_1d(nm)
 
+        centers = _as_float_1d("x_centers")
+        expected_centers = 0.5 * (edges[:-1] + edges[1:])
+        if not np.all(np.isfinite(centers)):
+            raise ValueError("x_centers must contain only finite values")
+        if not np.allclose(centers, expected_centers, rtol=0.0, atol=1e-12):
+            raise ValueError("x_centers must equal x_edges bin midpoints")
+
+        n_units = np.asarray(self.n_units)
+        n_units_float = n_units.astype(float)
+        if np.any(~np.isfinite(n_units_float)):
+            raise ValueError("n_units must contain only finite values")
+        if np.any(n_units_float < 0):
+            raise ValueError("n_units must be nonnegative")
+        if np.any(n_units_float != np.floor(n_units_float)):
+            raise ValueError("n_units must contain integer values")
+
+        def _check_summary(metric: str) -> None:
+            mean = _as_float_1d(f"mean_{metric}")
+            lo = _as_float_1d(f"ci_lo_{metric}")
+            hi = _as_float_1d(f"ci_hi_{metric}")
+
+            for name, arr in (
+                (f"mean_{metric}", mean),
+                (f"ci_lo_{metric}", lo),
+                (f"ci_hi_{metric}", hi),
+            ):
+                if np.any(np.isinf(arr)):
+                    raise ValueError(f"{name} must not contain infinite values")
+                finite = np.isfinite(arr)
+                if np.any(arr[finite] < 0.0):
+                    raise ValueError(f"{name} must be nonnegative where finite")
+
+            finite_ci = np.isfinite(mean) & np.isfinite(lo) & np.isfinite(hi)
+            if np.any(lo[finite_ci] > mean[finite_ci]):
+                raise ValueError(f"ci_lo_{metric} must be <= mean_{metric}")
+            if np.any(mean[finite_ci] > hi[finite_ci]):
+                raise ValueError(f"mean_{metric} must be <= ci_hi_{metric}")
+
+            empty = n_units_float == 0
+            for name, arr in (
+                (f"mean_{metric}", mean),
+                (f"ci_lo_{metric}", lo),
+                (f"ci_hi_{metric}", hi),
+            ):
+                if np.any(np.isfinite(arr[empty])):
+                    raise ValueError(f"{name} must be NaN where n_units == 0")
+
+        _check_summary("total")
+        _check_summary("tail")
+
+        pu_total = None
         if self.per_unit_total is not None:
-            pu = np.asarray(self.per_unit_total, dtype=float)
-            if pu.ndim != 2 or pu.shape[1] != B:
+            pu_total = np.asarray(self.per_unit_total, dtype=float)
+            if pu_total.ndim != 2 or pu_total.shape[1] != B:
                 raise ValueError(f"per_unit_total must be 2D with shape (N, {B})")
+            if np.any(np.isinf(pu_total)):
+                raise ValueError("per_unit_total must not contain infinite values")
+            finite = np.isfinite(pu_total)
+            if np.any(pu_total[finite] < 0.0):
+                raise ValueError("per_unit_total must be nonnegative where finite")
+
+        pu_tail = None
         if self.per_unit_tail is not None:
-            pu = np.asarray(self.per_unit_tail, dtype=float)
-            if pu.ndim != 2 or pu.shape[1] != B:
+            pu_tail = np.asarray(self.per_unit_tail, dtype=float)
+            if pu_tail.ndim != 2 or pu_tail.shape[1] != B:
                 raise ValueError(f"per_unit_tail must be 2D with shape (N, {B})")
+            if np.any(np.isinf(pu_tail)):
+                raise ValueError("per_unit_tail must not contain infinite values")
+            finite = np.isfinite(pu_tail)
+            if np.any(pu_tail[finite] < 0.0):
+                raise ValueError("per_unit_tail must be nonnegative where finite")
+
+        if pu_total is not None and pu_tail is not None and pu_total.shape != pu_tail.shape:
+            raise ValueError("per_unit_total and per_unit_tail shapes must match")
+
         if self.per_unit_ids is not None:
             ids = np.asarray(self.per_unit_ids, dtype=object).ravel()
             # If per-unit arrays exist, ensure N matches
-            if self.per_unit_total is not None:
-                pu = np.asarray(self.per_unit_total, dtype=float)
-                if ids.shape[0] != pu.shape[0]:
+            if pu_total is not None:
+                if ids.shape[0] != pu_total.shape[0]:
                     raise ValueError(
                         "per_unit_ids length must match per_unit_total rows"
                     )
-            if self.per_unit_tail is not None:
-                pu = np.asarray(self.per_unit_tail, dtype=float)
-                if ids.shape[0] != pu.shape[0]:
+            if pu_tail is not None:
+                if ids.shape[0] != pu_tail.shape[0]:
                     raise ValueError(
                         "per_unit_ids length must match per_unit_tail rows"
                     )

--- a/src/plotting/between_reward_segment_binning.py
+++ b/src/plotting/between_reward_segment_binning.py
@@ -115,6 +115,7 @@ def sync_bucket_window(
 def build_nonwalk_mask(opts, va, trx_idx: int, fi: int, n_frames: int):
     exclude_nonwalk = bool(
         getattr(opts, "btw_rwd_conditioned_exclude_nonwalking_frames", False)
+        or getattr(opts, "btw_rwd_return_leg_dist_exclude_nonwalking_frames", False)
     )
     if not exclude_nonwalk:
         return None

--- a/src/plotting/overlay_training_metric_hist.py
+++ b/src/plotting/overlay_training_metric_hist.py
@@ -48,7 +48,9 @@ class ExportedTrainingHistogram:
     #   - flat: (n_panels, bins+1) float array
     #   - grouped: object array length n_panels; each entry is list[np.ndarray] of 1D edges
     bin_edges: np.ndarray
+    n_raw: np.ndarray | None  # (n_panels,)
     n_used: np.ndarray  # (n_panels,)
+    n_dropped: np.ndarray | None  # (n_panels,)
     meta: dict
 
     @property
@@ -71,6 +73,221 @@ class ExportedTrainingHistogram:
     def normalize(self) -> bool:
         # present in histogram config, not always in meta historically
         return bool(self.meta.get("normalize", False))
+
+    def validate(self) -> None:
+        panel_labels = list(self.panel_labels)
+        P = len(panel_labels)
+        bins_meta = self.meta.get("bins", None)
+        if bins_meta is None:
+            raise ValueError("histogram export meta is missing bins")
+        B = int(bins_meta)
+        if B < 0:
+            raise ValueError("histogram export bins must be nonnegative")
+
+        def _check_1d_count(name: str, value, *, required: bool) -> np.ndarray | None:
+            if value is None:
+                if required:
+                    raise ValueError(f"{name} is required")
+                return None
+            arr = np.asarray(value)
+            if arr.ndim != 1 or arr.shape[0] != P:
+                raise ValueError(f"{name} must be 1D with length {P}")
+            arr_float = arr.astype(float)
+            if np.any(~np.isfinite(arr_float)):
+                raise ValueError(f"{name} must contain only finite values")
+            if np.any(arr_float < 0):
+                raise ValueError(f"{name} must be nonnegative")
+            if np.any(arr_float != np.floor(arr_float)):
+                raise ValueError(f"{name} must contain integer values")
+            return arr_float.astype(int)
+
+        n_raw = _check_1d_count("n_raw", self.n_raw, required=False)
+        n_used = _check_1d_count("n_used", self.n_used, required=True)
+        n_dropped = _check_1d_count("n_dropped", self.n_dropped, required=False)
+        if n_raw is not None and n_dropped is not None:
+            if np.any(n_raw != n_used + n_dropped):
+                raise ValueError("n_raw must equal n_used + n_dropped")
+
+        if np.asarray(self.bin_edges).shape[0] != P:
+            raise ValueError(f"bin_edges first dimension must match {P} panels")
+
+        def _panel_edges(panel_idx: int):
+            return normalize_panel_edges(np.asarray(self.bin_edges, dtype=object)[panel_idx])
+
+        def _validate_edges(panel_idx: int) -> int:
+            edges = _panel_edges(panel_idx)
+            if isinstance(edges, list):
+                if not edges:
+                    raise ValueError("grouped bin_edges must contain at least one group")
+                total_bins = 0
+                last_hi = None
+                for gi, group in enumerate(edges):
+                    group = np.asarray(group, dtype=float)
+                    if group.ndim != 1 or group.size < 2:
+                        raise ValueError(
+                            f"bin_edges panel {panel_idx} group {gi} must have >= 2 edges"
+                        )
+                    if not np.all(np.isfinite(group)):
+                        raise ValueError(
+                            f"bin_edges panel {panel_idx} group {gi} must be finite"
+                        )
+                    if np.any(np.diff(group) <= 0):
+                        raise ValueError(
+                            f"bin_edges panel {panel_idx} group {gi} must be strictly increasing"
+                        )
+                    if last_hi is not None and float(group[0]) <= last_hi:
+                        raise ValueError(
+                            f"bin_edges panel {panel_idx} groups must be non-overlapping"
+                        )
+                    last_hi = float(group[-1])
+                    total_bins += int(group.size - 1)
+                return total_bins
+
+            edges = np.asarray(edges, dtype=float)
+            if edges.ndim != 1 or edges.size < 2:
+                raise ValueError(f"bin_edges panel {panel_idx} must have >= 2 edges")
+            if not np.all(np.isfinite(edges)):
+                raise ValueError(f"bin_edges panel {panel_idx} must be finite")
+            if np.any(np.diff(edges) <= 0):
+                raise ValueError(
+                    f"bin_edges panel {panel_idx} must be strictly increasing"
+                )
+            return int(edges.size - 1)
+
+        for p_idx in range(P):
+            if _validate_edges(p_idx) != B:
+                raise ValueError(f"bin_edges panel {p_idx} must define {B} bins")
+
+        if self.per_fly:
+            self._validate_per_fly_payload(P, B, n_used)
+        else:
+            self._validate_pooled_payload(P, B, n_used)
+
+    def _validate_pooled_payload(self, P: int, B: int, n_used: np.ndarray) -> None:
+        counts = np.asarray(self.counts)
+        if counts.ndim != 2 or counts.shape != (P, B):
+            raise ValueError(f"counts must have shape {(P, B)}")
+        counts_float = counts.astype(float)
+        if np.any(~np.isfinite(counts_float)):
+            raise ValueError("counts must contain only finite values")
+        if np.any(counts_float < 0):
+            raise ValueError("counts must be nonnegative")
+        if np.any(counts_float != np.floor(counts_float)):
+            raise ValueError("counts must contain integer values")
+        if np.any(np.sum(counts_float, axis=1).astype(int) != n_used):
+            raise ValueError("pooled counts must sum to n_used per panel")
+
+    def _validate_per_fly_payload(self, P: int, B: int, n_used: np.ndarray) -> None:
+        for name in ("mean", "ci_lo", "ci_hi", "n_units", "n_units_panel"):
+            if getattr(self, name) is None:
+                raise ValueError(f"{name} is required when per_fly=True")
+
+        mean = np.asarray(self.mean, dtype=float)
+        ci_lo = np.asarray(self.ci_lo, dtype=float)
+        ci_hi = np.asarray(self.ci_hi, dtype=float)
+        n_units = np.asarray(self.n_units)
+        n_units_panel = np.asarray(self.n_units_panel)
+        if mean.shape != (P, B):
+            raise ValueError(f"mean must have shape {(P, B)}")
+        if ci_lo.shape != (P, B):
+            raise ValueError(f"ci_lo must have shape {(P, B)}")
+        if ci_hi.shape != (P, B):
+            raise ValueError(f"ci_hi must have shape {(P, B)}")
+        if n_units.shape != (P, B):
+            raise ValueError(f"n_units must have shape {(P, B)}")
+        if n_units_panel.shape != (P,):
+            raise ValueError(f"n_units_panel must have shape {(P,)}")
+
+        n_units_float = n_units.astype(float)
+        n_units_panel_float = n_units_panel.astype(float)
+        for name, arr_float in (
+            ("n_units", n_units_float),
+            ("n_units_panel", n_units_panel_float),
+        ):
+            if np.any(~np.isfinite(arr_float)):
+                raise ValueError(f"{name} must contain only finite values")
+            if np.any(arr_float < 0):
+                raise ValueError(f"{name} must be nonnegative")
+            if np.any(arr_float != np.floor(arr_float)):
+                raise ValueError(f"{name} must contain integer values")
+
+        for name, arr in (("mean", mean), ("ci_lo", ci_lo), ("ci_hi", ci_hi)):
+            if np.any(np.isinf(arr)):
+                raise ValueError(f"{name} must not contain infinite values")
+            finite = np.isfinite(arr)
+            if np.any(arr[finite] < 0.0):
+                raise ValueError(f"{name} must be nonnegative where finite")
+
+        finite_ci = np.isfinite(mean) & np.isfinite(ci_lo) & np.isfinite(ci_hi)
+        if np.any(ci_lo[finite_ci] > mean[finite_ci]):
+            raise ValueError("ci_lo must be <= mean where finite")
+        if np.any(mean[finite_ci] > ci_hi[finite_ci]):
+            raise ValueError("mean must be <= ci_hi where finite")
+
+        empty_bins = n_units_float == 0
+        for name, arr in (("mean", mean), ("ci_lo", ci_lo), ("ci_hi", ci_hi)):
+            if np.any(np.isfinite(arr[empty_bins])):
+                raise ValueError(f"{name} must be NaN where n_units == 0")
+
+        per_unit_panel = self.per_unit_panel
+        per_unit_ids_panel = self.per_unit_ids_panel
+        if per_unit_panel is None or per_unit_ids_panel is None:
+            raise ValueError(
+                "per_unit_panel and per_unit_ids_panel are required when per_fly=True"
+            )
+        if np.asarray(per_unit_panel, dtype=object).shape[0] != P:
+            raise ValueError("per_unit_panel first dimension must match panels")
+        if np.asarray(per_unit_ids_panel, dtype=object).shape[0] != P:
+            raise ValueError("per_unit_ids_panel first dimension must match panels")
+
+        per_unit_panel_arr = np.asarray(per_unit_panel, dtype=object)
+        per_unit_ids_panel_arr = np.asarray(per_unit_ids_panel, dtype=object)
+        for p_idx in range(P):
+            panel_values_raw = per_unit_panel_arr[p_idx]
+            panel_ids_raw = per_unit_ids_panel_arr[p_idx]
+            panel_values = np.asarray(panel_values_raw)
+            panel_ids = np.asarray(
+                [] if panel_ids_raw is None else panel_ids_raw, dtype=object
+            ).reshape(-1)
+
+            if int(n_units_panel_float[p_idx]) == 0:
+                if panel_values_raw is not None and panel_values.size:
+                    raise ValueError(
+                        f"per_unit_panel panel {p_idx} must be empty when n_units_panel == 0"
+                    )
+                if panel_ids.size:
+                    raise ValueError(
+                        f"per_unit_ids_panel panel {p_idx} must be empty when n_units_panel == 0"
+                    )
+                continue
+
+            panel_values = np.asarray(panel_values, dtype=float)
+            if panel_values.ndim != 2 or panel_values.shape[1] != B:
+                raise ValueError(
+                    f"per_unit_panel panel {p_idx} must have shape (N, {B})"
+                )
+            if panel_values.shape[0] != int(n_units_panel_float[p_idx]):
+                raise ValueError(
+                    f"per_unit_panel panel {p_idx} row count must match n_units_panel"
+                )
+            if panel_ids.shape[0] != panel_values.shape[0]:
+                raise ValueError(
+                    f"per_unit_ids_panel panel {p_idx} length must match per_unit rows"
+                )
+            if np.any(np.isinf(panel_values)):
+                raise ValueError(
+                    f"per_unit_panel panel {p_idx} must not contain infinite values"
+                )
+            finite = np.isfinite(panel_values)
+            if np.any(panel_values[finite] < 0.0):
+                raise ValueError(
+                    f"per_unit_panel panel {p_idx} must be nonnegative where finite"
+                )
+            observed_n_units = np.sum(np.isfinite(panel_values), axis=0)
+            if np.any(observed_n_units != n_units[p_idx].astype(int)):
+                raise ValueError(
+                    f"n_units panel {p_idx} must match finite per-unit values"
+                )
 
 
 def _mean_ci_from_util(x: np.ndarray, conf: float) -> tuple[float, float, float, int]:
@@ -240,7 +457,7 @@ def load_export_npz(group: str, path: str) -> ExportedTrainingHistogram:
     if isinstance(meta_json, (bytes, bytearray)):
         meta_json = meta_json.decode("utf-8")
     meta = json.loads(meta_json)
-    return ExportedTrainingHistogram(
+    hist = ExportedTrainingHistogram(
         group=group,
         panel_labels=panel_labels,
         counts=counts,
@@ -252,9 +469,13 @@ def load_export_npz(group: str, path: str) -> ExportedTrainingHistogram:
         per_unit_panel=per_unit_panel,
         per_unit_ids_panel=per_unit_ids_panel,
         bin_edges=bin_edges,
+        n_raw=np.asarray(d["n_raw"]) if "n_raw" in d.files else None,
         n_used=n_used,
+        n_dropped=np.asarray(d["n_dropped"]) if "n_dropped" in d.files else None,
         meta=meta,
     )
+    hist.validate()
+    return hist
 
 
 def _fmt_mismatch(name: str, vals: list) -> str:

--- a/src/validation/bundle_digest.py
+++ b/src/validation/bundle_digest.py
@@ -49,6 +49,75 @@ RETURN_PROB_EXCURSION_BIN_REGRESSION_KEYS = (
     "video_ids",
 )
 
+BETWEEN_REWARD_DISTANCE_HIST_REGRESSION_KEYS = (
+    "bin_edges",
+    "ci_hi",
+    "ci_lo",
+    "counts",
+    "mean",
+    "meta_json",
+    "n_dropped",
+    "n_raw",
+    "n_units",
+    "n_units_panel",
+    "n_used",
+    "panel_labels",
+    "per_unit_ids_panel",
+    "per_unit_panel",
+)
+
+BETWEEN_REWARD_CONDITIONED_DISTTRAV_REGRESSION_KEYS = (
+    "ci_hi_tail",
+    "ci_hi_total",
+    "ci_lo_tail",
+    "ci_lo_total",
+    "mean_tail",
+    "mean_total",
+    "meta",
+    "n_units",
+    "per_unit_ids",
+    "per_unit_tail",
+    "per_unit_total",
+    "x_centers",
+    "x_edges",
+)
+
+BETWEEN_REWARD_MAXDIST_SLI_REGRESSION_KEYS = (
+    "between_reward_maxdistN_ctrl",
+    "between_reward_maxdistN_exp",
+    "between_reward_maxdist_ctrl",
+    "between_reward_maxdist_exp",
+    "btw_rwd_sync_bucket_min_trajectories",
+    "bucket_len_min",
+    "group_label",
+    "sli",
+    "sli_select_keep_first_sync_buckets",
+    "sli_select_skip_first_sync_buckets",
+    "sli_training_idx",
+    "sli_ts",
+    "sli_use_training_mean",
+    "training_names",
+    "video_ids",
+)
+
+BETWEEN_REWARD_RETURN_LEG_DIST_SLI_REGRESSION_KEYS = (
+    "between_reward_return_leg_distN_ctrl",
+    "between_reward_return_leg_distN_exp",
+    "between_reward_return_leg_dist_ctrl",
+    "between_reward_return_leg_dist_exp",
+    "btw_rwd_sync_bucket_min_trajectories",
+    "bucket_len_min",
+    "group_label",
+    "sli",
+    "sli_select_keep_first_sync_buckets",
+    "sli_select_skip_first_sync_buckets",
+    "sli_training_idx",
+    "sli_ts",
+    "sli_use_training_mean",
+    "training_names",
+    "video_ids",
+)
+
 
 def _json_bytes(payload) -> bytes:
     return json.dumps(

--- a/test/paper_metrics/test_between_reward_conditioned_disttrav_result_invariants.py
+++ b/test/paper_metrics/test_between_reward_conditioned_disttrav_result_invariants.py
@@ -1,0 +1,78 @@
+import numpy as np
+import pytest
+
+from src.plotting.between_reward_conditioned_disttrav import (
+    BetweenRewardConditionedDistTravResult,
+)
+
+
+def _result(**overrides):
+    payload = {
+        "x_edges": np.asarray([2.0, 8.0, 16.0], dtype=float),
+        "x_centers": np.asarray([5.0, 12.0], dtype=float),
+        "mean_total": np.asarray([4.0, np.nan], dtype=float),
+        "ci_lo_total": np.asarray([3.5, np.nan], dtype=float),
+        "ci_hi_total": np.asarray([4.5, np.nan], dtype=float),
+        "mean_tail": np.asarray([2.0, np.nan], dtype=float),
+        "ci_lo_tail": np.asarray([1.5, np.nan], dtype=float),
+        "ci_hi_tail": np.asarray([2.5, np.nan], dtype=float),
+        "n_units": np.asarray([2, 0], dtype=int),
+        "meta": {"units": "mm"},
+        "per_unit_total": np.asarray([[3.0, np.nan], [5.0, np.nan]], dtype=float),
+        "per_unit_tail": np.asarray([[1.0, np.nan], [3.0, np.nan]], dtype=float),
+        "per_unit_ids": np.asarray(["fly_a", "fly_b"], dtype=object),
+    }
+    payload.update(overrides)
+    return BetweenRewardConditionedDistTravResult(**payload)
+
+
+def test_conditioned_disttrav_result_validate_accepts_consistent_result():
+    _result().validate()
+
+
+def test_conditioned_disttrav_result_validate_rejects_bad_edges_and_centers():
+    with pytest.raises(ValueError, match="strictly increasing"):
+        _result(x_edges=np.asarray([2.0, 8.0, 8.0])).validate()
+
+    with pytest.raises(ValueError, match="bin midpoints"):
+        _result(x_centers=np.asarray([5.0, 10.0])).validate()
+
+
+def test_conditioned_disttrav_result_validate_rejects_bad_counts():
+    with pytest.raises(ValueError, match="n_units must be nonnegative"):
+        _result(n_units=np.asarray([2, -1])).validate()
+
+    with pytest.raises(ValueError, match="n_units must contain integer values"):
+        _result(n_units=np.asarray([2.5, 0.0])).validate()
+
+
+def test_conditioned_disttrav_result_validate_rejects_negative_or_infinite_distances():
+    with pytest.raises(ValueError, match="mean_total must be nonnegative"):
+        _result(mean_total=np.asarray([-1.0, np.nan])).validate()
+
+    with pytest.raises(ValueError, match="ci_hi_tail must not contain infinite"):
+        _result(ci_hi_tail=np.asarray([np.inf, np.nan])).validate()
+
+    with pytest.raises(ValueError, match="per_unit_total must be nonnegative"):
+        _result(per_unit_total=np.asarray([[-1.0, np.nan], [5.0, np.nan]])).validate()
+
+
+def test_conditioned_disttrav_result_validate_rejects_inverted_confidence_interval():
+    with pytest.raises(ValueError, match="ci_lo_total must be <= mean_total"):
+        _result(ci_lo_total=np.asarray([4.5, np.nan])).validate()
+
+    with pytest.raises(ValueError, match="mean_tail must be <= ci_hi_tail"):
+        _result(ci_hi_tail=np.asarray([1.5, np.nan])).validate()
+
+
+def test_conditioned_disttrav_result_validate_rejects_finite_summary_for_empty_bin():
+    with pytest.raises(ValueError, match="mean_total must be NaN where n_units == 0"):
+        _result(mean_total=np.asarray([4.0, 1.0])).validate()
+
+
+def test_conditioned_disttrav_result_validate_rejects_per_unit_shape_mismatch():
+    with pytest.raises(ValueError, match="per_unit_total and per_unit_tail shapes"):
+        _result(per_unit_tail=np.asarray([[1.0, np.nan]])).validate()
+
+    with pytest.raises(ValueError, match="per_unit_ids length"):
+        _result(per_unit_ids=np.asarray(["fly_a"], dtype=object)).validate()

--- a/test/paper_metrics/test_between_reward_distance_bundle_invariants.py
+++ b/test/paper_metrics/test_between_reward_distance_bundle_invariants.py
@@ -1,0 +1,177 @@
+import numpy as np
+import pytest
+
+from src.analysis.sli_bundle_utils import (
+    normalize_sli_bundle,
+    validate_between_reward_maxdist_bundle,
+    validate_between_reward_return_leg_dist_bundle,
+)
+
+
+def _base_bundle(**overrides):
+    bundle = {
+        "sli": np.asarray([0.1, np.nan], dtype=float),
+        "sli_ts": np.asarray(
+            [
+                [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]],
+                [[np.nan, 0.1, 0.2], [0.3, np.nan, 0.5]],
+            ],
+            dtype=float,
+        ),
+        "group_label": np.asarray("Control", dtype=object),
+        "bucket_len_min": np.array(10.0, dtype=float),
+        "training_names": np.asarray(["T1", "T2"], dtype=object),
+        "video_ids": np.asarray(["video_a", "video_b"], dtype=object),
+        "sli_training_idx": np.array(1, dtype=int),
+        "sli_use_training_mean": np.array(True),
+        "sli_select_skip_first_sync_buckets": np.array(1, dtype=int),
+        "sli_select_keep_first_sync_buckets": np.array(0, dtype=int),
+    }
+    bundle.update(overrides)
+    return bundle
+
+
+def _maxdist_bundle(**overrides):
+    exp = np.asarray(
+        [
+            [[1.0, 2.0, np.nan], [3.0, 4.0, 5.0]],
+            [[np.nan, 1.5, 2.5], [2.0, np.nan, 3.0]],
+        ],
+        dtype=float,
+    )
+    ctrl = np.asarray(
+        [
+            [[1.0, np.nan, 2.0], [3.0, 4.0, np.nan]],
+            [[np.nan, np.nan, 1.0], [2.0, 2.5, 3.0]],
+        ],
+        dtype=float,
+    )
+    bundle = _base_bundle(
+        between_reward_maxdist_exp=exp,
+        between_reward_maxdist_ctrl=ctrl,
+        between_reward_maxdistN_exp=np.asarray(np.isfinite(exp), dtype=int),
+        between_reward_maxdistN_ctrl=np.asarray(np.isfinite(ctrl), dtype=int),
+    )
+    bundle.update(overrides)
+    return bundle
+
+
+def _return_leg_bundle(**overrides):
+    exp = np.asarray(
+        [
+            [[0.5, 1.0, np.nan], [1.5, 2.0, 2.5]],
+            [[np.nan, 0.5, 1.0], [1.0, np.nan, 1.5]],
+        ],
+        dtype=float,
+    )
+    ctrl = np.asarray(
+        [
+            [[0.5, np.nan, 1.0], [1.5, 2.0, np.nan]],
+            [[np.nan, np.nan, 0.5], [1.0, 1.25, 1.5]],
+        ],
+        dtype=float,
+    )
+    bundle = _base_bundle(
+        between_reward_return_leg_dist_exp=exp,
+        between_reward_return_leg_dist_ctrl=ctrl,
+        between_reward_return_leg_distN_exp=np.asarray(np.isfinite(exp), dtype=int),
+        between_reward_return_leg_distN_ctrl=np.asarray(np.isfinite(ctrl), dtype=int),
+    )
+    bundle.update(overrides)
+    return bundle
+
+
+def test_validate_between_reward_maxdist_bundle_accepts_valid_shapes_and_metadata():
+    validate_between_reward_maxdist_bundle(_maxdist_bundle())
+
+    normalized = normalize_sli_bundle(_maxdist_bundle())
+    assert normalized["between_reward_maxdist_exp"].shape == (2, 2, 3)
+
+
+def test_validate_between_reward_return_leg_dist_bundle_accepts_valid_shapes_and_metadata():
+    validate_between_reward_return_leg_dist_bundle(_return_leg_bundle())
+
+    normalized = normalize_sli_bundle(_return_leg_bundle())
+    assert normalized["between_reward_return_leg_dist_exp"].shape == (2, 2, 3)
+
+
+def test_validate_between_reward_distance_bundle_rejects_missing_metric_key():
+    bundle = _maxdist_bundle()
+    del bundle["between_reward_maxdist_ctrl"]
+
+    with pytest.raises(ValueError, match="missing between-reward max-distance keys"):
+        validate_between_reward_maxdist_bundle(bundle)
+
+
+def test_validate_between_reward_distance_bundle_rejects_metric_shape_mismatch():
+    with pytest.raises(
+        ValueError, match=r"between_reward_maxdist_exp\.shape=\(2, 2, 2\)"
+    ):
+        validate_between_reward_maxdist_bundle(
+            _maxdist_bundle(
+                between_reward_maxdist_exp=np.ones((2, 2, 2), dtype=float)
+            )
+        )
+
+
+def test_validate_between_reward_distance_bundle_rejects_bad_counts():
+    with pytest.raises(ValueError, match="negative values"):
+        validate_between_reward_return_leg_dist_bundle(
+            _return_leg_bundle(
+                between_reward_return_leg_distN_exp=np.asarray(
+                    [[[1, -1, 0], [1, 1, 1]], [[0, 1, 1], [1, 0, 1]]]
+                )
+            )
+        )
+
+    with pytest.raises(ValueError, match="non-integer values"):
+        validate_between_reward_return_leg_dist_bundle(
+            _return_leg_bundle(
+                between_reward_return_leg_distN_exp=np.asarray(
+                    [[[1, 1.5, 0], [1, 1, 1]], [[0, 1, 1], [1, 0, 1]]]
+                )
+            )
+        )
+
+
+def test_validate_between_reward_distance_bundle_rejects_bad_distances():
+    with pytest.raises(ValueError, match="negative values"):
+        validate_between_reward_maxdist_bundle(
+            _maxdist_bundle(
+                between_reward_maxdist_exp=np.asarray(
+                    [
+                        [[1.0, -2.0, np.nan], [3.0, 4.0, 5.0]],
+                        [[np.nan, 1.5, 2.5], [2.0, np.nan, 3.0]],
+                    ]
+                )
+            )
+        )
+
+    with pytest.raises(ValueError, match="infinite values"):
+        validate_between_reward_maxdist_bundle(
+            _maxdist_bundle(
+                between_reward_maxdist_exp=np.asarray(
+                    [
+                        [[1.0, np.inf, np.nan], [3.0, 4.0, 5.0]],
+                        [[np.nan, 1.5, 2.5], [2.0, np.nan, 3.0]],
+                    ]
+                )
+            )
+        )
+
+
+def test_validate_between_reward_distance_bundle_rejects_finite_value_with_zero_count():
+    with pytest.raises(ValueError, match="finite between_reward_return_leg_dist_exp"):
+        validate_between_reward_return_leg_dist_bundle(
+            _return_leg_bundle(
+                between_reward_return_leg_dist_exp=np.asarray(
+                    [
+                        [[0.5, 1.0, 2.0], [1.5, 2.0, 2.5]],
+                        [[np.nan, 0.5, 1.0], [1.0, np.nan, 1.5]],
+                    ]
+                ),
+                between_reward_return_leg_distN_exp=np.asarray(
+                    [[[1, 1, 0], [1, 1, 1]], [[0, 1, 1], [1, 0, 1]]]
+                ),
+            )
+        )

--- a/test/paper_metrics/test_between_reward_distance_histogram_export_invariants.py
+++ b/test/paper_metrics/test_between_reward_distance_histogram_export_invariants.py
@@ -1,0 +1,102 @@
+import numpy as np
+import pytest
+
+from src.plotting.overlay_training_metric_hist import ExportedTrainingHistogram
+
+
+def _per_fly_hist(**overrides):
+    payload = {
+        "group": "Control",
+        "panel_labels": ["T2"],
+        "counts": np.asarray(None, dtype=object),
+        "mean": np.asarray([[0.25, 0.75, np.nan]], dtype=float),
+        "ci_lo": np.asarray([[0.20, 0.70, np.nan]], dtype=float),
+        "ci_hi": np.asarray([[0.30, 0.80, np.nan]], dtype=float),
+        "n_units": np.asarray([[2, 2, 0]], dtype=int),
+        "n_units_panel": np.asarray([2], dtype=int),
+        "per_unit_panel": np.asarray(
+            [np.asarray([[0.2, 0.8, np.nan], [0.3, 0.7, np.nan]])],
+            dtype=object,
+        ),
+        "per_unit_ids_panel": np.asarray(
+            [np.asarray(["fly_a", "fly_b"], dtype=object)], dtype=object
+        ),
+        "bin_edges": np.asarray([[0.0, 60.0, 200.0, 1600.0]], dtype=float),
+        "n_raw": np.asarray([20], dtype=int),
+        "n_used": np.asarray([18], dtype=int),
+        "n_dropped": np.asarray([2], dtype=int),
+        "meta": {"bins": 3, "per_fly": True, "normalize": True},
+    }
+    payload.update(overrides)
+    return ExportedTrainingHistogram(**payload)
+
+
+def _pooled_hist(**overrides):
+    payload = {
+        "group": "Control",
+        "panel_labels": ["T1", "T2"],
+        "counts": np.asarray([[1, 2], [3, 0]], dtype=int),
+        "mean": None,
+        "ci_lo": None,
+        "ci_hi": None,
+        "n_units": None,
+        "n_units_panel": None,
+        "per_unit_panel": None,
+        "per_unit_ids_panel": None,
+        "bin_edges": np.asarray([[0.0, 5.0, 10.0], [0.0, 5.0, 10.0]]),
+        "n_raw": np.asarray([4, 3], dtype=int),
+        "n_used": np.asarray([3, 3], dtype=int),
+        "n_dropped": np.asarray([1, 0], dtype=int),
+        "meta": {"bins": 2, "per_fly": False, "normalize": False},
+    }
+    payload.update(overrides)
+    return ExportedTrainingHistogram(**payload)
+
+
+def test_exported_training_histogram_validate_accepts_per_fly_panel_payload():
+    _per_fly_hist().validate()
+
+
+def test_exported_training_histogram_validate_accepts_pooled_counts_payload():
+    _pooled_hist().validate()
+
+
+def test_exported_training_histogram_validate_rejects_bad_edges():
+    with pytest.raises(ValueError, match="strictly increasing"):
+        _per_fly_hist(bin_edges=np.asarray([[0.0, 60.0, 60.0, 1600.0]])).validate()
+
+
+def test_exported_training_histogram_validate_rejects_raw_used_dropped_mismatch():
+    with pytest.raises(ValueError, match="n_raw must equal n_used \\+ n_dropped"):
+        _per_fly_hist(n_raw=np.asarray([19])).validate()
+
+
+def test_exported_training_histogram_validate_rejects_bad_summary_values():
+    with pytest.raises(ValueError, match="mean must be nonnegative"):
+        _per_fly_hist(mean=np.asarray([[-0.1, 0.75, np.nan]])).validate()
+
+    with pytest.raises(ValueError, match="ci_lo must be <= mean"):
+        _per_fly_hist(ci_lo=np.asarray([[0.30, 0.70, np.nan]])).validate()
+
+    with pytest.raises(ValueError, match="mean must be NaN where n_units == 0"):
+        _per_fly_hist(mean=np.asarray([[0.25, 0.75, 0.1]])).validate()
+
+
+def test_exported_training_histogram_validate_rejects_bad_per_unit_payload():
+    with pytest.raises(ValueError, match="length must match per_unit rows"):
+        _per_fly_hist(
+            per_unit_ids_panel=np.asarray(
+                [np.asarray(["fly_a"], dtype=object)], dtype=object
+            )
+        ).validate()
+
+    with pytest.raises(ValueError, match="n_units panel 0 must match"):
+        _per_fly_hist(n_units=np.asarray([[1, 2, 0]], dtype=int)).validate()
+
+
+def test_exported_training_histogram_validate_rejects_bad_pooled_counts():
+    with pytest.raises(ValueError, match="counts must be nonnegative"):
+        _pooled_hist(counts=np.asarray([[1, -2], [3, 0]])).validate()
+
+    with pytest.raises(ValueError, match="pooled counts must sum to n_used"):
+        _pooled_hist(n_raw=np.asarray([5, 3]), n_used=np.asarray([4, 3])).validate()

--- a/test/paper_metrics/test_between_reward_distance_regression_manifests.py
+++ b/test/paper_metrics/test_between_reward_distance_regression_manifests.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+import pytest
+
+from src.validation.bundle_digest import check_manifest, load_manifest
+
+
+MANIFESTS = (
+    (
+        Path("test/reference/bundles/between_reward_distance_hist_paper_manifest.json"),
+        "Paper between-reward distance histogram export bundles",
+    ),
+    (
+        Path(
+            "test/reference/bundles/"
+            "between_reward_conditioned_disttrav_paper_manifest.json"
+        ),
+        "Paper between-reward conditioned distance-traveled export bundles",
+    ),
+    (
+        Path("test/reference/bundles/between_reward_maxdist_paper_manifest.json"),
+        "Paper between-reward max-distance SLI export bundles",
+    ),
+    (
+        Path(
+            "test/reference/bundles/"
+            "between_reward_return_leg_dist_paper_manifest.json"
+        ),
+        "Paper between-reward return-leg distance SLI export bundles",
+    ),
+)
+
+
+@pytest.mark.parametrize("manifest_path, description", MANIFESTS)
+def test_between_reward_distance_family_manifests_match_available_exports(
+    manifest_path, description
+):
+    manifest = load_manifest(manifest_path)
+    missing = [
+        bundle["path"]
+        for bundle in manifest["bundles"]
+        if not Path(bundle["path"]).exists()
+    ]
+    if missing:
+        pytest.skip(
+            f"{description} are not available locally: " + ", ".join(missing)
+        )
+
+    assert check_manifest(manifest_path) == []

--- a/test/paper_metrics/test_between_reward_distance_truth.py
+++ b/test/paper_metrics/test_between_reward_distance_truth.py
@@ -1,0 +1,259 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+from src.plotting.between_reward_conditioned_disttrav import (
+    BetweenRewardConditionedDistTravConfig,
+    BetweenRewardConditionedDistTravPlotter,
+)
+from src.plotting.between_reward_segment_metrics import (
+    dist_traveled_mm_masked,
+    max_radial_distance_mm_masked,
+    path_length_and_max_radius_mm_masked,
+)
+from src.plotting.btw_rwd_return_leg_dist_collectors import (
+    ReturnLegDistPerFlyCollector,
+)
+
+
+class _Trajectory:
+    def __init__(self, x, y=None, *, d=None, walking=None, bad=False, f=0):
+        self.x = np.asarray(x, dtype=float)
+        self.y = np.zeros_like(self.x) if y is None else np.asarray(y, dtype=float)
+        if d is None:
+            self.d = np.hypot(np.diff(self.x), np.diff(self.y))
+        else:
+            self.d = np.asarray(d, dtype=float)
+        self.walking = walking
+        self._bad = bad
+        self.f = f
+
+    def bad(self):
+        return self._bad
+
+
+class _Training:
+    start = 0
+    stop = 10
+    n = 1
+
+    def name(self):
+        return "T1"
+
+    def circles(self, _fly_idx):
+        return [(0.0, 0.0, 0.0)]
+
+
+class _Video:
+    def __init__(self, *, trx, segments_by_fly, noyc=True, sync_bucket_ranges=None):
+        self.fn = "fake-video"
+        self.f = 7
+        self.trns = [_Training()]
+        self.trx = trx
+        self.flies = list(range(len(trx)))
+        self.noyc = noyc
+        self._skipped = False
+        self.sync_bucket_ranges = sync_bucket_ranges
+        self._segments_by_fly = segments_by_fly
+        self.xf = SimpleNamespace(fctr=1.0)
+        self.ct = SimpleNamespace(pxPerMmFloor=lambda: 2.0)
+
+    def _numRewardsMsg(self, *_args, **_kwargs):
+        return 5
+
+    def _syncBucket(self, _trn, _df):
+        return 0, 2, None
+
+    def _iter_between_reward_segment_com(self, _trn, fly_idx, **_kwargs):
+        yield from self._segments_by_fly.get(fly_idx, [])
+
+
+def _segment(*, s, e, b_idx=0, max_i=None, max_d_mm=4.0):
+    return SimpleNamespace(
+        s=int(s), e=int(e), b_idx=int(b_idx), max_d_i=max_i, max_d_mm=float(max_d_mm)
+    )
+
+
+def test_between_reward_distance_traveled_sums_only_consecutive_kept_steps():
+    traj = _Trajectory(x=[0, 3, 6, 10, 10], d=[3, 3, 4, 0])
+
+    total = dist_traveled_mm_masked(
+        traj=traj,
+        s=0,
+        e=4,
+        fi=0,
+        nonwalk_mask=np.asarray([False, False, True, False]),
+        exclude_nonwalk=True,
+        px_per_mm=2.0,
+    )
+    distance_from_override = dist_traveled_mm_masked(
+        traj=traj,
+        s=0,
+        e=4,
+        fi=0,
+        nonwalk_mask=None,
+        exclude_nonwalk=False,
+        px_per_mm=2.0,
+        start_override=2,
+    )
+
+    assert total == 1.5
+    assert distance_from_override == 2.0
+
+
+def test_between_reward_distance_traveled_rejects_degenerate_windows_and_scale():
+    traj = _Trajectory(x=[0, 3], d=[3])
+
+    assert np.isnan(
+        dist_traveled_mm_masked(
+            traj=traj,
+            s=0,
+            e=1,
+            fi=0,
+            nonwalk_mask=None,
+            exclude_nonwalk=False,
+            px_per_mm=2.0,
+        )
+    )
+    assert np.isnan(
+        dist_traveled_mm_masked(
+            traj=traj,
+            s=0,
+            e=2,
+            fi=0,
+            nonwalk_mask=None,
+            exclude_nonwalk=False,
+            px_per_mm=0.0,
+        )
+    )
+
+
+def test_between_reward_max_distance_uses_kept_finite_frames_from_reward_center():
+    traj = _Trajectory(x=[0, 3, 4, 6], y=[0, 4, 0, 8], d=[5, 5, 10])
+
+    assert (
+        max_radial_distance_mm_masked(
+            traj=traj,
+            s=0,
+            e=4,
+            fi=0,
+            nonwalk_mask=None,
+            exclude_nonwalk=False,
+            px_per_mm=2.0,
+            center_xy=(0.0, 0.0),
+        )
+        == 5.0
+    )
+
+    assert (
+        max_radial_distance_mm_masked(
+            traj=traj,
+            s=0,
+            e=4,
+            fi=0,
+            nonwalk_mask=np.asarray([False, False, False, True]),
+            exclude_nonwalk=True,
+            px_per_mm=2.0,
+            center_xy=(0.0, 0.0),
+        )
+        == 2.5
+    )
+
+
+def test_path_length_and_max_radius_share_validity_gate():
+    traj = _Trajectory(x=[1, 1, 1], y=[0, 0, 0], d=[0, 0])
+
+    path_mm, radius_mm = path_length_and_max_radius_mm_masked(
+        traj=traj,
+        s=0,
+        e=3,
+        fi=0,
+        nonwalk_mask=None,
+        exclude_nonwalk=False,
+        px_per_mm=2.0,
+        center_xy=(0.0, 0.0),
+    )
+
+    assert np.isnan(path_mm)
+    assert np.isnan(radius_mm)
+
+
+def test_conditioned_distance_traveled_bins_total_and_return_leg_per_fly():
+    traj = _Trajectory(x=np.arange(12, dtype=float), d=np.ones(11))
+    # Segment max_i/max_d_mm are supplied by the fake iterator here; this test
+    # exercises downstream binning/aggregation, not max-distance discovery from x/y.
+    va = _Video(
+        trx=[traj],
+        segments_by_fly={
+            0: [
+                _segment(s=0, e=4, max_i=2, max_d_mm=4.0),
+                _segment(s=4, e=8, max_i=5, max_d_mm=7.0),
+                _segment(s=8, e=11, max_i=9, max_d_mm=12.0),
+            ]
+        },
+        sync_bucket_ranges=[[(0, 10)]],
+    )
+    cfg = BetweenRewardConditionedDistTravConfig(
+        out_file="unused.png",
+        training_index=0,
+        x_bin_edges_mm=[0.0, 6.0, 10.0],
+        ci_conf=0.95,
+    )
+    plotter = BetweenRewardConditionedDistTravPlotter(
+        [va],
+        SimpleNamespace(
+            com_exclude_wall_contact=False,
+            btw_rwd_conditioned_exclude_nonwalking_frames=False,
+        ),
+        gls=None,
+        customizer=None,
+        cfg=cfg,
+    )
+
+    y_total, y_tail, unit_ids, meta = plotter._collect_per_fly_binned_means()
+
+    np.testing.assert_allclose(y_total, [[1.5, 1.5]])
+    np.testing.assert_allclose(y_tail, [[0.5, 1.0]])
+    assert unit_ids.tolist() == ["fake-video|fly=7|trx=0"]
+    assert meta["units"] == "mm"
+
+
+def test_return_leg_collector_averages_by_sync_bucket_and_honors_nonwalk_option():
+    exp = _Trajectory(
+        x=np.arange(12, dtype=float),
+        d=np.ones(11),
+        walking=np.asarray([1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1]),
+    )
+    ctrl = _Trajectory(x=np.arange(12, dtype=float), d=np.full(11, 2.0), f=1)
+    va = _Video(
+        trx=[exp, ctrl],
+        segments_by_fly={
+            0: [
+                _segment(s=0, e=4, b_idx=0, max_i=2),
+                _segment(s=4, e=8, b_idx=0, max_i=5),
+                _segment(s=6, e=10, b_idx=1, max_i=8),
+            ],
+            1: [_segment(s=0, e=4, b_idx=0, max_i=1)],
+        },
+    )
+
+    collector = ReturnLegDistPerFlyCollector()
+    collector.vas = [va]
+    collector.opts = SimpleNamespace(
+        com_exclude_wall_contact=False,
+        btw_rwd_sync_bucket_min_trajectories=0,
+        btw_rwd_return_leg_dist_exclude_nonwalking_frames=True,
+        btw_rwd_return_leg_dist_min_walk_frames=2,
+    )
+    collector.cfg = SimpleNamespace(
+        skip_first_sync_buckets=0, keep_first_sync_buckets=0
+    )
+
+    mean_exp, mean_ctrl, n_exp, n_ctrl = (
+        collector.collect_return_leg_sync_bucket_arrays()
+    )
+
+    np.testing.assert_allclose(mean_exp, [[[0.5, 0.5]]])
+    np.testing.assert_allclose(mean_ctrl, [[[2.0, np.nan]]])
+    np.testing.assert_array_equal(n_exp, [[[2, 1]]])
+    np.testing.assert_array_equal(n_ctrl, [[[1, 0]]])

--- a/test/reference/bundles/between_reward_conditioned_disttrav_paper_manifest.json
+++ b/test/reference/bundles/between_reward_conditioned_disttrav_paper_manifest.json
@@ -1,0 +1,929 @@
+{
+  "bundles": [
+    {
+      "arrays": {
+        "ci_hi_tail": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "b320b19e9bf5df00e080970010303a868659b24532cab85123f8cb47c1cf50f0",
+          "shape": [
+            3
+          ]
+        },
+        "ci_hi_total": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "16abe6a99067481b978dddd0081128ba2cccc0e1f7abae546a143770b8110af5",
+          "shape": [
+            3
+          ]
+        },
+        "ci_lo_tail": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "f793d4822a4ccfa808a3946ca6336d22555e7e89af1cc4b9decf1a4bf9a079ad",
+          "shape": [
+            3
+          ]
+        },
+        "ci_lo_total": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "c537b8e89b05e4df2c24d0c095d2c8ca2eaa6c7f1bbe36e88d46f61432c3fb38",
+          "shape": [
+            3
+          ]
+        },
+        "mean_tail": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "28f038e8b2d3ec1ce7fb3c7189aa8cc3226a86e51010d9e3afefed6371e03468",
+          "shape": [
+            3
+          ]
+        },
+        "mean_total": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "72b91911070b880114df169869e2119d1acdc503519feacfeb10015502a18340",
+          "shape": [
+            3
+          ]
+        },
+        "meta": {
+          "dtype": "object",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "4ef10a8895612c575bf25bf087fe1b8eb3823cb6db1d383e957f3af43bde843b",
+          "shape": [
+            1
+          ]
+        },
+        "n_units": {
+          "dtype": "int64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "c873fe09d576729e9126f895f285edd6b045557b9dd83ca7d166c1e268569d90",
+          "shape": [
+            3
+          ]
+        },
+        "per_unit_ids": {
+          "dtype": "object",
+          "finite_count": 62,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "69f80d39322871b8b62fc5fa4d4b1846a6e864b326c8f3c385806b8234bdf1b4",
+          "shape": [
+            62
+          ]
+        },
+        "per_unit_tail": {
+          "dtype": "float64",
+          "finite_count": 184,
+          "kind": "numeric",
+          "nan_count": 2,
+          "sha256": "feaf363c2ec3280301f34806069946c15b2f0e3a5afd1298e9282eabb5337086",
+          "shape": [
+            62,
+            3
+          ]
+        },
+        "per_unit_total": {
+          "dtype": "float64",
+          "finite_count": 184,
+          "kind": "numeric",
+          "nan_count": 2,
+          "sha256": "fb3af2a200e9ad9cba8c8115530c477e87730f73f174f193e73807f28ef6419f",
+          "shape": [
+            62,
+            3
+          ]
+        },
+        "x_centers": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "a67397a9c9ef09831aa81547d46bd0484f739246fa92ef9c7bcaca72456c1217",
+          "shape": [
+            3
+          ]
+        },
+        "x_edges": {
+          "dtype": "float64",
+          "finite_count": 4,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "03f23cdadce8264c0d28476184fa07987f1ac9dbf8f8b913fc9ff7eb49c0817e",
+          "shape": [
+            4
+          ]
+        }
+      },
+      "keys": [
+        "ci_hi_tail",
+        "ci_hi_total",
+        "ci_lo_tail",
+        "ci_lo_total",
+        "mean_tail",
+        "mean_total",
+        "meta",
+        "n_units",
+        "per_unit_ids",
+        "per_unit_tail",
+        "per_unit_total",
+        "x_centers",
+        "x_edges"
+      ],
+      "name": "panel_4_flat_intact_ctrl_disttrav_by_maxdist",
+      "path": "exports/disttrav_by_dist_max_bin_intact_ctrlKir_flatLgc_T1_inclWall_2026-04-08.npz",
+      "sha256": "034e73821a674e54c28f38d0d77f9ff0bcf6efa996b9516ef79d0599250c29cc"
+    },
+    {
+      "arrays": {
+        "ci_hi_tail": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "15780deba5eed594d89aa533ff140229d3868a66ee410a5a22fa02f803d5fc3c",
+          "shape": [
+            3
+          ]
+        },
+        "ci_hi_total": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "f504bfbddcb5fbf6e560acb8aafe1d7c9d5d4ff705c2b179fa8dac1abddb03cf",
+          "shape": [
+            3
+          ]
+        },
+        "ci_lo_tail": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "b8f8894e3adcaccd3262b3a7db698fdbbf8ae534ece3c6fbfcad7c66389e940e",
+          "shape": [
+            3
+          ]
+        },
+        "ci_lo_total": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "fb85900b08aab9b252a0f335cc8e746b11f6aef8279cc9a183718f327872b20d",
+          "shape": [
+            3
+          ]
+        },
+        "mean_tail": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "112fa52939b03df6263e0f2529413c7c77128cf73b8770244a7eb6d8a0601272",
+          "shape": [
+            3
+          ]
+        },
+        "mean_total": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "0d110eed749ccb41d5c73cc04b962a281ed4958fa99f17819ce95cddf4dfdc61",
+          "shape": [
+            3
+          ]
+        },
+        "meta": {
+          "dtype": "object",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "abb37a5bfe56ea037e8e9b739ffdb92f30134bc6d792fb75d86a148cbf506bb7",
+          "shape": [
+            1
+          ]
+        },
+        "n_units": {
+          "dtype": "int64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "fcdab5667de2282443ab7cb7b8879c09364e2360523193ecdddd5b042875a10e",
+          "shape": [
+            3
+          ]
+        },
+        "per_unit_ids": {
+          "dtype": "object",
+          "finite_count": 54,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "b8e4588467d68220e8155bd9648c2ace7af0c5373e44e0cffcafb0054e1f67d8",
+          "shape": [
+            54
+          ]
+        },
+        "per_unit_tail": {
+          "dtype": "float64",
+          "finite_count": 158,
+          "kind": "numeric",
+          "nan_count": 4,
+          "sha256": "4cc47d8b8b4c56e73041377f3e66ad968e77ed2cc1616e56c685db0d76642c72",
+          "shape": [
+            54,
+            3
+          ]
+        },
+        "per_unit_total": {
+          "dtype": "float64",
+          "finite_count": 158,
+          "kind": "numeric",
+          "nan_count": 4,
+          "sha256": "f48258d28b0ed1d4e02beaa82a930e5ed9411ddb4551e5704fa065a87a192779",
+          "shape": [
+            54,
+            3
+          ]
+        },
+        "x_centers": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "a67397a9c9ef09831aa81547d46bd0484f739246fa92ef9c7bcaca72456c1217",
+          "shape": [
+            3
+          ]
+        },
+        "x_edges": {
+          "dtype": "float64",
+          "finite_count": 4,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "03f23cdadce8264c0d28476184fa07987f1ac9dbf8f8b913fc9ff7eb49c0817e",
+          "shape": [
+            4
+          ]
+        }
+      },
+      "keys": [
+        "ci_hi_tail",
+        "ci_hi_total",
+        "ci_lo_tail",
+        "ci_lo_total",
+        "mean_tail",
+        "mean_total",
+        "meta",
+        "n_units",
+        "per_unit_ids",
+        "per_unit_tail",
+        "per_unit_total",
+        "x_centers",
+        "x_edges"
+      ],
+      "name": "panel_4_flat_intact_pfn_disttrav_by_maxdist",
+      "path": "exports/disttrav_by_dist_max_bin_intact_pfnKir_flatLgc_T1_inclWall_2026-04-08.npz",
+      "sha256": "b93219f0f09105967e5d15266a90b974f2b10086a4f84daf4152fc000e7dc800"
+    },
+    {
+      "arrays": {
+        "ci_hi_tail": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "68b6d937ef6238318ee1e90f49436dcb722c5d98cfd208975b2186aaa531f84e",
+          "shape": [
+            3
+          ]
+        },
+        "ci_hi_total": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "e52ca12f6eed6350b6f6cbc719b341a597eb09266c8b5e9ba7dd9bac600976e8",
+          "shape": [
+            3
+          ]
+        },
+        "ci_lo_tail": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "687e1813bd661eb3f23763e4cac73bc200ee7dffc48e1b2c99a0cc67536fc562",
+          "shape": [
+            3
+          ]
+        },
+        "ci_lo_total": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "5880efe5da93d214f6759977343f951d3a812ca6aebf010acf9af458a33d6bc3",
+          "shape": [
+            3
+          ]
+        },
+        "mean_tail": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "dad5d4b98b332e0eda130603d4b7819a5cf17da40c0f61a3b7f905a0d1afdd69",
+          "shape": [
+            3
+          ]
+        },
+        "mean_total": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "338883b5f2795e1742eabfa8edaf729634ab810d5d27accaa19e7362bd92415f",
+          "shape": [
+            3
+          ]
+        },
+        "meta": {
+          "dtype": "object",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "cc7b1dac591fc75b718a77f66e4f450a491891da82bd1f6a097aa3d2bb56fa8a",
+          "shape": [
+            1
+          ]
+        },
+        "n_units": {
+          "dtype": "int64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "e0dca5036965ddfa3b16b0f377fa6b3228f495189b03159e4f47243f8afd6103",
+          "shape": [
+            3
+          ]
+        },
+        "per_unit_ids": {
+          "dtype": "object",
+          "finite_count": 58,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "e27b2085b7bb1885e5ca97c65da16d0fdc0172759954455f53abe7799ce60134",
+          "shape": [
+            58
+          ]
+        },
+        "per_unit_tail": {
+          "dtype": "float64",
+          "finite_count": 166,
+          "kind": "numeric",
+          "nan_count": 8,
+          "sha256": "b82fce72fa255f907428d76ee5e07d70fee56487656b45d483833c1cbc98a8cb",
+          "shape": [
+            58,
+            3
+          ]
+        },
+        "per_unit_total": {
+          "dtype": "float64",
+          "finite_count": 166,
+          "kind": "numeric",
+          "nan_count": 8,
+          "sha256": "bef83fab6f71ad004c184148ae6dc6622186938aabd6c77353dfee37e251db2d",
+          "shape": [
+            58,
+            3
+          ]
+        },
+        "x_centers": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "a67397a9c9ef09831aa81547d46bd0484f739246fa92ef9c7bcaca72456c1217",
+          "shape": [
+            3
+          ]
+        },
+        "x_edges": {
+          "dtype": "float64",
+          "finite_count": 4,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "03f23cdadce8264c0d28476184fa07987f1ac9dbf8f8b913fc9ff7eb49c0817e",
+          "shape": [
+            4
+          ]
+        }
+      },
+      "keys": [
+        "ci_hi_tail",
+        "ci_hi_total",
+        "ci_lo_tail",
+        "ci_lo_total",
+        "mean_tail",
+        "mean_total",
+        "meta",
+        "n_units",
+        "per_unit_ids",
+        "per_unit_tail",
+        "per_unit_total",
+        "x_centers",
+        "x_edges"
+      ],
+      "name": "panel_4_flat_ar_ctrl_disttrav_by_maxdist",
+      "path": "exports/disttrav_by_dist_max_bin_ar_ctrlKir_flatLgc_T1_inclWall_2026-04-08.npz",
+      "sha256": "1c32d1ed0d3dd990c55d3d9084fd6f401ec68137d83a7d8f1bca76d175b25499"
+    },
+    {
+      "arrays": {
+        "ci_hi_tail": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "a8e9fc0e4460fd69336b101d9b3609099e34776b6852c5d7d8c9a8bb02585d55",
+          "shape": [
+            1
+          ]
+        },
+        "ci_hi_total": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "2a20919825b26880c4bc4b777aa8b26bcc5de43f2902e4261c9f58f6c7c4bdce",
+          "shape": [
+            1
+          ]
+        },
+        "ci_lo_tail": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "9c606cadab0289390c489dab03c35c9cb6e359b703ebb2e2491e701bec6e62a4",
+          "shape": [
+            1
+          ]
+        },
+        "ci_lo_total": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "541b482981cf2ec37a717ca412c91c530fb31c26143a5d5e5f2653af9a6f553f",
+          "shape": [
+            1
+          ]
+        },
+        "mean_tail": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "78e843a100d03034ff951c7b2513ba4d73a7c4b213dabcd5dba4e353008d3d2c",
+          "shape": [
+            1
+          ]
+        },
+        "mean_total": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "545f2002503a2f0df3ebce164660c9b660fe1452a1da51cfc48cd5ef53d5e588",
+          "shape": [
+            1
+          ]
+        },
+        "meta": {
+          "dtype": "object",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "1f4840270aa295d10c4757980bbf7b1d87da47fcea2c8ba2d62a112a9e931410",
+          "shape": [
+            1
+          ]
+        },
+        "n_units": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "48001b2f2c5137abda63e9487ddf147cc471eff55eb6fef2e0bb9247bc2553c4",
+          "shape": [
+            1
+          ]
+        },
+        "per_unit_ids": {
+          "dtype": "object",
+          "finite_count": 51,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "68f4d8176549d86545bcfdba9521ab700ef0fcad21ab0a1ccedcf950b2a45cc7",
+          "shape": [
+            51
+          ]
+        },
+        "per_unit_tail": {
+          "dtype": "float64",
+          "finite_count": 51,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "2fe5aead50c3df88370b1c70eba22ab6752b05c6470b1f3654b24e9a60767fc5",
+          "shape": [
+            51,
+            1
+          ]
+        },
+        "per_unit_total": {
+          "dtype": "float64",
+          "finite_count": 51,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "b040d2bb1ed89eb8d9b853f9ea4e01d873ed7e942ecd3d241aa6101efed323fd",
+          "shape": [
+            51,
+            1
+          ]
+        },
+        "x_centers": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "bb384aa588e9aee3fae923334f5cec1416ad8ab038fe45e772beadf7ebfed103",
+          "shape": [
+            1
+          ]
+        },
+        "x_edges": {
+          "dtype": "float64",
+          "finite_count": 2,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "512785e675385dcb2d7af1cf379ac8784de4ff8d1be3de5be33040e1ef71e701",
+          "shape": [
+            2
+          ]
+        }
+      },
+      "keys": [
+        "ci_hi_tail",
+        "ci_hi_total",
+        "ci_lo_tail",
+        "ci_lo_total",
+        "mean_tail",
+        "mean_total",
+        "meta",
+        "n_units",
+        "per_unit_ids",
+        "per_unit_tail",
+        "per_unit_total",
+        "x_centers",
+        "x_edges"
+      ],
+      "name": "panel_5_flat_intact_ctrl_disttrav_by_maxdist_20_24mm",
+      "path": "exports/disttrav_by_dist_max_bin_intact_ctrlKir_flatLgc_T1_inclWall_20mmMin24mmMax_2026-04-08.npz",
+      "sha256": "7c93a918461c31821d4bec98931057ebafabe87551fbdbca4a8797e002955792"
+    },
+    {
+      "arrays": {
+        "ci_hi_tail": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "aba1313e977566686c3938033be1dac9ddc962f2e8cb77ad5755f553005eb8bd",
+          "shape": [
+            1
+          ]
+        },
+        "ci_hi_total": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "942f05178c887abd058c34a99678e3aa56b9f49996eed4f67e750723e4bbce65",
+          "shape": [
+            1
+          ]
+        },
+        "ci_lo_tail": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "92b2186bb01f8542621d3614b2d499bb32ff559b3e7da01cbe00816d90e18e37",
+          "shape": [
+            1
+          ]
+        },
+        "ci_lo_total": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "f42faf50d05e0cf0a3e10f1d245bb370297bb21f5e600d1aee2bab245c806ddc",
+          "shape": [
+            1
+          ]
+        },
+        "mean_tail": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "56711b082c76d141cf40a8da1b05f47e0f9a7388b3d5e914c7026374ed09366c",
+          "shape": [
+            1
+          ]
+        },
+        "mean_total": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "bd88a8b9c49540f0b0befc4d0ee71bb2a103edd8115751795bd8904307765529",
+          "shape": [
+            1
+          ]
+        },
+        "meta": {
+          "dtype": "object",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "f629c023d1165347c69a178baf639e8714cec01f698f91ae46a6d2eb1cfd7dc7",
+          "shape": [
+            1
+          ]
+        },
+        "n_units": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "dcbe298920b50037fcfb8dda1e57ad49eeeedd8e0ddafc2deed4902c1bc11d3a",
+          "shape": [
+            1
+          ]
+        },
+        "per_unit_ids": {
+          "dtype": "object",
+          "finite_count": 52,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "17be83acb48c3d40959c93a54f06744b991f1c0d7798e5b88bf92f1d36e382ea",
+          "shape": [
+            52
+          ]
+        },
+        "per_unit_tail": {
+          "dtype": "float64",
+          "finite_count": 52,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "9393d19629aaae2d017e2a37268fca88934f9097136977aff69e6713d75586b5",
+          "shape": [
+            52,
+            1
+          ]
+        },
+        "per_unit_total": {
+          "dtype": "float64",
+          "finite_count": 52,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "e972dee5b5483ef0368425625501df040d34798b98b65152b1cc212dcdf905a9",
+          "shape": [
+            52,
+            1
+          ]
+        },
+        "x_centers": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "bb384aa588e9aee3fae923334f5cec1416ad8ab038fe45e772beadf7ebfed103",
+          "shape": [
+            1
+          ]
+        },
+        "x_edges": {
+          "dtype": "float64",
+          "finite_count": 2,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "512785e675385dcb2d7af1cf379ac8784de4ff8d1be3de5be33040e1ef71e701",
+          "shape": [
+            2
+          ]
+        }
+      },
+      "keys": [
+        "ci_hi_tail",
+        "ci_hi_total",
+        "ci_lo_tail",
+        "ci_lo_total",
+        "mean_tail",
+        "mean_total",
+        "meta",
+        "n_units",
+        "per_unit_ids",
+        "per_unit_tail",
+        "per_unit_total",
+        "x_centers",
+        "x_edges"
+      ],
+      "name": "panel_5_flat_intact_pfn_disttrav_by_maxdist_20_24mm",
+      "path": "exports/disttrav_by_dist_max_bin_intact_pfnKir_flatLgc_T1_inclWall_20mmMin24mmMax_2026-04-08.npz",
+      "sha256": "9f7cdc0c76dcab5b37195b7588727c9b2c82cab5b3a140bfbb93ed77d2bd9717"
+    },
+    {
+      "arrays": {
+        "ci_hi_tail": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "d357c174943e9405cf3ddf4172ab0fc5b748d48039082766b3cdf0075c0c9284",
+          "shape": [
+            1
+          ]
+        },
+        "ci_hi_total": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "6fac61f9b1dab4ca3125b004cde9146140cc0c0ae14746be5656365b0f1b4407",
+          "shape": [
+            1
+          ]
+        },
+        "ci_lo_tail": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "410bfe84025f7d78d260f41f0038c65e8a5a4210df4620e1da915636580701b0",
+          "shape": [
+            1
+          ]
+        },
+        "ci_lo_total": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "4c7b9d501718b5028449c97151e5c77ade80ce30ade4d731de901b2f1882f3e2",
+          "shape": [
+            1
+          ]
+        },
+        "mean_tail": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "81d09fd8db87e2950321353a75be708d9ad9344a8d7ba3ac7722fd4bbaf87c46",
+          "shape": [
+            1
+          ]
+        },
+        "mean_total": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "342b25456b0fb789c5916871e9f0dc7af8573371ea65d2d735ccfe14826dc68a",
+          "shape": [
+            1
+          ]
+        },
+        "meta": {
+          "dtype": "object",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "1f251b1d2dbabe23ab3a193b857960ad77a234f87bb2793b81b4fc1d202b3ca6",
+          "shape": [
+            1
+          ]
+        },
+        "n_units": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "563e0ed5fdceb76bf32c350148f6ba0d166833b9cb2f5c5a1d465db005476b84",
+          "shape": [
+            1
+          ]
+        },
+        "per_unit_ids": {
+          "dtype": "object",
+          "finite_count": 53,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "58bb3d847637efb2d04b6c3272a19d5b883f0931f1c968bcafff71221726a5a7",
+          "shape": [
+            53
+          ]
+        },
+        "per_unit_tail": {
+          "dtype": "float64",
+          "finite_count": 53,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "eba8b42b245d04bb5e94095dd83f2b72ef4ef033dd10a7f6dc0fb8b1a5d9d82e",
+          "shape": [
+            53,
+            1
+          ]
+        },
+        "per_unit_total": {
+          "dtype": "float64",
+          "finite_count": 53,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "297721cf6e59a3e2d11b38344cf4a7464dd422320cec6faa7e3fe3386f09e58a",
+          "shape": [
+            53,
+            1
+          ]
+        },
+        "x_centers": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "bb384aa588e9aee3fae923334f5cec1416ad8ab038fe45e772beadf7ebfed103",
+          "shape": [
+            1
+          ]
+        },
+        "x_edges": {
+          "dtype": "float64",
+          "finite_count": 2,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "512785e675385dcb2d7af1cf379ac8784de4ff8d1be3de5be33040e1ef71e701",
+          "shape": [
+            2
+          ]
+        }
+      },
+      "keys": [
+        "ci_hi_tail",
+        "ci_hi_total",
+        "ci_lo_tail",
+        "ci_lo_total",
+        "mean_tail",
+        "mean_total",
+        "meta",
+        "n_units",
+        "per_unit_ids",
+        "per_unit_tail",
+        "per_unit_total",
+        "x_centers",
+        "x_edges"
+      ],
+      "name": "panel_5_flat_ar_ctrl_disttrav_by_maxdist_20_24mm",
+      "path": "exports/disttrav_by_dist_max_bin_ar_ctrlKir_flatLgc_T1_inclWall_20mmMin24mmMax_2026-04-08.npz",
+      "sha256": "42d330cf626c260f5da399baf33ec3822ac1954660af406b1eb95e00460a9c82"
+    }
+  ],
+  "schema_version": 1
+}

--- a/test/reference/bundles/between_reward_distance_hist_paper_manifest.json
+++ b/test/reference/bundles/between_reward_distance_hist_paper_manifest.json
@@ -1,0 +1,506 @@
+{
+  "bundles": [
+    {
+      "arrays": {
+        "bin_edges": {
+          "dtype": "float64",
+          "finite_count": 4,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "e7466be2f08ac3ee5aefbe80c452d400bf8e8933eb82dc08011183e6ff89ed25",
+          "shape": [
+            1,
+            4
+          ]
+        },
+        "ci_hi": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "5b70d721fd3b17386bd9b09daf9ee634a76bfd54802f1e217b3fd68783d7c007",
+          "shape": [
+            1,
+            3
+          ]
+        },
+        "ci_lo": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "0fca4a1cc7474b7f1e0a71f74c4c52f213fa9ee2aaef6f573f15fd48d271db7c",
+          "shape": [
+            1,
+            3
+          ]
+        },
+        "counts": {
+          "dtype": "object",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "acd75c0c99e3de9988d9de46a026e05dcc7dc46cbb3baa8972c13da55c81df23",
+          "shape": []
+        },
+        "mean": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "5f8ffa03bdd632f6058ade08dff37538fbf3674dd317caa471ef1adfe1ad9987",
+          "shape": [
+            1,
+            3
+          ]
+        },
+        "meta_json": {
+          "dtype": "<U765",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "805ddc7d767fc6b5c96859e3fa2577dfa16e81b62564eac95c0fffeea9cc5c1a",
+          "shape": []
+        },
+        "n_dropped": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "debcea1f166010e428df48387304e45c0bf7843a1fa7f1beb38f852228df789b",
+          "shape": [
+            1
+          ]
+        },
+        "n_raw": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "3084a759a63f5749e68f8cf24361c94c7712a3f25323288c0c3da70de34e043d",
+          "shape": [
+            1
+          ]
+        },
+        "n_units": {
+          "dtype": "int64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "8221c64bdb4c8c3d640f4ce97c4de348a232e61a6731411f7d53beff573d92a2",
+          "shape": [
+            1,
+            3
+          ]
+        },
+        "n_units_panel": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "8250ab532e40d24a67c08f58e0cd1d76cef63a045599ae5dc9279472cada42dd",
+          "shape": [
+            1
+          ]
+        },
+        "n_used": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "d89e8cd6f2ef488ddfe18e10b5c9578edcf051ee4824db55116b841281b72663",
+          "shape": [
+            1
+          ]
+        },
+        "panel_labels": {
+          "dtype": "object",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "8a6832011557ee714db45ca6d93f8541d8127ebd802781333bd8926b0ecd55ac",
+          "shape": [
+            1
+          ]
+        },
+        "per_unit_ids_panel": {
+          "dtype": "object",
+          "finite_count": 63,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "8579e6698278603c0f4c7c9096961579c568eeee4c50d96e0328add964580e0e",
+          "shape": [
+            1,
+            63
+          ]
+        },
+        "per_unit_panel": {
+          "dtype": "object",
+          "finite_count": 189,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "cdb34d83ae6440a89f34acbcc7c53dc0df32439243abe739131e504cd2480a73",
+          "shape": [
+            1,
+            63,
+            3
+          ]
+        }
+      },
+      "keys": [
+        "bin_edges",
+        "ci_hi",
+        "ci_lo",
+        "counts",
+        "mean",
+        "meta_json",
+        "n_dropped",
+        "n_raw",
+        "n_units",
+        "n_units_panel",
+        "n_used",
+        "panel_labels",
+        "per_unit_ids_panel",
+        "per_unit_panel"
+      ],
+      "name": "panel_3_flat_intact_ctrl_between_reward_distance",
+      "path": "exports/dist_trav_intact_ctrlKir_flatLgc_T2_inclWall_2026-04-08.npz",
+      "sha256": "f260fa6beb2b9c68764ce31ae97044ce5330c4daabec3e27972c7b7fa494ff40"
+    },
+    {
+      "arrays": {
+        "bin_edges": {
+          "dtype": "float64",
+          "finite_count": 4,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "e7466be2f08ac3ee5aefbe80c452d400bf8e8933eb82dc08011183e6ff89ed25",
+          "shape": [
+            1,
+            4
+          ]
+        },
+        "ci_hi": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "ac0c81b8160925171f81fcaf03e2f3c5276f35fbd9910c72386439cdd583213c",
+          "shape": [
+            1,
+            3
+          ]
+        },
+        "ci_lo": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "b3838527d8e149097a5ebafab9f1f20c82d5ad8c9be2b1ce0fb4205573e02550",
+          "shape": [
+            1,
+            3
+          ]
+        },
+        "counts": {
+          "dtype": "object",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "acd75c0c99e3de9988d9de46a026e05dcc7dc46cbb3baa8972c13da55c81df23",
+          "shape": []
+        },
+        "mean": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "f862abdae6f6341302283f118a8166ceb21c8f197f605a828072e5cf56f29457",
+          "shape": [
+            1,
+            3
+          ]
+        },
+        "meta_json": {
+          "dtype": "<U765",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "d2a8cba04fe078899140ad0175c730d44470a887e10648e6c0103ec8d052c803",
+          "shape": []
+        },
+        "n_dropped": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "3c88bf13b58cba9ca7fe10c55db47931f52b52975cf1e9eaa0c9b0ec29c7c6be",
+          "shape": [
+            1
+          ]
+        },
+        "n_raw": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "fe9ee0930d4c8c6c1bcc3b3987e87b78d9e629c5c9e60879b28383a626d8de82",
+          "shape": [
+            1
+          ]
+        },
+        "n_units": {
+          "dtype": "int64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "70d8c0f58c9448783ebb431344630e6f40b94d8c44f0a56cc37bf1dbd8fa25e4",
+          "shape": [
+            1,
+            3
+          ]
+        },
+        "n_units_panel": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "dcbe298920b50037fcfb8dda1e57ad49eeeedd8e0ddafc2deed4902c1bc11d3a",
+          "shape": [
+            1
+          ]
+        },
+        "n_used": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "54f81d4424e1650babddd21a9827999301027ea5f873a5c092c9c318fc834e74",
+          "shape": [
+            1
+          ]
+        },
+        "panel_labels": {
+          "dtype": "object",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "8a6832011557ee714db45ca6d93f8541d8127ebd802781333bd8926b0ecd55ac",
+          "shape": [
+            1
+          ]
+        },
+        "per_unit_ids_panel": {
+          "dtype": "object",
+          "finite_count": 52,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "dfd4e1cbba888dbeb353375fff0ac01ae7ee94ff8ce177d23f8ed65263fbd939",
+          "shape": [
+            1,
+            52
+          ]
+        },
+        "per_unit_panel": {
+          "dtype": "object",
+          "finite_count": 156,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "52cb5ca008a45ee4a60385ff0109c10cb1abc57b5bbef105528f12d8a6b4c9cc",
+          "shape": [
+            1,
+            52,
+            3
+          ]
+        }
+      },
+      "keys": [
+        "bin_edges",
+        "ci_hi",
+        "ci_lo",
+        "counts",
+        "mean",
+        "meta_json",
+        "n_dropped",
+        "n_raw",
+        "n_units",
+        "n_units_panel",
+        "n_used",
+        "panel_labels",
+        "per_unit_ids_panel",
+        "per_unit_panel"
+      ],
+      "name": "panel_3_flat_intact_pfn_between_reward_distance",
+      "path": "exports/dist_trav_intact_pfnKir_flatLgc_T2_inclWall_2026-04-08.npz",
+      "sha256": "8b697ffd94bd8a50503e46a5860d2f9148bec126865c6ea8b56b8f2079b3dde5"
+    },
+    {
+      "arrays": {
+        "bin_edges": {
+          "dtype": "float64",
+          "finite_count": 4,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "e7466be2f08ac3ee5aefbe80c452d400bf8e8933eb82dc08011183e6ff89ed25",
+          "shape": [
+            1,
+            4
+          ]
+        },
+        "ci_hi": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "22950b34d98d53e72a01f58c7bdd00b17c5a106a08dfb15f30d74f036097a549",
+          "shape": [
+            1,
+            3
+          ]
+        },
+        "ci_lo": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af74348202fd0c75b1b7760eba461fedb87ab2f606098603344f1508c40be5ff",
+          "shape": [
+            1,
+            3
+          ]
+        },
+        "counts": {
+          "dtype": "object",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "acd75c0c99e3de9988d9de46a026e05dcc7dc46cbb3baa8972c13da55c81df23",
+          "shape": []
+        },
+        "mean": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "2c9ef054f4c768d340983284b2ed05a2d8c8e62aa49288a4903f4e12ae9383c4",
+          "shape": [
+            1,
+            3
+          ]
+        },
+        "meta_json": {
+          "dtype": "<U765",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "01edeb852a8b26353ccb7cee06470734e2071d54e050da08d055e01c39d387e1",
+          "shape": []
+        },
+        "n_dropped": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "e7ed77624bef61797eed1a770a22f9886ddb54ebca1d37fe401302b08937ae17",
+          "shape": [
+            1
+          ]
+        },
+        "n_raw": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "b58a80af5baa70c6c5bd5ad44f701b198b773411b7cb976a21755cae0243d7ec",
+          "shape": [
+            1
+          ]
+        },
+        "n_units": {
+          "dtype": "int64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "19614069732b01f5951defff2ffc90df96f36c7cb806878fc52bb7a402099edf",
+          "shape": [
+            1,
+            3
+          ]
+        },
+        "n_units_panel": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "563e0ed5fdceb76bf32c350148f6ba0d166833b9cb2f5c5a1d465db005476b84",
+          "shape": [
+            1
+          ]
+        },
+        "n_used": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "4d30baf3d4599c6185f10e6b2cae16f2f581acd7fd2b74e76cc54aa08c2b69f1",
+          "shape": [
+            1
+          ]
+        },
+        "panel_labels": {
+          "dtype": "object",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "8a6832011557ee714db45ca6d93f8541d8127ebd802781333bd8926b0ecd55ac",
+          "shape": [
+            1
+          ]
+        },
+        "per_unit_ids_panel": {
+          "dtype": "object",
+          "finite_count": 53,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "68b739b93c47151f5478c2e35cbc831fd96d16b37cff86e43a3e73d48786aea6",
+          "shape": [
+            1,
+            53
+          ]
+        },
+        "per_unit_panel": {
+          "dtype": "object",
+          "finite_count": 159,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "84122e88da278c0868273e6cfe73fe02a475b4af6b9bee38b54ed0144e61083d",
+          "shape": [
+            1,
+            53,
+            3
+          ]
+        }
+      },
+      "keys": [
+        "bin_edges",
+        "ci_hi",
+        "ci_lo",
+        "counts",
+        "mean",
+        "meta_json",
+        "n_dropped",
+        "n_raw",
+        "n_units",
+        "n_units_panel",
+        "n_used",
+        "panel_labels",
+        "per_unit_ids_panel",
+        "per_unit_panel"
+      ],
+      "name": "panel_3_flat_ar_ctrl_between_reward_distance",
+      "path": "exports/dist_trav_ar_ctrlKir_flatLgc_T2_inclWall_2026-04-08.npz",
+      "sha256": "8ca0e44bce4493290f3c62a5fd5414d644c9e8f30cc5775acb50da8150762633"
+    }
+  ],
+  "schema_version": 1
+}

--- a/test/reference/bundles/between_reward_maxdist_paper_manifest.json
+++ b/test/reference/bundles/between_reward_maxdist_paper_manifest.json
@@ -1,0 +1,175 @@
+{
+  "bundles": [
+    {
+      "arrays": {
+        "between_reward_maxdistN_ctrl": {
+          "dtype": "int64",
+          "finite_count": 1242,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "8877ab99854143f8d2ae7eac724498e5330e41167dff69dc24f9fd5ad8355ffa",
+          "shape": [
+            69,
+            3,
+            6
+          ]
+        },
+        "between_reward_maxdistN_exp": {
+          "dtype": "int64",
+          "finite_count": 1242,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "6d167fdf1c44673250bf0d1782fc6a709ec37fdb87c860991990c4fb8790321b",
+          "shape": [
+            69,
+            3,
+            6
+          ]
+        },
+        "between_reward_maxdist_ctrl": {
+          "dtype": "float64",
+          "finite_count": 878,
+          "kind": "numeric",
+          "nan_count": 364,
+          "sha256": "2908ae590b7fc19fc2d30794200c888f2e8c23efed5339939287a66fa357ea52",
+          "shape": [
+            69,
+            3,
+            6
+          ]
+        },
+        "between_reward_maxdist_exp": {
+          "dtype": "float64",
+          "finite_count": 920,
+          "kind": "numeric",
+          "nan_count": 322,
+          "sha256": "2ccf8cac7fcd653e8e11e346943334d321bc29fb5db372064f5c84a3667c9737",
+          "shape": [
+            69,
+            3,
+            6
+          ]
+        },
+        "btw_rwd_sync_bucket_min_trajectories": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "f13ee6ed54ea2aae9fc49a9faeb5da6e8ddef0e12ed5d30d35a624ae813e0485",
+          "shape": []
+        },
+        "bucket_len_min": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "24b1f4ef66b650ff816e519b01742ff1753733d36e1b4c3e3b52743168915b1f",
+          "shape": []
+        },
+        "group_label": {
+          "dtype": "<U18",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "3d08ba1cb0dff4442a18ba6258e18780ad45f5802d65ad029a519bc4817d171c",
+          "shape": []
+        },
+        "sli": {
+          "dtype": "float64",
+          "finite_count": 62,
+          "kind": "numeric",
+          "nan_count": 7,
+          "sha256": "31fdbb97d3b48656fd3f11913c909063984a407f43dcd919cd7d010b31caef37",
+          "shape": [
+            69
+          ]
+        },
+        "sli_select_keep_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "sli_select_skip_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "sli_training_idx": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "sli_ts": {
+          "dtype": "float64",
+          "finite_count": 847,
+          "kind": "numeric",
+          "nan_count": 395,
+          "sha256": "d0c722c678aba09e7409135f820bc1b95b4938c0ccb9b87cd7658ba6d3230cec",
+          "shape": [
+            69,
+            3,
+            6
+          ]
+        },
+        "sli_use_training_mean": {
+          "dtype": "bool",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "a2709fcbfdeb023a70c53c31628d48d9306c5f4772ab12de7b67b66f3bf34fa7",
+          "shape": []
+        },
+        "training_names": {
+          "dtype": "object",
+          "finite_count": 3,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "4860b8926b4845ace4d18e00fcbf676c260d49d4d5ebe5df07e1aee6693e70f2",
+          "shape": [
+            3
+          ]
+        },
+        "video_ids": {
+          "dtype": "object",
+          "finite_count": 69,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "9242d4fcf88dee42c16d3fd736097f56281fbee20201cd164caa753a22b91071",
+          "shape": [
+            69
+          ]
+        }
+      },
+      "keys": [
+        "between_reward_maxdistN_ctrl",
+        "between_reward_maxdistN_exp",
+        "between_reward_maxdist_ctrl",
+        "between_reward_maxdist_exp",
+        "btw_rwd_sync_bucket_min_trajectories",
+        "bucket_len_min",
+        "group_label",
+        "sli",
+        "sli_select_keep_first_sync_buckets",
+        "sli_select_skip_first_sync_buckets",
+        "sli_training_idx",
+        "sli_ts",
+        "sli_use_training_mean",
+        "training_names",
+        "video_ids"
+      ],
+      "name": "panel_6_flat_intact_ctrl_between_reward_maxdist",
+      "path": "exports/maxdist_by_sb_intact_ctrlKir_flatLgc_2026-03-24.npz",
+      "sha256": "851ab4afa4b3521f55fee62025b2215c5a805fff4e5041f0f20551c046569935"
+    }
+  ],
+  "schema_version": 1
+}

--- a/test/reference/bundles/between_reward_return_leg_dist_paper_manifest.json
+++ b/test/reference/bundles/between_reward_return_leg_dist_paper_manifest.json
@@ -1,0 +1,175 @@
+{
+  "bundles": [
+    {
+      "arrays": {
+        "between_reward_return_leg_distN_ctrl": {
+          "dtype": "int64",
+          "finite_count": 1242,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "ed8b08355536777e67814aa38f63b3ba4f1cf2ca624e2546029615f7884810b0",
+          "shape": [
+            69,
+            3,
+            6
+          ]
+        },
+        "between_reward_return_leg_distN_exp": {
+          "dtype": "int64",
+          "finite_count": 1242,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "d5b8a0ad01b0787edf332b493dbab4cb05254c81c3bc38498605e1a8d48bb02e",
+          "shape": [
+            69,
+            3,
+            6
+          ]
+        },
+        "between_reward_return_leg_dist_ctrl": {
+          "dtype": "float64",
+          "finite_count": 878,
+          "kind": "numeric",
+          "nan_count": 364,
+          "sha256": "956bd97c936e56225d982dc7dd75e3f86473aeca3c3732f52a7f998623ef94aa",
+          "shape": [
+            69,
+            3,
+            6
+          ]
+        },
+        "between_reward_return_leg_dist_exp": {
+          "dtype": "float64",
+          "finite_count": 919,
+          "kind": "numeric",
+          "nan_count": 323,
+          "sha256": "d3d6c340e56a8511dbeac7b0bba6ea3875417c6e08777def64d0ca1224aba3e3",
+          "shape": [
+            69,
+            3,
+            6
+          ]
+        },
+        "btw_rwd_sync_bucket_min_trajectories": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "f13ee6ed54ea2aae9fc49a9faeb5da6e8ddef0e12ed5d30d35a624ae813e0485",
+          "shape": []
+        },
+        "bucket_len_min": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "24b1f4ef66b650ff816e519b01742ff1753733d36e1b4c3e3b52743168915b1f",
+          "shape": []
+        },
+        "group_label": {
+          "dtype": "<U18",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "3d08ba1cb0dff4442a18ba6258e18780ad45f5802d65ad029a519bc4817d171c",
+          "shape": []
+        },
+        "sli": {
+          "dtype": "float64",
+          "finite_count": 62,
+          "kind": "numeric",
+          "nan_count": 7,
+          "sha256": "31fdbb97d3b48656fd3f11913c909063984a407f43dcd919cd7d010b31caef37",
+          "shape": [
+            69
+          ]
+        },
+        "sli_select_keep_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "sli_select_skip_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "sli_training_idx": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "sli_ts": {
+          "dtype": "float64",
+          "finite_count": 847,
+          "kind": "numeric",
+          "nan_count": 395,
+          "sha256": "d0c722c678aba09e7409135f820bc1b95b4938c0ccb9b87cd7658ba6d3230cec",
+          "shape": [
+            69,
+            3,
+            6
+          ]
+        },
+        "sli_use_training_mean": {
+          "dtype": "bool",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "a2709fcbfdeb023a70c53c31628d48d9306c5f4772ab12de7b67b66f3bf34fa7",
+          "shape": []
+        },
+        "training_names": {
+          "dtype": "object",
+          "finite_count": 3,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "4860b8926b4845ace4d18e00fcbf676c260d49d4d5ebe5df07e1aee6693e70f2",
+          "shape": [
+            3
+          ]
+        },
+        "video_ids": {
+          "dtype": "object",
+          "finite_count": 69,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "9242d4fcf88dee42c16d3fd736097f56281fbee20201cd164caa753a22b91071",
+          "shape": [
+            69
+          ]
+        }
+      },
+      "keys": [
+        "between_reward_return_leg_distN_ctrl",
+        "between_reward_return_leg_distN_exp",
+        "between_reward_return_leg_dist_ctrl",
+        "between_reward_return_leg_dist_exp",
+        "btw_rwd_sync_bucket_min_trajectories",
+        "bucket_len_min",
+        "group_label",
+        "sli",
+        "sli_select_keep_first_sync_buckets",
+        "sli_select_skip_first_sync_buckets",
+        "sli_training_idx",
+        "sli_ts",
+        "sli_use_training_mean",
+        "training_names",
+        "video_ids"
+      ],
+      "name": "panel_7_flat_intact_ctrl_between_reward_return_leg_dist",
+      "path": "exports/dist_trav_return_intact_ctrlKir_flatLgc_bySB_2026-04-07.npz",
+      "sha256": "aecf56ab476f201d3c6479d7efcea1337f88481e3a17b7e7a8fcd09f8629b935"
+    }
+  ],
+  "schema_version": 1
+}


### PR DESCRIPTION
## Summary

Adds the three-layer correctness-check rollout for the between-reward distance metric family used in paper panels 3-7.

## Changes

- Added layer-one unit tests for between-reward distance traveled, max distance, and return-leg distance semantics.
- Added manifest regression tests for the real paper export bundles covering:
  - Panel 3 distance histogram exports
  - Panels 4/5 conditioned distance-traveled exports
  - Panel 6 max-distance SLI bundle
  - Panel 7 return-leg-distance SLI bundle
- Added runtime validation for:
  - max-distance and return-leg SLI-style bundles
  - conditioned distance-traveled result NPZs
  - exported training histogram payloads

## Validation

- `pytest test/paper_metrics`

## Notes

- The new checks follow the existing SLI / return-probability correctness-check pattern where possible.
- Histogram and conditioned-distance exports use their existing result/load structures rather than introducing new infrastructure.