### PR TITLE
Add correctness checks for turnback ratio bundles

### DIFF
--- a/scripts/make_turnback_contrast_bundle.py
+++ b/scripts/make_turnback_contrast_bundle.py
@@ -173,6 +173,9 @@ def main():
         turnback_inner_delta_mm=A0.get(
             "turnback_inner_delta_mm", np.array(np.nan, dtype=float)
         ),
+        turnback_outer_delta_mm=A0.get(
+            "turnback_outer_delta_mm", np.array(np.nan, dtype=float)
+        ),
         turnback_inner_radius_offset_px_A=A0.get(
             "turnback_inner_radius_offset_px", np.array(np.nan, dtype=float)
         ),

--- a/src/analysis/sli_bundle_utils.py
+++ b/src/analysis/sli_bundle_utils.py
@@ -52,6 +52,22 @@ BETWEEN_REWARD_RETURN_LEG_DIST_KEYS = (
     "between_reward_return_leg_distN_ctrl",
 )
 
+TURNBACK_RATIO_KEYS = (
+    "turnback_ratio_exp",
+    "turnback_ratio_ctrl",
+    "turnback_total_exp",
+    "turnback_total_ctrl",
+    "turnback_inner_delta_mm",
+    "turnback_outer_delta_mm",
+)
+
+TURNBACK_RATIO_PRIMARY_KEYS = (
+    "turnback_ratio_exp",
+    "turnback_ratio_ctrl",
+    "turnback_total_exp",
+    "turnback_total_ctrl",
+)
+
 
 def as_scalar(x):
     if isinstance(x, np.ndarray) and x.shape == ():
@@ -315,6 +331,84 @@ def validate_between_reward_return_leg_dist_bundle(
     )
 
 
+def _validate_probability_array(
+    bundle: dict,
+    key: str,
+    *,
+    where: str,
+    expected_shape: tuple[int, int, int],
+) -> np.ndarray:
+    arr = np.asarray(bundle[key], dtype=float)
+    if arr.ndim != 3:
+        raise ValueError(f"Bundle {where} has non-3D {key} shape {arr.shape}")
+    if arr.shape != expected_shape:
+        raise ValueError(
+            f"Bundle {where} has {key}.shape={arr.shape} "
+            f"but expected {expected_shape}"
+        )
+    if np.any(np.isinf(arr)):
+        raise ValueError(f"Bundle {where} has infinite values in {key}")
+    finite = np.isfinite(arr)
+    if np.any((arr[finite] < 0.0) | (arr[finite] > 1.0)):
+        raise ValueError(f"Bundle {where} has out-of-range probabilities in {key}")
+    return arr
+
+
+def validate_turnback_ratio_bundle(bundle: dict, *, path: str | None = None) -> None:
+    where = _bundle_label(bundle, path)
+    missing = [k for k in TURNBACK_RATIO_KEYS if k not in bundle]
+    if missing:
+        raise ValueError(f"Bundle {where} is missing turnback ratio keys: {missing}")
+
+    expected_shape = _expected_sync_bucket_metric_shape(bundle, where=where)
+    ratio_exp = _validate_probability_array(
+        bundle, "turnback_ratio_exp", where=where, expected_shape=expected_shape
+    )
+    ratio_ctrl = _validate_probability_array(
+        bundle, "turnback_ratio_ctrl", where=where, expected_shape=expected_shape
+    )
+    total_exp = _validate_3d_distance_count_array(
+        bundle, "turnback_total_exp", where=where, expected_shape=expected_shape
+    )
+    total_ctrl = _validate_3d_distance_count_array(
+        bundle, "turnback_total_ctrl", where=where, expected_shape=expected_shape
+    )
+
+    for key, ratio, total in (
+        ("turnback_ratio_exp", ratio_exp, total_exp),
+        ("turnback_ratio_ctrl", ratio_ctrl, total_ctrl),
+    ):
+        if np.any(~np.isfinite(ratio[total > 0])):
+            raise ValueError(f"Bundle {where} has non-finite {key} where total > 0")
+        if np.any(np.isfinite(ratio[total == 0])):
+            raise ValueError(f"Bundle {where} has finite {key} where total == 0")
+        implied_turns = ratio[total > 0] * total[total > 0]
+        if np.any(np.abs(implied_turns - np.rint(implied_turns)) > 1e-10):
+            raise ValueError(
+                f"Bundle {where} has {key} values inconsistent with integer counts"
+            )
+
+    inner_delta_mm = float(as_scalar(bundle["turnback_inner_delta_mm"]))
+    outer_delta_mm = float(as_scalar(bundle["turnback_outer_delta_mm"]))
+    if not np.isfinite(inner_delta_mm):
+        raise ValueError(f"Bundle {where} has non-finite turnback_inner_delta_mm")
+    if not np.isfinite(outer_delta_mm):
+        raise ValueError(f"Bundle {where} has non-finite turnback_outer_delta_mm")
+    if inner_delta_mm < 0.0:
+        raise ValueError(f"Bundle {where} has negative turnback_inner_delta_mm")
+    if outer_delta_mm <= inner_delta_mm:
+        raise ValueError(
+            f"Bundle {where} has turnback_outer_delta_mm={outer_delta_mm} "
+            f"<= turnback_inner_delta_mm={inner_delta_mm}"
+        )
+    if "turnback_inner_radius_offset_px" in bundle:
+        offset_px = float(as_scalar(bundle["turnback_inner_radius_offset_px"]))
+        if not np.isfinite(offset_px):
+            raise ValueError(
+                f"Bundle {where} has non-finite turnback_inner_radius_offset_px"
+            )
+
+
 def validate_return_prob_excursion_bin_bundle(
     bundle: dict, *, path: str | None = None
 ) -> None:
