### PR TITLE
Add correctness checks for turnback excursion-bin bundles

### DIFF
--- a/src/analysis/sli_bundle_utils.py
+++ b/src/analysis/sli_bundle_utils.py
@@ -38,6 +38,16 @@ RETURN_PROB_EXCURSION_BIN_KEYS = (
     "return_prob_excursion_bin_edges_mm",
 )
 
+TURNBACK_EXCURSION_BIN_KEYS = (
+    "turnback_excursion_bin_ratio_exp",
+    "turnback_excursion_bin_ratio_ctrl",
+    "turnback_excursion_bin_turn_exp",
+    "turnback_excursion_bin_turn_ctrl",
+    "turnback_excursion_bin_total_exp",
+    "turnback_excursion_bin_total_ctrl",
+    "turnback_excursion_bin_edges_mm",
+)
+
 BETWEEN_REWARD_MAXDIST_KEYS = (
     "between_reward_maxdist_exp",
     "between_reward_maxdist_ctrl",
@@ -566,6 +576,195 @@ def validate_return_prob_excursion_bin_bundle(
             raise ValueError(f"Bundle {where} has inconsistent {key} values")
 
 
+def validate_turnback_excursion_bin_bundle(
+    bundle: dict, *, path: str | None = None
+) -> None:
+    where = _bundle_label(bundle, path)
+    missing = [k for k in TURNBACK_EXCURSION_BIN_KEYS if k not in bundle]
+    if missing:
+        raise ValueError(
+            f"Bundle {where} is missing turnback excursion-bin keys: {missing}"
+        )
+
+    sli = np.asarray(bundle["sli"], dtype=float)
+    if sli.ndim != 1:
+        raise ValueError(f"Bundle {where} has non-1D sli shape {sli.shape}")
+    n_videos = int(sli.shape[0])
+
+    edges = np.asarray(bundle["turnback_excursion_bin_edges_mm"], dtype=float)
+    if edges.ndim != 1:
+        raise ValueError(
+            f"Bundle {where} has non-1D turnback_excursion_bin_edges_mm "
+            f"shape {edges.shape}"
+        )
+    if edges.size < 2:
+        raise ValueError(f"Bundle {where} has fewer than two turnback bin edges")
+    if not np.all(np.isfinite(edges)):
+        raise ValueError(f"Bundle {where} has non-finite resolved turnback bin edges")
+    if np.any(np.diff(edges) <= 0):
+        raise ValueError(f"Bundle {where} has non-increasing turnback bin edges")
+    n_bins = int(edges.size - 1)
+
+    if "turnback_excursion_bin_requested_edges_mm" in bundle:
+        requested = np.asarray(
+            bundle["turnback_excursion_bin_requested_edges_mm"], dtype=float
+        )
+        if requested.ndim != 1 or requested.size != edges.size:
+            raise ValueError(
+                f"Bundle {where} has turnback_excursion_bin_requested_edges_mm "
+                f"shape {requested.shape} but expected {(edges.size,)}"
+            )
+        if not np.all(np.isfinite(requested[:-1])):
+            raise ValueError(
+                f"Bundle {where} has non-finite interior requested turnback bin edges"
+            )
+        if np.any(np.diff(requested) <= 0):
+            raise ValueError(
+                f"Bundle {where} has non-increasing requested turnback bin edges"
+            )
+
+    if "turnback_excursion_bin_open_ended_upper_bin" in bundle:
+        open_ended = bool(
+            as_scalar(bundle["turnback_excursion_bin_open_ended_upper_bin"])
+        )
+        if open_ended and "turnback_excursion_bin_requested_edges_mm" in bundle:
+            requested = np.asarray(
+                bundle["turnback_excursion_bin_requested_edges_mm"], dtype=float
+            )
+            if not np.isposinf(float(requested[-1])):
+                raise ValueError(
+                    f"Bundle {where} marks an open-ended turnback bin but the "
+                    "requested last edge is not inf"
+                )
+
+    if "turnback_excursion_bin_trainings" in bundle:
+        trainings = np.asarray(bundle["turnback_excursion_bin_trainings"], dtype=int)
+        if trainings.ndim != 1:
+            raise ValueError(
+                f"Bundle {where} has non-1D turnback_excursion_bin_trainings "
+                f"shape {trainings.shape}"
+            )
+        if np.any(trainings < 0):
+            raise ValueError(
+                f"Bundle {where} has negative turnback_excursion_bin_trainings"
+            )
+
+    if "turnback_excursion_bin_window_summary" in bundle:
+        window_summary = as_str_array(bundle["turnback_excursion_bin_window_summary"])
+        if window_summary.shape[0] != n_videos:
+            raise ValueError(
+                f"Bundle {where} has len(turnback_excursion_bin_window_summary)="
+                f"{window_summary.shape[0]} but len(sli)={n_videos}"
+            )
+
+    for key in (
+        "turnback_excursion_bin_skip_first_sync_buckets",
+        "turnback_excursion_bin_keep_first_sync_buckets",
+        "turnback_excursion_bin_last_sync_buckets",
+    ):
+        if key in bundle and int(as_scalar(bundle[key])) < 0:
+            raise ValueError(f"Bundle {where} has negative {key}")
+
+    for key in (
+        "turnback_excursion_bin_inner_delta_mm",
+        "turnback_excursion_bin_border_width_mm",
+        "turnback_excursion_bin_inner_radius_offset_px",
+    ):
+        if key in bundle and not np.isfinite(float(as_scalar(bundle[key]))):
+            raise ValueError(f"Bundle {where} has non-finite {key}")
+    if (
+        "turnback_excursion_bin_inner_delta_mm" in bundle
+        and float(as_scalar(bundle["turnback_excursion_bin_inner_delta_mm"])) < 0.0
+    ):
+        raise ValueError(
+            f"Bundle {where} has negative turnback_excursion_bin_inner_delta_mm"
+        )
+    if (
+        "turnback_excursion_bin_border_width_mm" in bundle
+        and float(as_scalar(bundle["turnback_excursion_bin_border_width_mm"])) < 0.0
+    ):
+        raise ValueError(
+            f"Bundle {where} has negative turnback_excursion_bin_border_width_mm"
+        )
+
+    ratio_exp = _validate_return_prob_metric_array(
+        bundle,
+        "turnback_excursion_bin_ratio_exp",
+        where=where,
+        n_videos=n_videos,
+        n_bins=n_bins,
+    )
+    ratio_ctrl = _validate_return_prob_metric_array(
+        bundle,
+        "turnback_excursion_bin_ratio_ctrl",
+        where=where,
+        n_videos=n_videos,
+        n_bins=n_bins,
+    )
+    turn_exp = _validate_return_prob_metric_array(
+        bundle,
+        "turnback_excursion_bin_turn_exp",
+        where=where,
+        n_videos=n_videos,
+        n_bins=n_bins,
+    )
+    turn_ctrl = _validate_return_prob_metric_array(
+        bundle,
+        "turnback_excursion_bin_turn_ctrl",
+        where=where,
+        n_videos=n_videos,
+        n_bins=n_bins,
+    )
+    total_exp = _validate_return_prob_count_array(
+        bundle,
+        "turnback_excursion_bin_total_exp",
+        where=where,
+        n_videos=n_videos,
+        n_bins=n_bins,
+    )
+    total_ctrl = _validate_return_prob_count_array(
+        bundle,
+        "turnback_excursion_bin_total_ctrl",
+        where=where,
+        n_videos=n_videos,
+        n_bins=n_bins,
+    )
+
+    for key, ratio in (
+        ("turnback_excursion_bin_ratio_exp", ratio_exp),
+        ("turnback_excursion_bin_ratio_ctrl", ratio_ctrl),
+    ):
+        finite = np.isfinite(ratio)
+        if np.any((ratio[finite] < 0.0) | (ratio[finite] > 1.0)):
+            raise ValueError(f"Bundle {where} has out-of-range probabilities in {key}")
+
+    for key, values, total in (
+        ("turnback_excursion_bin_turn_exp", turn_exp, total_exp),
+        ("turnback_excursion_bin_turn_ctrl", turn_ctrl, total_ctrl),
+    ):
+        finite = np.isfinite(values)
+        if np.any(~finite):
+            raise ValueError(f"Bundle {where} has non-finite values in {key}")
+        if np.any(values[finite] < 0.0):
+            raise ValueError(f"Bundle {where} has negative values in {key}")
+        if np.any(values[finite] > total[finite] + 1e-12):
+            raise ValueError(f"Bundle {where} has {key} values greater than totals")
+
+    for key, ratio, values, total in (
+        ("turnback_excursion_bin_ratio_exp", ratio_exp, turn_exp, total_exp),
+        ("turnback_excursion_bin_ratio_ctrl", ratio_ctrl, turn_ctrl, total_ctrl),
+    ):
+        expected = np.full_like(values, np.nan, dtype=float)
+        np.divide(values, total, out=expected, where=(total > 0))
+        both_finite = np.isfinite(ratio) & np.isfinite(expected)
+        if np.any(~np.isfinite(ratio[total > 0])):
+            raise ValueError(f"Bundle {where} has non-finite {key} where total > 0")
+        if np.any(np.isfinite(ratio[total == 0])):
+            raise ValueError(f"Bundle {where} has finite {key} where total == 0")
+        if np.any(np.abs(ratio[both_finite] - expected[both_finite]) > 1e-10):
+            raise ValueError(f"Bundle {where} has inconsistent {key} values")
+
+
 def normalize_sli_bundle(bundle: dict, *, path: str | None = None) -> dict:
     missing = [k for k in REQ_BUNDLE_KEYS if k not in bundle]
     if missing:
@@ -601,6 +800,8 @@ def normalize_sli_bundle(bundle: dict, *, path: str | None = None) -> dict:
         validate_between_reward_return_leg_dist_bundle(out, path=path)
     if any(k in out for k in TURNBACK_RATIO_PRIMARY_KEYS):
         validate_turnback_ratio_bundle(out, path=path)
+    if any(k in out for k in TURNBACK_EXCURSION_BIN_KEYS):
+        validate_turnback_excursion_bin_bundle(out, path=path)
     return out
 
 

--- a/src/exporting/turnback_excursion_bin_sli_bundle.py
+++ b/src/exporting/turnback_excursion_bin_sli_bundle.py
@@ -4,6 +4,10 @@ import os
 
 import numpy as np
 
+from src.analysis.sli_bundle_utils import (
+    validate_sli_bundle,
+    validate_turnback_excursion_bin_bundle,
+)
 from src.exporting.com_sli_bundle import (
     _compute_sli_scalar_and_timeseries_from_rpid,
     _safe_group_label,
@@ -487,8 +491,7 @@ def export_turnback_excursion_bin_sli_bundle(vas, opts, gls, out_fn):
     )
 
     os.makedirs(os.path.dirname(out_fn) or ".", exist_ok=True)
-    np.savez_compressed(
-        out_fn,
+    payload = dict(
         sli=np.asarray(sli, dtype=float),
         sli_ts=np.asarray(sli_ts, dtype=float),
         group_label=np.asarray(group_label),
@@ -548,6 +551,9 @@ def export_turnback_excursion_bin_sli_bundle(vas, opts, gls, out_fn):
         ),
         bucket_len_min=np.array(np.nan, dtype=float),
     )
+    validate_sli_bundle(payload, path=out_fn)
+    validate_turnback_excursion_bin_bundle(payload, path=out_fn)
+    np.savez_compressed(out_fn, **payload)
     print(
         f"[export] Wrote turnback-excursion-bin+SLI bundle: {out_fn} "
         f"(n={n_videos}, bins={n_bins})"

--- a/src/plotting/turnback_excursion_bin_sli_bundle_plotter.py
+++ b/src/plotting/turnback_excursion_bin_sli_bundle_plotter.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import numpy as np
 
+from src.analysis.sli_bundle_utils import load_sli_bundle
 from src.plotting.return_prob_outer_radius_sli_bundle_plotter import (
     _ci_triplet,
     _selected_groups,
@@ -202,7 +203,7 @@ def plot_turnback_excursion_bin_sli_bundles(
     if opts is None:
         opts = SimpleNamespace(imageFormat="png", fontSize=None, fontFamily=None)
 
-    loaded = [np.load(path, allow_pickle=True) for path in bundles]
+    loaded = [load_sli_bundle(path) for path in bundles]
 
     if sli_top_fraction is None:
         sli_top_fraction = sli_fraction

--- a/src/validation/bundle_digest.py
+++ b/src/validation/bundle_digest.py
@@ -49,6 +49,35 @@ RETURN_PROB_EXCURSION_BIN_REGRESSION_KEYS = (
     "video_ids",
 )
 
+TURNBACK_EXCURSION_BIN_REGRESSION_KEYS = (
+    "group_label",
+    "sli",
+    "sli_select_keep_first_sync_buckets",
+    "sli_select_skip_first_sync_buckets",
+    "sli_training_idx",
+    "sli_ts",
+    "sli_use_training_mean",
+    "training_names",
+    "turnback_excursion_bin_border_width_mm",
+    "turnback_excursion_bin_edges_mm",
+    "turnback_excursion_bin_inner_delta_mm",
+    "turnback_excursion_bin_inner_radius_offset_px",
+    "turnback_excursion_bin_keep_first_sync_buckets",
+    "turnback_excursion_bin_last_sync_buckets",
+    "turnback_excursion_bin_open_ended_upper_bin",
+    "turnback_excursion_bin_ratio_ctrl",
+    "turnback_excursion_bin_ratio_exp",
+    "turnback_excursion_bin_requested_edges_mm",
+    "turnback_excursion_bin_skip_first_sync_buckets",
+    "turnback_excursion_bin_total_ctrl",
+    "turnback_excursion_bin_total_exp",
+    "turnback_excursion_bin_trainings",
+    "turnback_excursion_bin_turn_ctrl",
+    "turnback_excursion_bin_turn_exp",
+    "turnback_excursion_bin_window_summary",
+    "video_ids",
+)
+
 BETWEEN_REWARD_DISTANCE_HIST_REGRESSION_KEYS = (
     "bin_edges",
     "ci_hi",

--- a/test/paper_metrics/test_turnback_excursion_bin_bundle_invariants.py
+++ b/test/paper_metrics/test_turnback_excursion_bin_bundle_invariants.py
@@ -1,0 +1,170 @@
+import numpy as np
+import pytest
+
+from src.analysis.sli_bundle_utils import (
+    normalize_sli_bundle,
+    validate_turnback_excursion_bin_bundle,
+)
+
+
+def _bundle(**overrides):
+    bundle = {
+        "sli": np.asarray([0.1], dtype=float),
+        "sli_ts": np.asarray([[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]], dtype=float),
+        "group_label": np.asarray("Control", dtype=object),
+        "bucket_len_min": np.array(np.nan, dtype=float),
+        "training_names": np.asarray(["T1", "T2"], dtype=object),
+        "video_ids": np.asarray(["video_a"], dtype=object),
+        "sli_training_idx": np.array(1, dtype=int),
+        "sli_use_training_mean": np.array(True),
+        "sli_select_skip_first_sync_buckets": np.array(1, dtype=int),
+        "sli_select_keep_first_sync_buckets": np.array(0, dtype=int),
+        "turnback_excursion_bin_ratio_exp": np.asarray([[0.5, np.nan]]),
+        "turnback_excursion_bin_ratio_ctrl": np.asarray([[0.2, 0.6]]),
+        "turnback_excursion_bin_turn_exp": np.asarray([[2.0, 0.0]]),
+        "turnback_excursion_bin_turn_ctrl": np.asarray([[1.0, 3.0]]),
+        "turnback_excursion_bin_total_exp": np.asarray([[4, 0]], dtype=int),
+        "turnback_excursion_bin_total_ctrl": np.asarray([[5, 5]], dtype=int),
+        "turnback_excursion_bin_edges_mm": np.asarray([2.0, 8.0, 16.0]),
+        "turnback_excursion_bin_requested_edges_mm": np.asarray([2.0, 8.0, 16.0]),
+        "turnback_excursion_bin_open_ended_upper_bin": np.asarray(False),
+        "turnback_excursion_bin_trainings": np.asarray([1], dtype=int),
+        "turnback_excursion_bin_skip_first_sync_buckets": np.array(0, dtype=int),
+        "turnback_excursion_bin_keep_first_sync_buckets": np.array(0, dtype=int),
+        "turnback_excursion_bin_last_sync_buckets": np.array(0, dtype=int),
+        "turnback_excursion_bin_inner_delta_mm": np.array(2.0, dtype=float),
+        "turnback_excursion_bin_inner_radius_offset_px": np.array(0.0, dtype=float),
+        "turnback_excursion_bin_border_width_mm": np.array(0.1, dtype=float),
+        "turnback_excursion_bin_window_summary": np.asarray(
+            ["T2 training 2[0,10)"], dtype=object
+        ),
+    }
+    bundle.update(overrides)
+    return bundle
+
+
+def test_validate_turnback_excursion_bin_bundle_accepts_valid_shapes_and_metadata():
+    validate_turnback_excursion_bin_bundle(_bundle())
+
+    normalized = normalize_sli_bundle(_bundle())
+    assert normalized["turnback_excursion_bin_ratio_exp"].shape == (1, 2)
+
+
+def test_validate_turnback_excursion_bin_bundle_rejects_missing_metric_key():
+    bundle = _bundle()
+    del bundle["turnback_excursion_bin_ratio_exp"]
+
+    with pytest.raises(ValueError, match="missing turnback excursion-bin"):
+        validate_turnback_excursion_bin_bundle(bundle)
+
+
+def test_validate_turnback_excursion_bin_bundle_rejects_metric_shape_mismatch():
+    with pytest.raises(
+        ValueError, match=r"turnback_excursion_bin_ratio_exp\.shape=\(1, 1\)"
+    ):
+        validate_turnback_excursion_bin_bundle(
+            _bundle(turnback_excursion_bin_ratio_exp=np.asarray([[0.5]]))
+        )
+
+
+def test_validate_turnback_excursion_bin_bundle_rejects_bad_edges():
+    with pytest.raises(ValueError, match="fewer than two"):
+        validate_turnback_excursion_bin_bundle(
+            _bundle(turnback_excursion_bin_edges_mm=np.asarray([2.0]))
+        )
+
+    with pytest.raises(ValueError, match="non-increasing"):
+        validate_turnback_excursion_bin_bundle(
+            _bundle(turnback_excursion_bin_edges_mm=np.asarray([2.0, 8.0, 8.0]))
+        )
+
+    with pytest.raises(ValueError, match="non-finite resolved"):
+        validate_turnback_excursion_bin_bundle(
+            _bundle(turnback_excursion_bin_edges_mm=np.asarray([2.0, 8.0, np.inf]))
+        )
+
+
+def test_validate_turnback_excursion_bin_bundle_allows_requested_inf_last_edge():
+    validate_turnback_excursion_bin_bundle(
+        _bundle(
+            turnback_excursion_bin_edges_mm=np.asarray([2.0, 8.0, 20.0]),
+            turnback_excursion_bin_requested_edges_mm=np.asarray([2.0, 8.0, np.inf]),
+            turnback_excursion_bin_open_ended_upper_bin=np.asarray(True),
+        )
+    )
+
+
+def test_validate_turnback_excursion_bin_bundle_rejects_bad_totals():
+    with pytest.raises(ValueError, match="negative values"):
+        validate_turnback_excursion_bin_bundle(
+            _bundle(turnback_excursion_bin_total_exp=np.asarray([[4, -1]]))
+        )
+
+    with pytest.raises(ValueError, match="non-integer values"):
+        validate_turnback_excursion_bin_bundle(
+            _bundle(turnback_excursion_bin_total_exp=np.asarray([[4.5, 0.0]]))
+        )
+
+
+def test_validate_turnback_excursion_bin_bundle_rejects_bad_probabilities():
+    with pytest.raises(ValueError, match="out-of-range probabilities"):
+        validate_turnback_excursion_bin_bundle(
+            _bundle(turnback_excursion_bin_ratio_exp=np.asarray([[1.2, np.nan]]))
+        )
+
+    with pytest.raises(ValueError, match="finite .* where total == 0"):
+        validate_turnback_excursion_bin_bundle(
+            _bundle(turnback_excursion_bin_ratio_exp=np.asarray([[0.5, 0.0]]))
+        )
+
+
+def test_validate_turnback_excursion_bin_bundle_rejects_inconsistent_ratio():
+    with pytest.raises(ValueError, match="inconsistent"):
+        validate_turnback_excursion_bin_bundle(
+            _bundle(turnback_excursion_bin_ratio_exp=np.asarray([[0.25, np.nan]]))
+        )
+
+
+def test_validate_turnback_excursion_bin_bundle_rejects_turn_mass_above_total():
+    with pytest.raises(ValueError, match="non-finite values"):
+        validate_turnback_excursion_bin_bundle(
+            _bundle(turnback_excursion_bin_turn_exp=np.asarray([[2.0, np.nan]]))
+        )
+
+    with pytest.raises(ValueError, match="greater than totals"):
+        validate_turnback_excursion_bin_bundle(
+            _bundle(turnback_excursion_bin_turn_exp=np.asarray([[5.0, 0.0]]))
+        )
+
+
+def test_validate_turnback_excursion_bin_bundle_rejects_bad_metadata():
+    with pytest.raises(
+        ValueError, match="len\\(turnback_excursion_bin_window_summary\\)=2"
+    ):
+        validate_turnback_excursion_bin_bundle(
+            _bundle(turnback_excursion_bin_window_summary=np.asarray(["a", "b"]))
+        )
+
+    with pytest.raises(
+        ValueError, match="negative turnback_excursion_bin_inner_delta_mm"
+    ):
+        validate_turnback_excursion_bin_bundle(
+            _bundle(turnback_excursion_bin_inner_delta_mm=np.asarray(-1.0))
+        )
+
+    with pytest.raises(
+        ValueError, match="non-finite turnback_excursion_bin_inner_radius_offset_px"
+    ):
+        validate_turnback_excursion_bin_bundle(
+            _bundle(turnback_excursion_bin_inner_radius_offset_px=np.asarray(np.nan))
+        )
+
+    with pytest.raises(ValueError, match="negative turnback_excursion_bin_trainings"):
+        validate_turnback_excursion_bin_bundle(
+            _bundle(turnback_excursion_bin_trainings=np.asarray([-1]))
+        )
+
+    with pytest.raises(ValueError, match="requested last edge is not inf"):
+        validate_turnback_excursion_bin_bundle(
+            _bundle(turnback_excursion_bin_open_ended_upper_bin=np.asarray(True))
+        )

--- a/test/paper_metrics/test_turnback_excursion_bin_regression_manifest.py
+++ b/test/paper_metrics/test_turnback_excursion_bin_regression_manifest.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.validation.bundle_digest import check_manifest, load_manifest
+
+
+MANIFEST = Path("test/reference/bundles/turnback_excursion_bin_paper_manifest.json")
+
+
+def _missing_bundle_paths(manifest):
+    return [
+        bundle["path"]
+        for bundle in manifest["bundles"]
+        if not Path(bundle["path"]).exists()
+    ]
+
+
+def _bundles_missing_manifest_keys(manifest):
+    missing = []
+    for bundle in manifest["bundles"]:
+        path = Path(bundle["path"])
+        if not path.exists():
+            continue
+        with np.load(path, allow_pickle=True) as data:
+            missing_keys = [key for key in bundle["keys"] if key not in data.files]
+        if missing_keys:
+            missing.append((bundle["path"], missing_keys))
+    return missing
+
+
+def test_paper_turnback_excursion_bin_bundle_manifest_matches_available_exports():
+    manifest = load_manifest(MANIFEST)
+    missing_paths = _missing_bundle_paths(manifest)
+    if missing_paths:
+        pytest.skip(
+            "Paper turnback excursion-bin export bundles are not available locally: "
+            + ", ".join(missing_paths)
+        )
+
+    missing_keys = _bundles_missing_manifest_keys(manifest)
+    if missing_keys:
+        detail = "; ".join(
+            f"{path}: {', '.join(keys)}" for path, keys in missing_keys
+        )
+        pytest.skip(
+            "Paper turnback excursion-bin export bundles predate required metadata: "
+            + detail
+        )
+
+    assert check_manifest(MANIFEST) == []

--- a/test/paper_metrics/test_turnback_excursion_bin_truth.py
+++ b/test/paper_metrics/test_turnback_excursion_bin_truth.py
@@ -1,0 +1,227 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from src.exporting.turnback_excursion_bin_sli_bundle import (
+    _bin_edges_mm,
+    _compute_turnback_curves,
+    _effective_windowing,
+    _integrated_bin_contribution,
+    _selected_training_indices,
+    _selected_windows_for_va,
+)
+
+
+class _Training:
+    def __init__(self, start=0, stop=100, *, circle=True, name="training"):
+        self.start = start
+        self.stop = stop
+        self._circle = circle
+        self._name = name
+
+    def isCircle(self):
+        return self._circle
+
+    def name(self):
+        return self._name
+
+
+class _Trajectory:
+    def __init__(self, episodes, *, bad=False):
+        self._episodes = list(episodes)
+        self._bad = bad
+        self.calls = []
+
+    def reward_turnback_excursion_episodes_for_training(self, **kwargs):
+        self.calls.append(kwargs)
+        return list(self._episodes)
+
+
+def _episode(stop, max_outer_delta_mm, turns_back, *, inner=2.0):
+    return {
+        "stop": stop,
+        "max_outer_delta_mm": max_outer_delta_mm,
+        "effective_inner_delta_mm": inner,
+        "turns_back": turns_back,
+    }
+
+
+def _va(
+    *,
+    trns=None,
+    trx=None,
+    sync_bucket_ranges=None,
+    noyc=False,
+    skipped=False,
+    fn="fake-video"
+):
+    return SimpleNamespace(
+        fn=fn,
+        trns=list(trns if trns is not None else [_Training()]),
+        trx=list(trx if trx is not None else []),
+        sync_bucket_ranges=sync_bucket_ranges,
+        noyc=noyc,
+        _skipped=skipped,
+    )
+
+
+def _curves(vas, edges=(2.0, 8.0, 16.0), **overrides):
+    params = {
+        "bin_edges_mm": np.asarray(edges, dtype=float),
+        "inner_delta_mm": 2.0,
+        "border_width_mm": 0.1,
+        "radius_offset_px": 0.0,
+        "selected_trainings": [0],
+        "skip_first": 0,
+        "keep_first": 0,
+        "last_sync_buckets": 0,
+        "debug": False,
+    }
+    params.update(overrides)
+    return _compute_turnback_curves(vas, **params)
+
+
+def test_integrated_bin_contribution_is_exact_threshold_average_above_inner_radius():
+    assert (
+        _integrated_bin_contribution(1.0, 2.0, 8.0, min_valid_outer_delta_mm=2.0) == 1.0
+    )
+    assert _integrated_bin_contribution(
+        5.0, 2.0, 8.0, min_valid_outer_delta_mm=2.0
+    ) == pytest.approx(0.5)
+    assert (
+        _integrated_bin_contribution(8.0, 2.0, 8.0, min_valid_outer_delta_mm=2.0) == 0.0
+    )
+    assert np.isnan(
+        _integrated_bin_contribution(5.0, 2.0, 8.0, min_valid_outer_delta_mm=8.0)
+    )
+
+
+def test_bin_edges_accept_panel_edges_and_reject_bad_inputs():
+    opts = SimpleNamespace(turnback_excursion_bin_edges_mm="2,8,16,inf")
+    np.testing.assert_allclose(_bin_edges_mm(opts), [2.0, 8.0, 16.0, np.inf])
+
+    with pytest.raises(ValueError, match="required"):
+        _bin_edges_mm(SimpleNamespace(turnback_excursion_bin_edges_mm=""))
+
+    with pytest.raises(ValueError, match="at least two"):
+        _bin_edges_mm(SimpleNamespace(turnback_excursion_bin_edges_mm="2"))
+
+    with pytest.raises(ValueError, match="monotonically increasing|inf.*last edge"):
+        _bin_edges_mm(SimpleNamespace(turnback_excursion_bin_edges_mm="2,inf,16"))
+
+    with pytest.raises(
+        ValueError, match="monotonically increasing|strictly increasing"
+    ):
+        _bin_edges_mm(SimpleNamespace(turnback_excursion_bin_edges_mm="2,8,8"))
+
+
+def test_training_selection_and_windowing_match_panel_metadata_conventions():
+    vas = [_va(trns=[_Training(name="t1"), _Training(name="T2"), _Training(name="T3")])]
+
+    opts = SimpleNamespace(turnback_excursion_bin_trainings="3,1-2,2")
+    assert _selected_training_indices(vas, opts) == [0, 1, 2]
+
+    opts = SimpleNamespace(turnback_excursion_bin_trainings="9")
+    assert _selected_training_indices(vas, opts) == [0, 1, 2]
+
+    assert _selected_training_indices([_va(skipped=True)], SimpleNamespace()) == []
+
+    va = _va(
+        trns=[_Training(name="T1")],
+        sync_bucket_ranges=[[(0, 10), (10, 20), (20, 30), (30, 40)]],
+    )
+    windows = _selected_windows_for_va(
+        va, [0], skip_first=1, keep_first=3, last_sync_buckets=2
+    )
+
+    assert windows == [
+        {
+            "training_idx": 0,
+            "training_name": "T1",
+            "start": 20,
+            "stop": 40,
+            "bucket_ranges": [(20, 30), (30, 40)],
+        }
+    ]
+
+
+def test_effective_windowing_uses_metric_specific_overrides_and_clamps_negative_values():
+    opts = SimpleNamespace(
+        skip_first_sync_buckets=5,
+        keep_first_sync_buckets=6,
+        turnback_excursion_bin_skip_first_sync_buckets=-2,
+        turnback_excursion_bin_keep_first_sync_buckets=None,
+        turnback_excursion_bin_last_sync_buckets=-3,
+    )
+
+    assert _effective_windowing(opts) == (0, 6, 0)
+
+
+def test_turnback_binned_counts_only_successful_observed_turnbacks():
+    exp = _Trajectory(
+        [
+            _episode(10, 4.0, True),
+            _episode(20, 10.0, False),
+            _episode(30, np.nan, True),
+            _episode(80, 4.0, True),
+        ]
+    )
+    ctrl = _Trajectory([_episode(10, 10.0, True), _episode(20, 4.0, False)])
+    va = _va(trx=[exp, ctrl], sync_bucket_ranges=[[(0, 50)]])
+
+    ratio_exp, ratio_ctrl, turn_exp, turn_ctrl, total_exp, total_ctrl, _ = _curves([va])
+
+    np.testing.assert_allclose(turn_exp, [[2.0 / 3.0, 1.0]])
+    np.testing.assert_array_equal(total_exp, [[1, 1]])
+    np.testing.assert_allclose(ratio_exp, [[2.0 / 3.0, 1.0]])
+
+    np.testing.assert_allclose(turn_ctrl, [[0.0, 0.75]])
+    np.testing.assert_array_equal(total_ctrl, [[1, 1]])
+    np.testing.assert_allclose(ratio_ctrl, [[0.0, 0.75]])
+
+
+def test_turnback_binned_average_is_not_bin_membership():
+    exp = _Trajectory(
+        [
+            _episode(10, 1.0, True),
+            _episode(20, 5.0, True),
+            _episode(30, 8.0, True),
+            _episode(40, 20.0, True),
+        ]
+    )
+
+    ratio_exp, _, turn_exp, _, total_exp, _, _ = _curves([_va(trx=[exp], noyc=True)])
+
+    np.testing.assert_allclose(turn_exp, [[1.5, 3.0]])
+    np.testing.assert_array_equal(total_exp, [[4, 4]])
+    np.testing.assert_allclose(ratio_exp, [[0.375, 0.75]])
+
+
+def test_open_ended_bin_resolves_from_nonturning_excursions_but_does_not_count_them():
+    exp = _Trajectory([_episode(10, 20.0, False)])
+
+    ratio_exp, _, turn_exp, _, total_exp, _, _ = _curves(
+        [_va(trx=[exp], noyc=True)], edges=(2.0, 8.0, np.inf)
+    )
+
+    assert np.isnan(ratio_exp).all()
+    np.testing.assert_allclose(turn_exp, [[0.0, 0.0]])
+    np.testing.assert_array_equal(total_exp, [[0, 0]])
+
+
+def test_open_ended_bin_rejects_when_no_observed_excursion_exceeds_lower_edge():
+    exp = _Trajectory([_episode(10, 8.0, True)])
+
+    with pytest.raises(ValueError, match="no observed excursion exceeded it"):
+        _curves([_va(trx=[exp], noyc=True)], edges=(2.0, 16.0, np.inf))
+
+
+def test_bins_at_or_below_effective_inner_radius_are_not_counted():
+    exp = _Trajectory([_episode(10, 8.0, True, inner=8.0)])
+
+    ratio_exp, _, turn_exp, _, total_exp, _, _ = _curves([_va(trx=[exp], noyc=True)])
+
+    assert np.isnan(ratio_exp[0, 0])
+    np.testing.assert_array_equal(total_exp, [[0, 1]])
+    np.testing.assert_allclose(turn_exp, [[0.0, 1.0]])

--- a/test/reference/bundles/turnback_excursion_bin_paper_manifest.json
+++ b/test/reference/bundles/turnback_excursion_bin_paper_manifest.json
@@ -1,0 +1,1679 @@
+{
+  "bundles": [
+    {
+      "arrays": {
+        "group_label": {
+          "dtype": "<U12",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "8e9a5272c02ec04b039a591db294fda16bafd6e9fa6215a94cd7970a2b26ce1a",
+          "shape": []
+        },
+        "sli": {
+          "dtype": "float64",
+          "finite_count": 62,
+          "kind": "numeric",
+          "nan_count": 7,
+          "sha256": "31fdbb97d3b48656fd3f11913c909063984a407f43dcd919cd7d010b31caef37",
+          "shape": [
+            69
+          ]
+        },
+        "sli_select_keep_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "sli_select_skip_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "sli_training_idx": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "sli_ts": {
+          "dtype": "float64",
+          "finite_count": 847,
+          "kind": "numeric",
+          "nan_count": 395,
+          "sha256": "d0c722c678aba09e7409135f820bc1b95b4938c0ccb9b87cd7658ba6d3230cec",
+          "shape": [
+            69,
+            3,
+            6
+          ]
+        },
+        "sli_use_training_mean": {
+          "dtype": "bool",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "a2709fcbfdeb023a70c53c31628d48d9306c5f4772ab12de7b67b66f3bf34fa7",
+          "shape": []
+        },
+        "training_names": {
+          "dtype": "<U10",
+          "finite_count": 3,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "4860b8926b4845ace4d18e00fcbf676c260d49d4d5ebe5df07e1aee6693e70f2",
+          "shape": [
+            3
+          ]
+        },
+        "turnback_excursion_bin_border_width_mm": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "45d2b662d9d490ae9b932759c910b26b9a874065de620f4ac0a3a23a65e40b8c",
+          "shape": []
+        },
+        "turnback_excursion_bin_edges_mm": {
+          "dtype": "float64",
+          "finite_count": 4,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "600bb49a72c2a699197ae6a3819f8db405dc3b717e3a4eb7401fa8858533c7df",
+          "shape": [
+            4
+          ]
+        },
+        "turnback_excursion_bin_inner_delta_mm": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "3f710ac088db33363087de2b9a657541fe5447821debaa9fe5cbd538eb1a5f29",
+          "shape": []
+        },
+        "turnback_excursion_bin_inner_radius_offset_px": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "turnback_excursion_bin_keep_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "turnback_excursion_bin_last_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "turnback_excursion_bin_open_ended_upper_bin": {
+          "dtype": "bool",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "a2709fcbfdeb023a70c53c31628d48d9306c5f4772ab12de7b67b66f3bf34fa7",
+          "shape": []
+        },
+        "turnback_excursion_bin_ratio_ctrl": {
+          "dtype": "float64",
+          "finite_count": 192,
+          "kind": "numeric",
+          "nan_count": 15,
+          "sha256": "c704000515cfad79e6dd8c2c69962f5015948f016f38a8b1146904892af38421",
+          "shape": [
+            69,
+            3
+          ]
+        },
+        "turnback_excursion_bin_ratio_exp": {
+          "dtype": "float64",
+          "finite_count": 201,
+          "kind": "numeric",
+          "nan_count": 6,
+          "sha256": "e90602c896a77313acd8daec345d5b48c46682703652be39bede0542fd15e737",
+          "shape": [
+            69,
+            3
+          ]
+        },
+        "turnback_excursion_bin_requested_edges_mm": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "e93d64fadf98c2a8662467d6f4a431f2437e24d274c4c9a74a8537788a79303c",
+          "shape": [
+            4
+          ]
+        },
+        "turnback_excursion_bin_skip_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "turnback_excursion_bin_total_ctrl": {
+          "dtype": "int64",
+          "finite_count": 207,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "16aa63a8047539bf64c0c3e229a2a09b309e8559f1d746e6be8494c02ea9e8b3",
+          "shape": [
+            69,
+            3
+          ]
+        },
+        "turnback_excursion_bin_total_exp": {
+          "dtype": "int64",
+          "finite_count": 207,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "ad6ab5e13ae43551136bc5f13bd99094aca60486179514e18ebb793c98afc9a8",
+          "shape": [
+            69,
+            3
+          ]
+        },
+        "turnback_excursion_bin_trainings": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": [
+            1
+          ]
+        },
+        "turnback_excursion_bin_turn_ctrl": {
+          "dtype": "float64",
+          "finite_count": 207,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "d61ffc3d7fb46234409acb1316a991fbe70d8d3b9a14351f259c0c76fd7c7e97",
+          "shape": [
+            69,
+            3
+          ]
+        },
+        "turnback_excursion_bin_turn_exp": {
+          "dtype": "float64",
+          "finite_count": 207,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "1912d66d25aee9bb5b86c9cf13d0012a039f1d67217cfdea0d512f7d3243eb56",
+          "shape": [
+            69,
+            3
+          ]
+        },
+        "turnback_excursion_bin_window_summary": {
+          "dtype": "object",
+          "finite_count": 69,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "b6c08fc2c9aa6510358417b79c6da111c9bf15b739e851b88bacb7229954443e",
+          "shape": [
+            69
+          ]
+        },
+        "video_ids": {
+          "dtype": "<U77",
+          "finite_count": 69,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "9242d4fcf88dee42c16d3fd736097f56281fbee20201cd164caa753a22b91071",
+          "shape": [
+            69
+          ]
+        }
+      },
+      "keys": [
+        "group_label",
+        "sli",
+        "sli_select_keep_first_sync_buckets",
+        "sli_select_skip_first_sync_buckets",
+        "sli_training_idx",
+        "sli_ts",
+        "sli_use_training_mean",
+        "training_names",
+        "turnback_excursion_bin_border_width_mm",
+        "turnback_excursion_bin_edges_mm",
+        "turnback_excursion_bin_inner_delta_mm",
+        "turnback_excursion_bin_inner_radius_offset_px",
+        "turnback_excursion_bin_keep_first_sync_buckets",
+        "turnback_excursion_bin_last_sync_buckets",
+        "turnback_excursion_bin_open_ended_upper_bin",
+        "turnback_excursion_bin_ratio_ctrl",
+        "turnback_excursion_bin_ratio_exp",
+        "turnback_excursion_bin_requested_edges_mm",
+        "turnback_excursion_bin_skip_first_sync_buckets",
+        "turnback_excursion_bin_total_ctrl",
+        "turnback_excursion_bin_total_exp",
+        "turnback_excursion_bin_trainings",
+        "turnback_excursion_bin_turn_ctrl",
+        "turnback_excursion_bin_turn_exp",
+        "turnback_excursion_bin_window_summary",
+        "video_ids"
+      ],
+      "name": "panel22_flat_intact_ctrlKir",
+      "path": "exports/turnback_binned_intact_ctrlKir_flatLgc_T2_16mmPlus_2026-04-27.npz",
+      "sha256": "6edbc36d92985f7a3d8ef61516f731e4fb9e4be3805674a2d784ce48d2409719"
+    },
+    {
+      "arrays": {
+        "group_label": {
+          "dtype": "<U12",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "442fb87346d53c659207fc7463aa95d5df261121f14d3ee5f34aa286777730f9",
+          "shape": []
+        },
+        "sli": {
+          "dtype": "float64",
+          "finite_count": 52,
+          "kind": "numeric",
+          "nan_count": 9,
+          "sha256": "6f8aec8a03575bd0f377321fbda947f9b2bb137a4a7d02d19abfc5108263c6ca",
+          "shape": [
+            61
+          ]
+        },
+        "sli_select_keep_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "sli_select_skip_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "sli_training_idx": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "sli_ts": {
+          "dtype": "float64",
+          "finite_count": 698,
+          "kind": "numeric",
+          "nan_count": 400,
+          "sha256": "f5342732a54f3cb0c3c3884976e0e5d0bd15138d5ae0b3f1172b081e117c4646",
+          "shape": [
+            61,
+            3,
+            6
+          ]
+        },
+        "sli_use_training_mean": {
+          "dtype": "bool",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "a2709fcbfdeb023a70c53c31628d48d9306c5f4772ab12de7b67b66f3bf34fa7",
+          "shape": []
+        },
+        "training_names": {
+          "dtype": "<U10",
+          "finite_count": 3,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "4860b8926b4845ace4d18e00fcbf676c260d49d4d5ebe5df07e1aee6693e70f2",
+          "shape": [
+            3
+          ]
+        },
+        "turnback_excursion_bin_border_width_mm": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "45d2b662d9d490ae9b932759c910b26b9a874065de620f4ac0a3a23a65e40b8c",
+          "shape": []
+        },
+        "turnback_excursion_bin_edges_mm": {
+          "dtype": "float64",
+          "finite_count": 4,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "fd8110095dc967295ceccd9c2a8583fd38e692a1a81c6e13e4428d40ad74545f",
+          "shape": [
+            4
+          ]
+        },
+        "turnback_excursion_bin_inner_delta_mm": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "3f710ac088db33363087de2b9a657541fe5447821debaa9fe5cbd538eb1a5f29",
+          "shape": []
+        },
+        "turnback_excursion_bin_inner_radius_offset_px": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "turnback_excursion_bin_keep_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "turnback_excursion_bin_last_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "turnback_excursion_bin_open_ended_upper_bin": {
+          "dtype": "bool",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "a2709fcbfdeb023a70c53c31628d48d9306c5f4772ab12de7b67b66f3bf34fa7",
+          "shape": []
+        },
+        "turnback_excursion_bin_ratio_ctrl": {
+          "dtype": "float64",
+          "finite_count": 168,
+          "kind": "numeric",
+          "nan_count": 15,
+          "sha256": "4fede6391b8a10228a4e828d4c6318f7cf1644ae721c1409137dc40ca72fcad8",
+          "shape": [
+            61,
+            3
+          ]
+        },
+        "turnback_excursion_bin_ratio_exp": {
+          "dtype": "float64",
+          "finite_count": 174,
+          "kind": "numeric",
+          "nan_count": 9,
+          "sha256": "620b927dcef85c41f84d504fd3a1f5b5f99754959bc1cb9adfdb5343a25f89ea",
+          "shape": [
+            61,
+            3
+          ]
+        },
+        "turnback_excursion_bin_requested_edges_mm": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "e93d64fadf98c2a8662467d6f4a431f2437e24d274c4c9a74a8537788a79303c",
+          "shape": [
+            4
+          ]
+        },
+        "turnback_excursion_bin_skip_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "turnback_excursion_bin_total_ctrl": {
+          "dtype": "int64",
+          "finite_count": 183,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "97a5d4bcc9749bd72b0bf9a7b6eba9755930f70409e91e781b62fc781c61a1e8",
+          "shape": [
+            61,
+            3
+          ]
+        },
+        "turnback_excursion_bin_total_exp": {
+          "dtype": "int64",
+          "finite_count": 183,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "052b952ba044bc9bd20b9d5a08de14f954182dcb3b5ae579c44f26eb8dc114e1",
+          "shape": [
+            61,
+            3
+          ]
+        },
+        "turnback_excursion_bin_trainings": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": [
+            1
+          ]
+        },
+        "turnback_excursion_bin_turn_ctrl": {
+          "dtype": "float64",
+          "finite_count": 183,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "26a4e46f566be1e7897163490faa590fc1646aab3cc5e00bf8e02caf02e7232f",
+          "shape": [
+            61,
+            3
+          ]
+        },
+        "turnback_excursion_bin_turn_exp": {
+          "dtype": "float64",
+          "finite_count": 183,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "15e0423e228fee62f90675a333a2cda5e0bd12f81f204dabef9f5a42b25d02e9",
+          "shape": [
+            61,
+            3
+          ]
+        },
+        "turnback_excursion_bin_window_summary": {
+          "dtype": "object",
+          "finite_count": 61,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "2d08d09b19bb628e2dc195c41e6045c423f8f078a07d826c00eeb8f24030f8ed",
+          "shape": [
+            61
+          ]
+        },
+        "video_ids": {
+          "dtype": "<U77",
+          "finite_count": 61,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "abf0dc060c8feb451a3d022a7f25453b53789fa16b561d0ef5ef2091680dca6e",
+          "shape": [
+            61
+          ]
+        }
+      },
+      "keys": [
+        "group_label",
+        "sli",
+        "sli_select_keep_first_sync_buckets",
+        "sli_select_skip_first_sync_buckets",
+        "sli_training_idx",
+        "sli_ts",
+        "sli_use_training_mean",
+        "training_names",
+        "turnback_excursion_bin_border_width_mm",
+        "turnback_excursion_bin_edges_mm",
+        "turnback_excursion_bin_inner_delta_mm",
+        "turnback_excursion_bin_inner_radius_offset_px",
+        "turnback_excursion_bin_keep_first_sync_buckets",
+        "turnback_excursion_bin_last_sync_buckets",
+        "turnback_excursion_bin_open_ended_upper_bin",
+        "turnback_excursion_bin_ratio_ctrl",
+        "turnback_excursion_bin_ratio_exp",
+        "turnback_excursion_bin_requested_edges_mm",
+        "turnback_excursion_bin_skip_first_sync_buckets",
+        "turnback_excursion_bin_total_ctrl",
+        "turnback_excursion_bin_total_exp",
+        "turnback_excursion_bin_trainings",
+        "turnback_excursion_bin_turn_ctrl",
+        "turnback_excursion_bin_turn_exp",
+        "turnback_excursion_bin_window_summary",
+        "video_ids"
+      ],
+      "name": "panel22_flat_intact_pfnKir",
+      "path": "exports/turnback_binned_intact_pfnKir_flatLgc_T2_16mmPlus_2026-04-27.npz",
+      "sha256": "1da04f1e39d5005ee2bfa92c4a0ce5355fafe5c8f57ddd199547c067a56d9839"
+    },
+    {
+      "arrays": {
+        "group_label": {
+          "dtype": "<U15",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "f5c0a07f74cd084e052f5d9264dbb39ab23cb7e94463ca4a29600ffe2331c01c",
+          "shape": []
+        },
+        "sli": {
+          "dtype": "float64",
+          "finite_count": 55,
+          "kind": "numeric",
+          "nan_count": 11,
+          "sha256": "a8196f842f5c6fcf023d7bb3e3d6e825e165dde52ac6da721d70cef063cd0553",
+          "shape": [
+            66
+          ]
+        },
+        "sli_select_keep_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "sli_select_skip_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "sli_training_idx": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "sli_ts": {
+          "dtype": "float64",
+          "finite_count": 714,
+          "kind": "numeric",
+          "nan_count": 474,
+          "sha256": "a05bc6b4630ede45a61d098b7f71e3ff9c709731ea20869503b9b78c35bee2fa",
+          "shape": [
+            66,
+            3,
+            6
+          ]
+        },
+        "sli_use_training_mean": {
+          "dtype": "bool",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "a2709fcbfdeb023a70c53c31628d48d9306c5f4772ab12de7b67b66f3bf34fa7",
+          "shape": []
+        },
+        "training_names": {
+          "dtype": "<U10",
+          "finite_count": 3,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "4860b8926b4845ace4d18e00fcbf676c260d49d4d5ebe5df07e1aee6693e70f2",
+          "shape": [
+            3
+          ]
+        },
+        "turnback_excursion_bin_border_width_mm": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "45d2b662d9d490ae9b932759c910b26b9a874065de620f4ac0a3a23a65e40b8c",
+          "shape": []
+        },
+        "turnback_excursion_bin_edges_mm": {
+          "dtype": "float64",
+          "finite_count": 4,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "c89d2601a005932be2e3d75361bc38f253006f6141605799408f443e7f3eabb4",
+          "shape": [
+            4
+          ]
+        },
+        "turnback_excursion_bin_inner_delta_mm": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "3f710ac088db33363087de2b9a657541fe5447821debaa9fe5cbd538eb1a5f29",
+          "shape": []
+        },
+        "turnback_excursion_bin_inner_radius_offset_px": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "turnback_excursion_bin_keep_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "turnback_excursion_bin_last_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "turnback_excursion_bin_open_ended_upper_bin": {
+          "dtype": "bool",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "a2709fcbfdeb023a70c53c31628d48d9306c5f4772ab12de7b67b66f3bf34fa7",
+          "shape": []
+        },
+        "turnback_excursion_bin_ratio_ctrl": {
+          "dtype": "float64",
+          "finite_count": 174,
+          "kind": "numeric",
+          "nan_count": 24,
+          "sha256": "e97417a6b56c6679520d85878b1b9762c5d5ce5f43721e3f4c87ef0b64bd479c",
+          "shape": [
+            66,
+            3
+          ]
+        },
+        "turnback_excursion_bin_ratio_exp": {
+          "dtype": "float64",
+          "finite_count": 189,
+          "kind": "numeric",
+          "nan_count": 9,
+          "sha256": "05cecf0739932fef0b2a7362bbbf0b00b971347555d84ba0d2109676fa6ad3b5",
+          "shape": [
+            66,
+            3
+          ]
+        },
+        "turnback_excursion_bin_requested_edges_mm": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "e93d64fadf98c2a8662467d6f4a431f2437e24d274c4c9a74a8537788a79303c",
+          "shape": [
+            4
+          ]
+        },
+        "turnback_excursion_bin_skip_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "turnback_excursion_bin_total_ctrl": {
+          "dtype": "int64",
+          "finite_count": 198,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "791df8395553913a599ce801b4eaa21a9f9a732dd1c902678737805ced3bc37b",
+          "shape": [
+            66,
+            3
+          ]
+        },
+        "turnback_excursion_bin_total_exp": {
+          "dtype": "int64",
+          "finite_count": 198,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7e52092acc392009ac80492b38669598063ab1e36b647cf497167dd08a2e2f47",
+          "shape": [
+            66,
+            3
+          ]
+        },
+        "turnback_excursion_bin_trainings": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": [
+            1
+          ]
+        },
+        "turnback_excursion_bin_turn_ctrl": {
+          "dtype": "float64",
+          "finite_count": 198,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "fd1165aca5e102d7218476a2fec5cce38dee10f90f3fe31df6c407684c8a3a47",
+          "shape": [
+            66,
+            3
+          ]
+        },
+        "turnback_excursion_bin_turn_exp": {
+          "dtype": "float64",
+          "finite_count": 198,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "5efc2c22efe6a00d6e424a804596c5b23cb179dc2ef3cafff2f5edea11f06468",
+          "shape": [
+            66,
+            3
+          ]
+        },
+        "turnback_excursion_bin_window_summary": {
+          "dtype": "object",
+          "finite_count": 66,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "f1886f4d81e40f64bd746cfbb7322cced9f55f713a6c7c66a721eda608249b05",
+          "shape": [
+            66
+          ]
+        },
+        "video_ids": {
+          "dtype": "<U77",
+          "finite_count": 66,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "b08398ff7eed90d810d604ccae4cf8f80597ffc45c14ad4a90d57238fc3c22d0",
+          "shape": [
+            66
+          ]
+        }
+      },
+      "keys": [
+        "group_label",
+        "sli",
+        "sli_select_keep_first_sync_buckets",
+        "sli_select_skip_first_sync_buckets",
+        "sli_training_idx",
+        "sli_ts",
+        "sli_use_training_mean",
+        "training_names",
+        "turnback_excursion_bin_border_width_mm",
+        "turnback_excursion_bin_edges_mm",
+        "turnback_excursion_bin_inner_delta_mm",
+        "turnback_excursion_bin_inner_radius_offset_px",
+        "turnback_excursion_bin_keep_first_sync_buckets",
+        "turnback_excursion_bin_last_sync_buckets",
+        "turnback_excursion_bin_open_ended_upper_bin",
+        "turnback_excursion_bin_ratio_ctrl",
+        "turnback_excursion_bin_ratio_exp",
+        "turnback_excursion_bin_requested_edges_mm",
+        "turnback_excursion_bin_skip_first_sync_buckets",
+        "turnback_excursion_bin_total_ctrl",
+        "turnback_excursion_bin_total_exp",
+        "turnback_excursion_bin_trainings",
+        "turnback_excursion_bin_turn_ctrl",
+        "turnback_excursion_bin_turn_exp",
+        "turnback_excursion_bin_window_summary",
+        "video_ids"
+      ],
+      "name": "panel22_flat_ar_ctrlKir",
+      "path": "exports/turnback_binned_ar_ctrlKir_flatLgc_T2_16mmPlus_2026-04-27.npz",
+      "sha256": "7cdb332e85d29e1c2695c76a10ce5a5e9a6352a39bfb23f58ce8c1b98bd04b0a"
+    },
+    {
+      "arrays": {
+        "group_label": {
+          "dtype": "<U12",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "a4cad8fde309f3f989b2a3ead41ab0499b5bf7a2556bf8b6ed1f0b2992c9ca28",
+          "shape": []
+        },
+        "sli": {
+          "dtype": "float64",
+          "finite_count": 57,
+          "kind": "numeric",
+          "nan_count": 13,
+          "sha256": "f848e9a318ca46c756d0af9df72ea7211e0ad40ac26bd6914b09f56032031ceb",
+          "shape": [
+            70
+          ]
+        },
+        "sli_select_keep_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "sli_select_skip_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "sli_training_idx": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "sli_ts": {
+          "dtype": "float64",
+          "finite_count": 725,
+          "kind": "numeric",
+          "nan_count": 535,
+          "sha256": "a150bb57d279d662974e4b7bac6d2e10e9e0429ea505a20ee465e7b0baba35d2",
+          "shape": [
+            70,
+            3,
+            6
+          ]
+        },
+        "sli_use_training_mean": {
+          "dtype": "bool",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "a2709fcbfdeb023a70c53c31628d48d9306c5f4772ab12de7b67b66f3bf34fa7",
+          "shape": []
+        },
+        "training_names": {
+          "dtype": "<U10",
+          "finite_count": 3,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "4860b8926b4845ace4d18e00fcbf676c260d49d4d5ebe5df07e1aee6693e70f2",
+          "shape": [
+            3
+          ]
+        },
+        "turnback_excursion_bin_border_width_mm": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "45d2b662d9d490ae9b932759c910b26b9a874065de620f4ac0a3a23a65e40b8c",
+          "shape": []
+        },
+        "turnback_excursion_bin_edges_mm": {
+          "dtype": "float64",
+          "finite_count": 4,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "966d665b191df2caa07bf49870a786fd10a03c9f7b69c75142de58de499fd8bd",
+          "shape": [
+            4
+          ]
+        },
+        "turnback_excursion_bin_inner_delta_mm": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "3f710ac088db33363087de2b9a657541fe5447821debaa9fe5cbd538eb1a5f29",
+          "shape": []
+        },
+        "turnback_excursion_bin_inner_radius_offset_px": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "turnback_excursion_bin_keep_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "turnback_excursion_bin_last_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "turnback_excursion_bin_open_ended_upper_bin": {
+          "dtype": "bool",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "a2709fcbfdeb023a70c53c31628d48d9306c5f4772ab12de7b67b66f3bf34fa7",
+          "shape": []
+        },
+        "turnback_excursion_bin_ratio_ctrl": {
+          "dtype": "float64",
+          "finite_count": 183,
+          "kind": "numeric",
+          "nan_count": 27,
+          "sha256": "f83b1c42ed26241a4fc873d2041e07595f71c0b444c2c802089dd3aaa25f2a29",
+          "shape": [
+            70,
+            3
+          ]
+        },
+        "turnback_excursion_bin_ratio_exp": {
+          "dtype": "float64",
+          "finite_count": 204,
+          "kind": "numeric",
+          "nan_count": 6,
+          "sha256": "97f80d256a2dac051a9b41dd80115eedc013e73e52b0c4308a6359368a24bb5d",
+          "shape": [
+            70,
+            3
+          ]
+        },
+        "turnback_excursion_bin_requested_edges_mm": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "e93d64fadf98c2a8662467d6f4a431f2437e24d274c4c9a74a8537788a79303c",
+          "shape": [
+            4
+          ]
+        },
+        "turnback_excursion_bin_skip_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "turnback_excursion_bin_total_ctrl": {
+          "dtype": "int64",
+          "finite_count": 210,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "5231afa4188102e62a10f68f76df19adaf368bdf334a1ea1f074a18ce6fe74f2",
+          "shape": [
+            70,
+            3
+          ]
+        },
+        "turnback_excursion_bin_total_exp": {
+          "dtype": "int64",
+          "finite_count": 210,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "15d915f7639ed20e5630b39de4caafc07af0a1059fa56561e575a286fadb0531",
+          "shape": [
+            70,
+            3
+          ]
+        },
+        "turnback_excursion_bin_trainings": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": [
+            1
+          ]
+        },
+        "turnback_excursion_bin_turn_ctrl": {
+          "dtype": "float64",
+          "finite_count": 210,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "aec3b30013375987806714f952f1fd0c7bccd415bfdb3b3056ad0212ca02e14e",
+          "shape": [
+            70,
+            3
+          ]
+        },
+        "turnback_excursion_bin_turn_exp": {
+          "dtype": "float64",
+          "finite_count": 210,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "e8ec152329b152170caa29635c92494b6ee8a1309b1443389d60b9af101a8704",
+          "shape": [
+            70,
+            3
+          ]
+        },
+        "turnback_excursion_bin_window_summary": {
+          "dtype": "object",
+          "finite_count": 70,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "40dd95b3dfae479769e77aa7a80f9450360d5ca24585276d09bfdcba93fa257e",
+          "shape": [
+            70
+          ]
+        },
+        "video_ids": {
+          "dtype": "<U77",
+          "finite_count": 70,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "ecf5acae59ab4b33174263f089c0f599ea1db072cc6fd69841163681556fd85d",
+          "shape": [
+            70
+          ]
+        }
+      },
+      "keys": [
+        "group_label",
+        "sli",
+        "sli_select_keep_first_sync_buckets",
+        "sli_select_skip_first_sync_buckets",
+        "sli_training_idx",
+        "sli_ts",
+        "sli_use_training_mean",
+        "training_names",
+        "turnback_excursion_bin_border_width_mm",
+        "turnback_excursion_bin_edges_mm",
+        "turnback_excursion_bin_inner_delta_mm",
+        "turnback_excursion_bin_inner_radius_offset_px",
+        "turnback_excursion_bin_keep_first_sync_buckets",
+        "turnback_excursion_bin_last_sync_buckets",
+        "turnback_excursion_bin_open_ended_upper_bin",
+        "turnback_excursion_bin_ratio_ctrl",
+        "turnback_excursion_bin_ratio_exp",
+        "turnback_excursion_bin_requested_edges_mm",
+        "turnback_excursion_bin_skip_first_sync_buckets",
+        "turnback_excursion_bin_total_ctrl",
+        "turnback_excursion_bin_total_exp",
+        "turnback_excursion_bin_trainings",
+        "turnback_excursion_bin_turn_ctrl",
+        "turnback_excursion_bin_turn_exp",
+        "turnback_excursion_bin_window_summary",
+        "video_ids"
+      ],
+      "name": "panel28_agarose_intact_ctrlKir",
+      "path": "exports/turnback_binned_intact_ctrlKir_agaroseLgc_T2_16mmPlus_2026-05-16.npz",
+      "sha256": "83282bdba4904756dc49f672776dd4f27a3d0b1750fbf579c5a819ab44feecc0"
+    },
+    {
+      "arrays": {
+        "group_label": {
+          "dtype": "<U12",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "36120744ee171c62a1776c7b88b40ce08381af3e8b7bdaa64d109654fc96fe3f",
+          "shape": []
+        },
+        "sli": {
+          "dtype": "float64",
+          "finite_count": 62,
+          "kind": "numeric",
+          "nan_count": 6,
+          "sha256": "0a873e430999a23d6e990e5a4ba3e9e7204febf11799ae186e000ad5d50bde8c",
+          "shape": [
+            68
+          ]
+        },
+        "sli_select_keep_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "sli_select_skip_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "sli_training_idx": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "sli_ts": {
+          "dtype": "float64",
+          "finite_count": 805,
+          "kind": "numeric",
+          "nan_count": 419,
+          "sha256": "9c09b496e7a2e5fecef72084575c4270cb93de95e08ffe4f2ec698942d9efd92",
+          "shape": [
+            68,
+            3,
+            6
+          ]
+        },
+        "sli_use_training_mean": {
+          "dtype": "bool",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "a2709fcbfdeb023a70c53c31628d48d9306c5f4772ab12de7b67b66f3bf34fa7",
+          "shape": []
+        },
+        "training_names": {
+          "dtype": "<U10",
+          "finite_count": 3,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "4860b8926b4845ace4d18e00fcbf676c260d49d4d5ebe5df07e1aee6693e70f2",
+          "shape": [
+            3
+          ]
+        },
+        "turnback_excursion_bin_border_width_mm": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "45d2b662d9d490ae9b932759c910b26b9a874065de620f4ac0a3a23a65e40b8c",
+          "shape": []
+        },
+        "turnback_excursion_bin_edges_mm": {
+          "dtype": "float64",
+          "finite_count": 4,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "a75f03a6bdcd75c38e26e6fc14285a0064378a237c8d5bef2401807fb9394ba9",
+          "shape": [
+            4
+          ]
+        },
+        "turnback_excursion_bin_inner_delta_mm": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "3f710ac088db33363087de2b9a657541fe5447821debaa9fe5cbd538eb1a5f29",
+          "shape": []
+        },
+        "turnback_excursion_bin_inner_radius_offset_px": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "turnback_excursion_bin_keep_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "turnback_excursion_bin_last_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "turnback_excursion_bin_open_ended_upper_bin": {
+          "dtype": "bool",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "a2709fcbfdeb023a70c53c31628d48d9306c5f4772ab12de7b67b66f3bf34fa7",
+          "shape": []
+        },
+        "turnback_excursion_bin_ratio_ctrl": {
+          "dtype": "float64",
+          "finite_count": 195,
+          "kind": "numeric",
+          "nan_count": 9,
+          "sha256": "9b17de88049f966b7df7c083eaaa5efca51686daa759cb25d741b03d44c7c77d",
+          "shape": [
+            68,
+            3
+          ]
+        },
+        "turnback_excursion_bin_ratio_exp": {
+          "dtype": "float64",
+          "finite_count": 195,
+          "kind": "numeric",
+          "nan_count": 9,
+          "sha256": "bafa0f200373527cbe6d02e3218f833684a97f22007c5bd162b4b1fbb2205e63",
+          "shape": [
+            68,
+            3
+          ]
+        },
+        "turnback_excursion_bin_requested_edges_mm": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "e93d64fadf98c2a8662467d6f4a431f2437e24d274c4c9a74a8537788a79303c",
+          "shape": [
+            4
+          ]
+        },
+        "turnback_excursion_bin_skip_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "turnback_excursion_bin_total_ctrl": {
+          "dtype": "int64",
+          "finite_count": 204,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c3835f6fb0f652687d21440058d1b230ec4d9ccb0abc5295fdc6f29b17c5074",
+          "shape": [
+            68,
+            3
+          ]
+        },
+        "turnback_excursion_bin_total_exp": {
+          "dtype": "int64",
+          "finite_count": 204,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "5cd056394b59d655178fa300d57237fd01e52a2c60683a7ebcc9a6849fcba783",
+          "shape": [
+            68,
+            3
+          ]
+        },
+        "turnback_excursion_bin_trainings": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": [
+            1
+          ]
+        },
+        "turnback_excursion_bin_turn_ctrl": {
+          "dtype": "float64",
+          "finite_count": 204,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "8f6e8edd2de559a36a5434df7ca9e9b8641616af0357f398f9b3794f9b777c4e",
+          "shape": [
+            68,
+            3
+          ]
+        },
+        "turnback_excursion_bin_turn_exp": {
+          "dtype": "float64",
+          "finite_count": 204,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "4da9b46760e8595f81a8cc72223d75c19cca6e6cb56df6914fcd16f56bf3e242",
+          "shape": [
+            68,
+            3
+          ]
+        },
+        "turnback_excursion_bin_window_summary": {
+          "dtype": "object",
+          "finite_count": 68,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "42cf5e5ffd5797c4ccd5d16ba679b0e1b7457200aaaa2dd48194621a53a8c92d",
+          "shape": [
+            68
+          ]
+        },
+        "video_ids": {
+          "dtype": "<U77",
+          "finite_count": 68,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "de65ed6b074433adc765e0f5f8da4a7ba8133eaf717cc1fcb571ec7eb70ce211",
+          "shape": [
+            68
+          ]
+        }
+      },
+      "keys": [
+        "group_label",
+        "sli",
+        "sli_select_keep_first_sync_buckets",
+        "sli_select_skip_first_sync_buckets",
+        "sli_training_idx",
+        "sli_ts",
+        "sli_use_training_mean",
+        "training_names",
+        "turnback_excursion_bin_border_width_mm",
+        "turnback_excursion_bin_edges_mm",
+        "turnback_excursion_bin_inner_delta_mm",
+        "turnback_excursion_bin_inner_radius_offset_px",
+        "turnback_excursion_bin_keep_first_sync_buckets",
+        "turnback_excursion_bin_last_sync_buckets",
+        "turnback_excursion_bin_open_ended_upper_bin",
+        "turnback_excursion_bin_ratio_ctrl",
+        "turnback_excursion_bin_ratio_exp",
+        "turnback_excursion_bin_requested_edges_mm",
+        "turnback_excursion_bin_skip_first_sync_buckets",
+        "turnback_excursion_bin_total_ctrl",
+        "turnback_excursion_bin_total_exp",
+        "turnback_excursion_bin_trainings",
+        "turnback_excursion_bin_turn_ctrl",
+        "turnback_excursion_bin_turn_exp",
+        "turnback_excursion_bin_window_summary",
+        "video_ids"
+      ],
+      "name": "panel28_agarose_intact_pfnKir",
+      "path": "exports/turnback_binned_intact_pfnKir_agaroseLgc_T2_16mmPlus_2026-05-16.npz",
+      "sha256": "03a98a791b28b6727248055d86ddae9fd692fd176fae4dd1f6f42f3bd27c4acf"
+    },
+    {
+      "arrays": {
+        "group_label": {
+          "dtype": "<U15",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "92d1aa72852de059939beefe3f8226ee2bb60e2bdd2e1d19f2300f61de351885",
+          "shape": []
+        },
+        "sli": {
+          "dtype": "float64",
+          "finite_count": 58,
+          "kind": "numeric",
+          "nan_count": 6,
+          "sha256": "f2802c97b981c687973114c8074a06591e638417392f01d34d9d642fa1ee2d26",
+          "shape": [
+            64
+          ]
+        },
+        "sli_select_keep_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "sli_select_skip_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "sli_training_idx": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "sli_ts": {
+          "dtype": "float64",
+          "finite_count": 646,
+          "kind": "numeric",
+          "nan_count": 506,
+          "sha256": "9f4db91fc936eaa76890fd1ea44caff7294ec7814c385fcd11be2bf43845fc05",
+          "shape": [
+            64,
+            3,
+            6
+          ]
+        },
+        "sli_use_training_mean": {
+          "dtype": "bool",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "a2709fcbfdeb023a70c53c31628d48d9306c5f4772ab12de7b67b66f3bf34fa7",
+          "shape": []
+        },
+        "training_names": {
+          "dtype": "<U10",
+          "finite_count": 3,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "4860b8926b4845ace4d18e00fcbf676c260d49d4d5ebe5df07e1aee6693e70f2",
+          "shape": [
+            3
+          ]
+        },
+        "turnback_excursion_bin_border_width_mm": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "45d2b662d9d490ae9b932759c910b26b9a874065de620f4ac0a3a23a65e40b8c",
+          "shape": []
+        },
+        "turnback_excursion_bin_edges_mm": {
+          "dtype": "float64",
+          "finite_count": 4,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "dca24997d74a78e2471b243e82a0068300f47291444ff761840f8c4c21c1f56c",
+          "shape": [
+            4
+          ]
+        },
+        "turnback_excursion_bin_inner_delta_mm": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "3f710ac088db33363087de2b9a657541fe5447821debaa9fe5cbd538eb1a5f29",
+          "shape": []
+        },
+        "turnback_excursion_bin_inner_radius_offset_px": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "turnback_excursion_bin_keep_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "turnback_excursion_bin_last_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "turnback_excursion_bin_open_ended_upper_bin": {
+          "dtype": "bool",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "a2709fcbfdeb023a70c53c31628d48d9306c5f4772ab12de7b67b66f3bf34fa7",
+          "shape": []
+        },
+        "turnback_excursion_bin_ratio_ctrl": {
+          "dtype": "float64",
+          "finite_count": 174,
+          "kind": "numeric",
+          "nan_count": 18,
+          "sha256": "8c324f757654bde2fac612939f6bc86581ee2450da56d7ec9e8ba116d62368e1",
+          "shape": [
+            64,
+            3
+          ]
+        },
+        "turnback_excursion_bin_ratio_exp": {
+          "dtype": "float64",
+          "finite_count": 192,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "60150669769b76b136a3f26336be61a517bb73c4389d6d4bcda65aa89d23778e",
+          "shape": [
+            64,
+            3
+          ]
+        },
+        "turnback_excursion_bin_requested_edges_mm": {
+          "dtype": "float64",
+          "finite_count": 3,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "e93d64fadf98c2a8662467d6f4a431f2437e24d274c4c9a74a8537788a79303c",
+          "shape": [
+            4
+          ]
+        },
+        "turnback_excursion_bin_skip_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "turnback_excursion_bin_total_ctrl": {
+          "dtype": "int64",
+          "finite_count": 192,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "fee0740fe09463971c9e6aef1679ed5f76690e638bbf2e8b2aad4801edb3edde",
+          "shape": [
+            64,
+            3
+          ]
+        },
+        "turnback_excursion_bin_total_exp": {
+          "dtype": "int64",
+          "finite_count": 192,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "2fa346f657964dea74a3b3f0a18c47f1be7bb80c01ab50717ba7933436f622ac",
+          "shape": [
+            64,
+            3
+          ]
+        },
+        "turnback_excursion_bin_trainings": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": [
+            1
+          ]
+        },
+        "turnback_excursion_bin_turn_ctrl": {
+          "dtype": "float64",
+          "finite_count": 192,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "4cafdb4f2f63ee6b35990daca6143cefddba7c5d10d074d71b1b00c23e96d110",
+          "shape": [
+            64,
+            3
+          ]
+        },
+        "turnback_excursion_bin_turn_exp": {
+          "dtype": "float64",
+          "finite_count": 192,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "2740a4e416520bb12076a98f8b3e0d82ca0048bdb7aae7e434bfffeb3b6fbd1d",
+          "shape": [
+            64,
+            3
+          ]
+        },
+        "turnback_excursion_bin_window_summary": {
+          "dtype": "object",
+          "finite_count": 64,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "aa3023104a277d1ac7ba840c3edd3fa6cf798c8b9581ff99875f91cbc8779fd3",
+          "shape": [
+            64
+          ]
+        },
+        "video_ids": {
+          "dtype": "<U77",
+          "finite_count": 64,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "b4681f0b7714818b0beff460bd7706e2f3f881138fa093b0fafb9410a73dbe5e",
+          "shape": [
+            64
+          ]
+        }
+      },
+      "keys": [
+        "group_label",
+        "sli",
+        "sli_select_keep_first_sync_buckets",
+        "sli_select_skip_first_sync_buckets",
+        "sli_training_idx",
+        "sli_ts",
+        "sli_use_training_mean",
+        "training_names",
+        "turnback_excursion_bin_border_width_mm",
+        "turnback_excursion_bin_edges_mm",
+        "turnback_excursion_bin_inner_delta_mm",
+        "turnback_excursion_bin_inner_radius_offset_px",
+        "turnback_excursion_bin_keep_first_sync_buckets",
+        "turnback_excursion_bin_last_sync_buckets",
+        "turnback_excursion_bin_open_ended_upper_bin",
+        "turnback_excursion_bin_ratio_ctrl",
+        "turnback_excursion_bin_ratio_exp",
+        "turnback_excursion_bin_requested_edges_mm",
+        "turnback_excursion_bin_skip_first_sync_buckets",
+        "turnback_excursion_bin_total_ctrl",
+        "turnback_excursion_bin_total_exp",
+        "turnback_excursion_bin_trainings",
+        "turnback_excursion_bin_turn_ctrl",
+        "turnback_excursion_bin_turn_exp",
+        "turnback_excursion_bin_window_summary",
+        "video_ids"
+      ],
+      "name": "panel28_agarose_ar_ctrlKir",
+      "path": "exports/turnback_binned_ar_ctrlKir_agaroseLgc_T2_16mmPlus_2026-05-16.npz",
+      "sha256": "6b6e9556633ddde23550f17411b7a17c60234e3860d698ca09f7ccae9d90444a"
+    }
+  ],
+  "schema_version": 1
+}


### PR DESCRIPTION
## Summary

Adds the three-layer correctness-check rollout for turnback excursion-bin ratio bundles used by Panels 22 and 28.

## Changes

- Add layer-one truth tests for turnback excursion-bin semantics:
  - bin edge parsing
  - training/window selection
  - integrated bin contribution
  - open-ended upper-bin resolution
  - ratio/turn/total behavior
  - effective-inner-radius bin exclusion

- Add layer-two manifest regression coverage:
  - register turnback excursion-bin digest keys
  - add manifest test wrapper
  - add reference manifest for available Panel 22 and Panel 28 exported bundles

- Add layer-three runtime bundle validation:
  - validate shapes and metadata
  - validate resolved/requested bin edges and open-ended-bin metadata
  - validate trainings/window metadata alignment
  - validate probability ranges, count arrays, turn mass bounds, and ratio consistency
  - run validation on export and bundle load/normalization

## Validation

- `pytest test/paper_metrics/test_turnback_excursion_bin_truth.py`
- `pytest test/paper_metrics/test_turnback_excursion_bin_bundle_invariants.py`
- `pytest test/paper_metrics`