@@ -505,6 +599,8 @@ def normalize_sli_bundle(bundle: dict, *, path: str | None = None) -> dict:
         validate_between_reward_maxdist_bundle(out, path=path)
     if any(k in out for k in BETWEEN_REWARD_RETURN_LEG_DIST_KEYS):
         validate_between_reward_return_leg_dist_bundle(out, path=path)
+    if any(k in out for k in TURNBACK_RATIO_PRIMARY_KEYS):
+        validate_turnback_ratio_bundle(out, path=path)
     return out
 
 

--- a/src/exporting/turnback_sli_bundle.py
+++ b/src/exporting/turnback_sli_bundle.py
@@ -262,6 +262,9 @@ def export_turnback_sli_bundle(vas, opts, gls, out_fn):
         turnback_inner_delta_mm=np.array(
             float(getattr(opts, "turnback_inner_delta_mm", 0.0)), dtype=float
         ),
+        turnback_outer_delta_mm=np.array(
+            float(getattr(opts, "turnback_outer_delta_mm", 2.0)), dtype=float
+        ),
         turnback_inner_radius_offset_px=np.array(
             float(getattr(opts, "turnback_inner_radius_offset_px", 0.0)), dtype=float
         ),

--- a/src/exporting/turnback_sli_bundle.py
+++ b/src/exporting/turnback_sli_bundle.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import os
 import numpy as np
 
+from src.analysis.sli_bundle_utils import (
+    validate_sli_bundle,
+    validate_turnback_ratio_bundle,
+)
 from src.exporting.com_sli_bundle import (
     _compute_sli_scalar_and_timeseries_from_rpid,
     _safe_group_label,
@@ -224,9 +228,7 @@ def export_turnback_sli_bundle(vas, opts, gls, out_fn):
         fly_ids = np.array([-1] * len(vas_ok), dtype=int)
         video_ids = np.array([f"va_{i}" for i in range(len(vas_ok))], dtype=object)
 
-    os.makedirs(os.path.dirname(out_fn) or ".", exist_ok=True)
-    np.savez_compressed(
-        out_fn,
+    payload = dict(
         sli=sli,
         sli_ts=sli_ts,
         turnback_ratio_exp=ratio_exp,
@@ -269,6 +271,11 @@ def export_turnback_sli_bundle(vas, opts, gls, out_fn):
             float(getattr(opts, "turnback_inner_radius_offset_px", 0.0)), dtype=float
         ),
     )
+    validate_sli_bundle(payload, path=out_fn)
+    validate_turnback_ratio_bundle(payload, path=out_fn)
+
+    os.makedirs(os.path.dirname(out_fn) or ".", exist_ok=True)
+    np.savez_compressed(out_fn, **payload)
     print(f"[export] Wrote turnback+SLI bundle: {out_fn} (n={len(vas_ok)})")
     _dbg(
         opts,

--- a/src/validation/bundle_digest.py
+++ b/src/validation/bundle_digest.py
@@ -118,6 +118,26 @@ BETWEEN_REWARD_RETURN_LEG_DIST_SLI_REGRESSION_KEYS = (
     "video_ids",
 )
 
+TURNBACK_RATIO_REGRESSION_KEYS = (
+    "bucket_len_min",
+    "group_label",
+    "sli",
+    "sli_select_keep_first_sync_buckets",
+    "sli_select_skip_first_sync_buckets",
+    "sli_training_idx",
+    "sli_ts",
+    "sli_use_training_mean",
+    "training_names",
+    "turnback_inner_delta_mm",
+    "turnback_inner_radius_offset_px",
+    "turnback_outer_delta_mm",
+    "turnback_ratio_ctrl",
+    "turnback_ratio_exp",
+    "turnback_total_ctrl",
+    "turnback_total_exp",
+    "video_ids",
+)
+
 
 def _json_bytes(payload) -> bytes:
     return json.dumps(

--- a/test/paper_metrics/test_bundle_digest.py
+++ b/test/paper_metrics/test_bundle_digest.py
@@ -6,6 +6,7 @@ import pytest
 from src.validation.bundle_digest import (
     RETURN_PROB_EXCURSION_BIN_REGRESSION_KEYS,
     SLI_REGRESSION_KEYS,
+    TURNBACK_RATIO_REGRESSION_KEYS,
     check_manifest,
     digest_npz,
     write_manifest,
@@ -62,6 +63,31 @@ def _write_return_prob_excursion_bin_bundle(path, *, ratio, unchecked=None):
     np.savez_compressed(path, **payload)
 
 
+def _write_turnback_ratio_bundle(path, *, ratio, unchecked=None):
+    payload = {
+        "bucket_len_min": np.array(10.0, dtype=float),
+        "group_label": np.asarray("Intact Control>Kir", dtype=object),
+        "sli": np.asarray([0.1], dtype=float),
+        "sli_select_keep_first_sync_buckets": np.array(0, dtype=int),
+        "sli_select_skip_first_sync_buckets": np.array(1, dtype=int),
+        "sli_training_idx": np.array(1, dtype=int),
+        "sli_ts": np.asarray([[[1.0, np.nan, 3.0]]], dtype=float),
+        "sli_use_training_mean": np.array(True),
+        "training_names": np.asarray(["T1"], dtype=object),
+        "turnback_inner_delta_mm": np.array(4.0, dtype=float),
+        "turnback_inner_radius_offset_px": np.array(0.0, dtype=float),
+        "turnback_outer_delta_mm": np.array(8.0, dtype=float),
+        "turnback_ratio_ctrl": np.asarray([[[0.2, np.nan]]], dtype=float),
+        "turnback_ratio_exp": np.asarray(ratio, dtype=float),
+        "turnback_total_ctrl": np.asarray([[[5, 0]]], dtype=int),
+        "turnback_total_exp": np.asarray([[[4, 4]]], dtype=int),
+        "video_ids": np.asarray(["video_a::f7"], dtype=object),
+    }
+    if unchecked is not None:
+        payload["unchecked_metric"] = np.asarray(unchecked, dtype=float)
+    np.savez_compressed(path, **payload)
+
+
 def test_npz_digest_is_stable_across_npz_key_write_order(tmp_path):
     a = tmp_path / "a.npz"
     b = tmp_path / "b.npz"
@@ -99,6 +125,19 @@ def test_npz_digest_can_be_limited_to_return_prob_excursion_bin_regression_keys(
     assert (
         digest_npz(a, keys=RETURN_PROB_EXCURSION_BIN_REGRESSION_KEYS)["sha256"]
         == digest_npz(b, keys=RETURN_PROB_EXCURSION_BIN_REGRESSION_KEYS)["sha256"]
+    )
+    assert digest_npz(a)["sha256"] != digest_npz(b)["sha256"]
+
+
+def test_npz_digest_can_be_limited_to_turnback_ratio_regression_keys(tmp_path):
+    a = tmp_path / "a.npz"
+    b = tmp_path / "b.npz"
+    _write_turnback_ratio_bundle(a, ratio=[[[1.0, 0.5]]], unchecked=[1.0])
+    _write_turnback_ratio_bundle(b, ratio=[[[1.0, 0.5]]], unchecked=[999.0])
+
+    assert (
+        digest_npz(a, keys=TURNBACK_RATIO_REGRESSION_KEYS)["sha256"]
+        == digest_npz(b, keys=TURNBACK_RATIO_REGRESSION_KEYS)["sha256"]
     )
     assert digest_npz(a)["sha256"] != digest_npz(b)["sha256"]
 

--- a/test/paper_metrics/test_turnback_ratio_bundle_invariants.py
+++ b/test/paper_metrics/test_turnback_ratio_bundle_invariants.py
@@ -1,0 +1,150 @@
+import numpy as np
+import pytest
+
+from src.analysis.sli_bundle_utils import (
+    normalize_sli_bundle,
+    validate_turnback_ratio_bundle,
+)
+
+
+def _bundle(**overrides):
+    bundle = {
+        "sli": np.asarray([0.1, np.nan], dtype=float),
+        "sli_ts": np.asarray(
+            [
+                [[0.1, 0.2, 0.3], [0.4, 0.5, np.nan]],
+                [[np.nan, 0.1, 0.2], [0.3, np.nan, 0.5]],
+            ]
+        ),
+        "group_label": np.asarray("Intact Control>Kir", dtype=object),
+        "bucket_len_min": np.array(10, dtype=float),
+        "training_names": np.asarray(["T1", "T2"], dtype=object),
+        "video_ids": np.asarray(["video_a", "video_b"], dtype=object),
+        "sli_training_idx": np.array(1, dtype=int),
+        "sli_use_training_mean": np.array(True),
+        "sli_select_skip_first_sync_buckets": np.array(1, dtype=int),
+        "sli_select_keep_first_sync_buckets": np.array(0, dtype=int),
+        "turnback_ratio_exp": np.asarray(
+            [
+                [[1.0, 0.5, np.nan], [0.0, 2.0 / 3.0, np.nan]],
+                [[np.nan, 1.0, 0.25], [0.5, np.nan, 1.0]],
+            ],
+            dtype=float,
+        ),
+        "turnback_ratio_ctrl": np.asarray(
+            [
+                [[0.0, 0.25, np.nan], [0.5, np.nan, 1.0]],
+                [[np.nan, 0.0, 0.75], [1.0, 0.5, np.nan]],
+            ],
+            dtype=float,
+        ),
+        "turnback_total_exp": np.asarray(
+            [[[1, 2, 0], [1, 3, 0]], [[0, 1, 4], [2, 0, 1]]], dtype=int
+        ),
+        "turnback_total_ctrl": np.asarray(
+            [[[1, 4, 0], [2, 0, 1]], [[0, 1, 4], [1, 2, 0]]], dtype=int
+        ),
+        "turnback_inner_delta_mm": np.array(4.0, dtype=float),
+        "turnback_outer_delta_mm": np.array(8.0, dtype=float),
+        "turnback_inner_radius_offset_px": np.array(0.0, dtype=float),
+    }
+    bundle.update(overrides)
+    return bundle
+
+
+def test_validate_turnback_ratio_bundle_accepts_valid_shapes_and_metadata():
+    validate_turnback_ratio_bundle(_bundle())
+
+    normalized = normalize_sli_bundle(_bundle())
+    assert normalized["turnback_ratio_exp"].shape == (2, 2, 3)
+
+
+def test_validate_turnback_ratio_bundle_rejects_missing_metric_key():
+    bundle = _bundle()
+    del bundle["turnback_outer_delta_mm"]
+
+    with pytest.raises(ValueError, match="missing turnback ratio keys"):
+        validate_turnback_ratio_bundle(bundle)
+
+
+def test_validate_turnback_ratio_bundle_rejects_metric_shape_mismatch():
+    with pytest.raises(ValueError, match=r"turnback_ratio_exp\.shape=\(2, 2, 2\)"):
+        validate_turnback_ratio_bundle(
+            _bundle(turnback_ratio_exp=np.ones((2, 2, 2), dtype=float))
+        )
+
+
+def test_validate_turnback_ratio_bundle_rejects_bad_totals():
+    with pytest.raises(ValueError, match="negative values"):
+        validate_turnback_ratio_bundle(
+            _bundle(
+                turnback_total_exp=np.asarray(
+                    [[[1, -1, 0], [1, 3, 0]], [[0, 1, 4], [2, 0, 1]]]
+                )
+            )
+        )
+
+    with pytest.raises(ValueError, match="non-integer values"):
+        validate_turnback_ratio_bundle(
+            _bundle(
+                turnback_total_ctrl=np.asarray(
+                    [[[1, 4.5, 0], [2, 0, 1]], [[0, 1, 4], [1, 2, 0]]]
+                )
+            )
+        )
+
+
+def test_validate_turnback_ratio_bundle_rejects_bad_probabilities():
+    with pytest.raises(ValueError, match="out-of-range probabilities"):
+        validate_turnback_ratio_bundle(
+            _bundle(
+                turnback_ratio_exp=np.asarray(
+                    [
+                        [[1.2, 0.5, np.nan], [0.0, 2.0 / 3.0, np.nan]],
+                        [
+                            [np.nan, 1.0, 0.25],
+                            [0.5, np.nan, 1.0],
+                        ],
+                    ]
+                )
+            )
+        )
+
+    with pytest.raises(ValueError, match="finite turnback_ratio_exp where total == 0"):
+        validate_turnback_ratio_bundle(
+            _bundle(
+                turnback_ratio_exp=np.asarray(
+                    [
+                        [[1.0, 0.5, 0.0], [0.0, 2.0 / 3.0, np.nan]],
+                        [[np.nan, 1.0, 0.25], [0.5, np.nan, 1.0]],
+                    ]
+                )
+            )
+        )
+
+
+def test_validate_turnback_ratio_bundle_rejects_ratio_inconsistent_with_counts():
+    with pytest.raises(ValueError, match="inconsistent with integer counts"):
+        validate_turnback_ratio_bundle(
+            _bundle(
+                turnback_ratio_ctrl=np.asarray(
+                    [
+                        [[0.0, 0.3, np.nan], [0.5, np.nan, 1.0]],
+                        [[np.nan, 0.0, 0.75], [1.0, 0.5, np.nan]],
+                    ]
+                )
+            )
+        )
+
+
+def test_validate_turnback_ratio_bundle_rejects_bad_radius_metadata():
+    with pytest.raises(ValueError, match="turnback_outer_delta_mm=.*<="):
+        validate_turnback_ratio_bundle(_bundle(turnback_outer_delta_mm=np.array(4.0)))
+
+    with pytest.raises(ValueError, match="negative turnback_inner_delta_mm"):
+        validate_turnback_ratio_bundle(_bundle(turnback_inner_delta_mm=np.array(-1.0)))
+
+    with pytest.raises(ValueError, match="non-finite turnback_inner_radius_offset_px"):
+        validate_turnback_ratio_bundle(
+            _bundle(turnback_inner_radius_offset_px=np.array(np.nan))
+        )

--- a/test/paper_metrics/test_turnback_ratio_regression_manifest.py
+++ b/test/paper_metrics/test_turnback_ratio_regression_manifest.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.validation.bundle_digest import check_manifest, load_manifest
+
+
+MANIFEST = Path("test/reference/bundles/turnback_ratio_paper_manifest.json")
+
+
+def _missing_bundle_paths(manifest):
+    return [
+        bundle["path"]
+        for bundle in manifest["bundles"]
+        if not Path(bundle["path"]).exists()
+    ]
+
+
+def _bundles_missing_manifest_keys(manifest):
+    missing = []
+    for bundle in manifest["bundles"]:
+        path = Path(bundle["path"])
+        if not path.exists():
+            continue
+        with np.load(path, allow_pickle=True) as data:
+            missing_keys = [key for key in bundle["keys"] if key not in data.files]
+        if missing_keys:
+            missing.append((bundle["path"], missing_keys))
+    return missing
+
+
+def test_paper_turnback_ratio_bundle_manifest_matches_available_exports():
+    manifest = load_manifest(MANIFEST)
+    missing_paths = _missing_bundle_paths(manifest)
+    if missing_paths:
+        pytest.skip(
+            "Paper turnback-ratio export bundles are not available locally: "
+            + ", ".join(missing_paths)
+        )
+
+    missing_keys = _bundles_missing_manifest_keys(manifest)
+    if missing_keys:
+        detail = "; ".join(
+            f"{path}: {', '.join(keys)}" for path, keys in missing_keys
+        )
+        pytest.skip(
+            "Paper turnback-ratio export bundles predate required metadata: "
+            + detail
+        )
+
+    assert check_manifest(MANIFEST) == []

--- a/test/paper_metrics/test_turnback_ratio_truth.py
+++ b/test/paper_metrics/test_turnback_ratio_truth.py
@@ -187,7 +187,7 @@ def test_turnback_bundle_export_records_inner_and_outer_radius_metadata(
     )
     opts = SimpleNamespace(
         export_group_label="Intact Control>Kir",
-        best_worst_trn=2,
+        best_worst_trn=1,
         sli_use_training_mean=True,
         sli_select_skip_first_sync_buckets=1,
         sli_select_keep_first_sync_buckets=0,

--- a/test/paper_metrics/test_turnback_ratio_truth.py
+++ b/test/paper_metrics/test_turnback_ratio_truth.py
@@ -1,10 +1,14 @@
+import sys
 from types import SimpleNamespace
 
 import numpy as np
 
 from src.analysis.trajectory import Trajectory
 from src.analysis.video_analysis import VideoAnalysis
-from src.exporting.turnback_sli_bundle import _extract_turnback_arrays
+from src.exporting.turnback_sli_bundle import (
+    _extract_turnback_arrays,
+    export_turnback_sli_bundle,
+)
 
 
 class _CircleTraining:
@@ -159,3 +163,43 @@ def test_turnback_bundle_extraction_keeps_exp_ctrl_axes_and_pads_missing_buckets
     np.testing.assert_allclose(ratio_ctrl, [[[0.0, np.nan, np.nan]]])
     np.testing.assert_array_equal(total_exp, [[[3, 2, 0]]])
     np.testing.assert_array_equal(total_ctrl, [[[1, 0, 0]]])
+
+
+def test_turnback_bundle_export_records_inner_and_outer_radius_metadata(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setitem(
+        sys.modules,
+        "analyze",
+        SimpleNamespace(bucketLenForType=lambda _metric: (10.0, None)),
+    )
+    ratio = np.asarray([[[1.0, 0.5], [0.0, np.nan]]], dtype=float)
+    total = np.asarray([[[3, 2], [1, 0]]], dtype=int)
+    va = SimpleNamespace(
+        fn="fake-video",
+        f=7,
+        _skipped=False,
+        noyc=False,
+        trns=[_CircleTraining(start=0, stop=10)],
+        reward_turnback_dual_circle_counts={"ratio": ratio, "total": total},
+        _numRewardsMsg=lambda *_args, **_kwargs: 5,
+        _syncBucket=lambda _trn, _df: (0, 2, None),
+    )
+    opts = SimpleNamespace(
+        export_group_label="Intact Control>Kir",
+        best_worst_trn=2,
+        sli_use_training_mean=True,
+        sli_select_skip_first_sync_buckets=1,
+        sli_select_keep_first_sync_buckets=0,
+        turnback_inner_delta_mm=4.0,
+        turnback_outer_delta_mm=8.0,
+        turnback_inner_radius_offset_px=0.25,
+    )
+    out = tmp_path / "turnback_bundle.npz"
+
+    export_turnback_sli_bundle([va], opts, gls=None, out_fn=str(out))
+
+    with np.load(out, allow_pickle=True) as bundle:
+        assert float(bundle["turnback_inner_delta_mm"]) == 4.0
+        assert float(bundle["turnback_outer_delta_mm"]) == 8.0
+        assert float(bundle["turnback_inner_radius_offset_px"]) == 0.25

--- a/test/paper_metrics/test_turnback_ratio_truth.py
+++ b/test/paper_metrics/test_turnback_ratio_truth.py
@@ -1,0 +1,161 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+from src.analysis.trajectory import Trajectory
+from src.analysis.video_analysis import VideoAnalysis
+from src.exporting.turnback_sli_bundle import _extract_turnback_arrays
+
+
+class _CircleTraining:
+    def __init__(self, *, start=0, stop=10, circle=True, radius_px=10.0):
+        self.start = int(start)
+        self.stop = int(stop)
+        self._circle = bool(circle)
+        self._radius_px = float(radius_px)
+
+    def isCircle(self):
+        return self._circle
+
+    def circles(self, _fly_idx):
+        return [(0.0, 0.0, self._radius_px)]
+
+    def name(self):
+        return "T1"
+
+    def sname(self):
+        return self.name()
+
+
+class _TrajectoryEpisodes:
+    def __init__(self, episodes, *, bad=False):
+        self._episodes = list(episodes)
+        self._bad = bool(bad)
+        self.calls = []
+
+    def reward_turnback_dual_circle_episodes_for_training(self, **kwargs):
+        self.calls.append(kwargs)
+        return list(self._episodes)
+
+
+def _trajectory_at_distances(distances_px, *, training_stop=None):
+    trj = object.__new__(Trajectory)
+    trj.x = np.asarray(distances_px, dtype=float)
+    trj.y = np.zeros_like(trj.x)
+    trj.f = 0
+    trj.va = SimpleNamespace(
+        xf=SimpleNamespace(fctr=1.0), ct=SimpleNamespace(pxPerMmFloor=lambda: 1.0)
+    )
+    trn = _CircleTraining(
+        start=0,
+        stop=len(trj.x) if training_stop is None else training_stop,
+        radius_px=10.0,
+    )
+    return trj, trn
+
+
+def test_turnback_dual_circle_detects_success_failure_and_excludes_censored_episode():
+    trj, trn = _trajectory_at_distances(
+        [
+            13.0,  # inside inner
+            15.0,  # exit inner, still inside outer
+            16.0,
+            13.0,  # re-enter inner: success
+            13.0,
+            15.0,  # exit inner
+            19.0,  # exit outer before re-entry: failure
+            13.0,
+            13.0,
+            15.0,  # exit inner
+            16.0,  # training end before outcome: censored and excluded
+        ]
+    )
+
+    episodes = trj.reward_turnback_dual_circle_episodes_for_training(
+        trn=trn, inner_delta_mm=4.0, outer_delta_mm=8.0, border_width_mm=0.0
+    )
+
+    assert episodes == [
+        {"start": 1, "stop": 3, "turns_back": True, "end_reason": "reenter_inner"},
+        {
+            "start": 5,
+            "stop": 7,
+            "turns_back": False,
+            "end_reason": "exit_outer",
+        },
+    ]
+
+
+def test_turnback_dual_circle_rejects_invalid_geometry_and_non_circle_training():
+    trj, trn = _trajectory_at_distances([13.0, 15.0, 13.0])
+
+    assert (
+        trj.reward_turnback_dual_circle_episodes_for_training(
+            trn=trn, inner_delta_mm=8.0, outer_delta_mm=4.0, border_width_mm=0.0
+        )
+        == []
+    )
+    assert (
+        trj.reward_turnback_dual_circle_episodes_for_training(
+            trn=_CircleTraining(circle=False),
+            inner_delta_mm=4.0,
+            outer_delta_mm=8.0,
+            border_width_mm=0.0,
+        )
+        == []
+    )
+
+
+def test_turnback_ratio_bins_by_outcome_frame_and_leaves_empty_buckets_nan():
+    exp = _TrajectoryEpisodes(
+        [
+            {"start": 1, "stop": 4, "turns_back": True},
+            {"start": 1, "stop": 6, "turns_back": False},
+            {"start": 8, "stop": 10, "turns_back": True},
+        ]
+    )
+    ctrl = _TrajectoryEpisodes([])
+    va = SimpleNamespace(
+        circle=True,
+        opts=SimpleNamespace(
+            turnback_inner_delta_mm=4.0,
+            turnback_outer_delta_mm=8.0,
+            turnback_border_width_mm=0.0,
+            turnback_inner_radius_offset_px=0.0,
+            turnback_dual_circle_debug=False,
+        ),
+        sync_bucket_ranges=[[(0, 5), (5, 10), (10, 15)]],
+        trns=[_CircleTraining(start=0, stop=15)],
+        trx=[exp, ctrl],
+    )
+
+    VideoAnalysis.analyzeRewardTurnbackDualCircle(va)
+
+    counts = va.reward_turnback_dual_circle_counts
+    np.testing.assert_array_equal(counts["turnback"], [[[1, 1, 0], [0, 0, 0]]])
+    np.testing.assert_array_equal(counts["total"], [[[1, 2, 0], [0, 0, 0]]])
+    np.testing.assert_allclose(
+        counts["ratio"], [[[1.0, 0.5, np.nan], [np.nan, np.nan, np.nan]]]
+    )
+
+    assert exp.calls[0]["inner_delta_mm"] == 4.0
+    assert exp.calls[0]["outer_delta_mm"] == 8.0
+
+
+def test_turnback_bundle_extraction_keeps_exp_ctrl_axes_and_pads_missing_buckets():
+    ratio = np.asarray([[[1.0, 0.5], [0.0, np.nan]]], dtype=float)
+    total = np.asarray([[[3, 2], [1, 0]]], dtype=int)
+    va = SimpleNamespace(
+        fn="fake-video",
+        trns=[_CircleTraining(start=0, stop=15)],
+        reward_turnback_dual_circle_counts={"ratio": ratio, "total": total},
+        _numRewardsMsg=lambda *args, **_kwargs: 5,
+        _syncBucket=lambda _trn, _df: (0, 3, None),
+    )
+
+    ratio_exp, ratio_ctrl, total_exp, total_ctrl = _extract_turnback_arrays([va])
+
+    np.testing.assert_allclose(ratio_exp, [[[1.0, 0.5, np.nan]]])
+    np.testing.assert_allclose(ratio_ctrl, [[[0.0, np.nan, np.nan]]])
+    np.testing.assert_array_equal(total_exp, [[[3, 2, 0]]])
+    np.testing.assert_array_equal(total_ctrl, [[[1, 0, 0]]])

--- a/test/reference/bundles/turnback_ratio_paper_manifest.json
+++ b/test/reference/bundles/turnback_ratio_paper_manifest.json
@@ -1,0 +1,193 @@
+{
+  "bundles": [
+    {
+      "arrays": {
+        "bucket_len_min": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "24b1f4ef66b650ff816e519b01742ff1753733d36e1b4c3e3b52743168915b1f",
+          "shape": []
+        },
+        "group_label": {
+          "dtype": "object",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "3d08ba1cb0dff4442a18ba6258e18780ad45f5802d65ad029a519bc4817d171c",
+          "shape": []
+        },
+        "sli": {
+          "dtype": "float64",
+          "finite_count": 62,
+          "kind": "numeric",
+          "nan_count": 7,
+          "sha256": "31fdbb97d3b48656fd3f11913c909063984a407f43dcd919cd7d010b31caef37",
+          "shape": [
+            69
+          ]
+        },
+        "sli_select_keep_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "sli_select_skip_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "sli_training_idx": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "sli_ts": {
+          "dtype": "float64",
+          "finite_count": 847,
+          "kind": "numeric",
+          "nan_count": 395,
+          "sha256": "d0c722c678aba09e7409135f820bc1b95b4938c0ccb9b87cd7658ba6d3230cec",
+          "shape": [
+            69,
+            3,
+            6
+          ]
+        },
+        "sli_use_training_mean": {
+          "dtype": "bool",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "a2709fcbfdeb023a70c53c31628d48d9306c5f4772ab12de7b67b66f3bf34fa7",
+          "shape": []
+        },
+        "training_names": {
+          "dtype": "object",
+          "finite_count": 3,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "4860b8926b4845ace4d18e00fcbf676c260d49d4d5ebe5df07e1aee6693e70f2",
+          "shape": [
+            3
+          ]
+        },
+        "turnback_inner_delta_mm": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "400c52dd5bd0047d64c0582af027b387a7938a64283d0d4f727331140cb6462c",
+          "shape": []
+        },
+        "turnback_inner_radius_offset_px": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "turnback_outer_delta_mm": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "2d311251337c35e4d3628720f349d4133233ed476372432e57314e0ab316bc35",
+          "shape": []
+        },
+        "turnback_ratio_ctrl": {
+          "dtype": "float64",
+          "finite_count": 863,
+          "kind": "numeric",
+          "nan_count": 379,
+          "sha256": "66013fb4e5f5f07d22142e9f5e674999e196244f4c96be73db2222ba48842f8a",
+          "shape": [
+            69,
+            3,
+            6
+          ]
+        },
+        "turnback_ratio_exp": {
+          "dtype": "float64",
+          "finite_count": 960,
+          "kind": "numeric",
+          "nan_count": 282,
+          "sha256": "bcfa2dd512f70e54def0624bc50079f6d7cf82a30579526050e12bb94c7430cf",
+          "shape": [
+            69,
+            3,
+            6
+          ]
+        },
+        "turnback_total_ctrl": {
+          "dtype": "int64",
+          "finite_count": 1242,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "90dee950a4282c23654be7b81da8dfc1e85060b93d90bc24941ef3cc91ffd3f1",
+          "shape": [
+            69,
+            3,
+            6
+          ]
+        },
+        "turnback_total_exp": {
+          "dtype": "int64",
+          "finite_count": 1242,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "b9db713f1d37eb09acf32dba993d964cc118a88b2c3873b3c288f63ac9b273c7",
+          "shape": [
+            69,
+            3,
+            6
+          ]
+        },
+        "video_ids": {
+          "dtype": "object",
+          "finite_count": 69,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "67ae8ffff576c7d4b16b7117ddcc25acdb9af9f36266ad2e06c498d1b843c9b0",
+          "shape": [
+            69
+          ]
+        }
+      },
+      "keys": [
+        "bucket_len_min",
+        "group_label",
+        "sli",
+        "sli_select_keep_first_sync_buckets",
+        "sli_select_skip_first_sync_buckets",
+        "sli_training_idx",
+        "sli_ts",
+        "sli_use_training_mean",
+        "training_names",
+        "turnback_inner_delta_mm",
+        "turnback_inner_radius_offset_px",
+        "turnback_outer_delta_mm",
+        "turnback_ratio_ctrl",
+        "turnback_ratio_exp",
+        "turnback_total_ctrl",
+        "turnback_total_exp",
+        "video_ids"
+      ],
+      "name": "turnback_4mm_8mm_intact_ctrlKir_flatLgc_2026-02-09",
+      "path": "exports/turnback_4mm_8mm_intact_ctrlKir_flatLgc_2026-02-09.npz",
+      "sha256": "d3494c29963dd15e4790300a0652c8ba57af32a5953efa75809998c9cdf1b34d"
+    }
+  ],
+  "schema_version": 1
+}


### PR DESCRIPTION
## Summary

Adds the three-layer correctness-check rollout for the dual-circle turnback ratio metric used in panel 8.

## Changes

- Add spec-level truth tests for turnback episode parsing, sync-bucket aggregation, bundle extraction, and radius metadata export.
- Add turnback ratio bundle digest keys, manifest coverage, and regression test wiring for the panel 8 export bundle.
- Add runtime validation for turnback ratio bundles, including shape checks, probability bounds, denominator/NaN consistency, ratio/count compatibility, and radius metadata validation.
- Validate turnback bundles before export and during normalized bundle loading.

## Validation

- `pytest test/paper_metrics`