### PR TITLE
Add COM magnitude paper-metric correctness checks

### DIFF
--- a/src/analysis/sli_bundle_utils.py
+++ b/src/analysis/sli_bundle_utils.py
@@ -62,6 +62,16 @@ BETWEEN_REWARD_RETURN_LEG_DIST_KEYS = (
     "between_reward_return_leg_distN_ctrl",
 )
 
+COMMAG_KEYS = (
+    "commag_exp",
+    "commag_ctrl",
+)
+
+COMMAG_COUNT_KEYS = (
+    "commagN_exp",
+    "commagN_ctrl",
+)
+
 TURNBACK_RATIO_KEYS = (
     "turnback_ratio_exp",
     "turnback_ratio_ctrl",
@@ -339,6 +349,59 @@ def validate_between_reward_return_leg_dist_bundle(
         count_ctrl_key="between_reward_return_leg_distN_ctrl",
         path=path,
     )
+
+
+def validate_commag_bundle(bundle: dict, *, path: str | None = None) -> None:
+    where = _bundle_label(bundle, path)
+    missing = [k for k in COMMAG_KEYS if k not in bundle]
+    if missing:
+        raise ValueError(f"Bundle {where} is missing COM-magnitude keys: {missing}")
+
+    expected_shape = _expected_sync_bucket_metric_shape(bundle, where=where)
+    value_exp = _validate_3d_distance_metric_array(
+        bundle, "commag_exp", where=where, expected_shape=expected_shape
+    )
+    value_ctrl = _validate_3d_distance_metric_array(
+        bundle, "commag_ctrl", where=where, expected_shape=expected_shape
+    )
+
+    bucket_len_min = float(as_scalar(bundle.get("bucket_len_min", np.nan)))
+    if not np.isfinite(bucket_len_min) or bucket_len_min <= 0.0:
+        raise ValueError(f"Bundle {where} has invalid bucket_len_min={bucket_len_min}")
+
+    min_segments = int(as_scalar(bundle.get("btw_rwd_sync_bucket_min_trajectories", 1)))
+    if min_segments < 0:
+        raise ValueError(
+            f"Bundle {where} has negative btw_rwd_sync_bucket_min_trajectories"
+        )
+
+    present_count_keys = [k for k in COMMAG_COUNT_KEYS if k in bundle]
+    if present_count_keys and set(present_count_keys) != set(COMMAG_COUNT_KEYS):
+        missing_counts = [k for k in COMMAG_COUNT_KEYS if k not in bundle]
+        raise ValueError(
+            f"Bundle {where} has incomplete COM-magnitude count keys: {missing_counts}"
+        )
+    if not present_count_keys:
+        return
+
+    count_exp = _validate_3d_distance_count_array(
+        bundle, "commagN_exp", where=where, expected_shape=expected_shape
+    )
+    count_ctrl = _validate_3d_distance_count_array(
+        bundle, "commagN_ctrl", where=where, expected_shape=expected_shape
+    )
+
+    sufficient_count = max(1, min_segments)
+    for key, values, counts in (
+        ("commag_exp", value_exp, count_exp),
+        ("commag_ctrl", value_ctrl, count_ctrl),
+    ):
+        finite = np.isfinite(values)
+        if np.any(finite & (counts < sufficient_count)):
+            raise ValueError(
+                f"Bundle {where} has finite {key} where count is below "
+                f"{sufficient_count}"
+            )
 
 
 def _validate_probability_array(
@@ -798,6 +861,8 @@ def normalize_sli_bundle(bundle: dict, *, path: str | None = None) -> dict:
         validate_between_reward_maxdist_bundle(out, path=path)
     if any(k in out for k in BETWEEN_REWARD_RETURN_LEG_DIST_KEYS):
         validate_between_reward_return_leg_dist_bundle(out, path=path)
+    if any(k in out for k in COMMAG_KEYS):
+        validate_commag_bundle(out, path=path)
     if any(k in out for k in TURNBACK_RATIO_PRIMARY_KEYS):
         validate_turnback_ratio_bundle(out, path=path)
     if any(k in out for k in TURNBACK_EXCURSION_BIN_KEYS):

--- a/src/exporting/com_sli_bundle.py
+++ b/src/exporting/com_sli_bundle.py
@@ -1,6 +1,7 @@
 import numpy as np
 import os
 
+from src.analysis.sli_bundle_utils import validate_commag_bundle, validate_sli_bundle
 from src.analysis.between_reward_filters import (
     mask_metric_by_min_between_reward_trajectories,
     min_between_reward_sync_bucket_trajectories,
@@ -144,6 +145,8 @@ def export_com_sli_bundle(vas, opts, gls, out_fn):
     if not out_fn.lower().endswith(".npz"):
         out_fn += ".npz"
 
+    validate_sli_bundle(bundle, path=out_fn)
+    validate_commag_bundle(bundle, path=out_fn)
     os.makedirs(os.path.dirname(out_fn) or ".", exist_ok=True)
     np.savez_compressed(out_fn, **bundle)
     print(f"[export] Wrote COM+SLI bundle: {out_fn} (n={len(bundle['sli'])})")

--- a/src/validation/bundle_digest.py
+++ b/src/validation/bundle_digest.py
@@ -147,6 +147,24 @@ BETWEEN_REWARD_RETURN_LEG_DIST_SLI_REGRESSION_KEYS = (
     "video_ids",
 )
 
+COMMAG_SLI_REGRESSION_KEYS = (
+    "btw_rwd_sync_bucket_min_trajectories",
+    "bucket_len_min",
+    "commagN_ctrl",
+    "commagN_exp",
+    "commag_ctrl",
+    "commag_exp",
+    "group_label",
+    "sli",
+    "sli_select_keep_first_sync_buckets",
+    "sli_select_skip_first_sync_buckets",
+    "sli_training_idx",
+    "sli_ts",
+    "sli_use_training_mean",
+    "training_names",
+    "video_ids",
+)
+
 TURNBACK_RATIO_REGRESSION_KEYS = (
     "bucket_len_min",
     "group_label",

--- a/test/paper_metrics/test_bundle_digest.py
+++ b/test/paper_metrics/test_bundle_digest.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from src.validation.bundle_digest import (
+    COMMAG_SLI_REGRESSION_KEYS,
     RETURN_PROB_EXCURSION_BIN_REGRESSION_KEYS,
     SLI_REGRESSION_KEYS,
     TURNBACK_RATIO_REGRESSION_KEYS,
@@ -88,6 +89,29 @@ def _write_turnback_ratio_bundle(path, *, ratio, unchecked=None):
     np.savez_compressed(path, **payload)
 
 
+def _write_commag_bundle(path, *, commag, unchecked=None):
+    payload = {
+        "btw_rwd_sync_bucket_min_trajectories": np.array(1, dtype=int),
+        "bucket_len_min": np.array(10.0, dtype=float),
+        "commagN_ctrl": np.asarray([[[1, 0]]], dtype=int),
+        "commagN_exp": np.asarray([[[1, 1]]], dtype=int),
+        "commag_ctrl": np.asarray([[[1.0, np.nan]]], dtype=float),
+        "commag_exp": np.asarray(commag, dtype=float),
+        "group_label": np.asarray("Control", dtype=object),
+        "sli": np.asarray([0.1], dtype=float),
+        "sli_select_keep_first_sync_buckets": np.array(0, dtype=int),
+        "sli_select_skip_first_sync_buckets": np.array(1, dtype=int),
+        "sli_training_idx": np.array(0, dtype=int),
+        "sli_ts": np.asarray([[[1.0, np.nan]]], dtype=float),
+        "sli_use_training_mean": np.array(True),
+        "training_names": np.asarray(["T1"], dtype=object),
+        "video_ids": np.asarray(["video_a"], dtype=object),
+    }
+    if unchecked is not None:
+        payload["unchecked_metric"] = np.asarray(unchecked, dtype=float)
+    np.savez_compressed(path, **payload)
+
+
 def test_npz_digest_is_stable_across_npz_key_write_order(tmp_path):
     a = tmp_path / "a.npz"
     b = tmp_path / "b.npz"
@@ -138,6 +162,19 @@ def test_npz_digest_can_be_limited_to_turnback_ratio_regression_keys(tmp_path):
     assert (
         digest_npz(a, keys=TURNBACK_RATIO_REGRESSION_KEYS)["sha256"]
         == digest_npz(b, keys=TURNBACK_RATIO_REGRESSION_KEYS)["sha256"]
+    )
+    assert digest_npz(a)["sha256"] != digest_npz(b)["sha256"]
+
+
+def test_npz_digest_can_be_limited_to_commag_regression_keys(tmp_path):
+    a = tmp_path / "a.npz"
+    b = tmp_path / "b.npz"
+    _write_commag_bundle(a, commag=[[[1.0, 2.0]]], unchecked=[1.0])
+    _write_commag_bundle(b, commag=[[[1.0, 2.0]]], unchecked=[999.0])
+
+    assert (
+        digest_npz(a, keys=COMMAG_SLI_REGRESSION_KEYS)["sha256"]
+        == digest_npz(b, keys=COMMAG_SLI_REGRESSION_KEYS)["sha256"]
     )
     assert digest_npz(a)["sha256"] != digest_npz(b)["sha256"]
 

--- a/test/paper_metrics/test_commag_bundle_invariants.py
+++ b/test/paper_metrics/test_commag_bundle_invariants.py
@@ -1,0 +1,183 @@
+import numpy as np
+import pytest
+
+from src.analysis.sli_bundle_utils import normalize_sli_bundle, validate_commag_bundle
+
+
+def _bundle(**overrides):
+    exp = np.asarray(
+        [
+            [[1.0, 2.0, np.nan], [3.0, 4.0, 5.0]],
+            [[np.nan, 1.5, 2.5], [2.0, np.nan, 3.0]],
+        ],
+        dtype=float,
+    )
+    ctrl = np.asarray(
+        [
+            [[1.0, np.nan, 2.0], [3.0, 4.0, np.nan]],
+            [[np.nan, np.nan, 1.0], [2.0, 2.5, 3.0]],
+        ],
+        dtype=float,
+    )
+    bundle = {
+        "sli": np.asarray([0.1, np.nan], dtype=float),
+        "sli_ts": np.asarray(
+            [
+                [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]],
+                [[np.nan, 0.1, 0.2], [0.3, np.nan, 0.5]],
+            ],
+            dtype=float,
+        ),
+        "commag_exp": exp,
+        "commag_ctrl": ctrl,
+        "commagN_exp": np.asarray(np.isfinite(exp), dtype=int),
+        "commagN_ctrl": np.asarray(np.isfinite(ctrl), dtype=int),
+        "group_label": np.asarray("Control", dtype=object),
+        "bucket_len_min": np.array(10.0, dtype=float),
+        "training_names": np.asarray(["T1", "T2"], dtype=object),
+        "video_ids": np.asarray(["video_a", "video_b"], dtype=object),
+        "sli_training_idx": np.array(1, dtype=int),
+        "sli_use_training_mean": np.array(True),
+        "sli_select_skip_first_sync_buckets": np.array(1, dtype=int),
+        "sli_select_keep_first_sync_buckets": np.array(0, dtype=int),
+        "btw_rwd_sync_bucket_min_trajectories": np.array(1, dtype=int),
+    }
+    bundle.update(overrides)
+    return bundle
+
+
+def test_validate_commag_bundle_accepts_valid_shapes_counts_and_metadata():
+    validate_commag_bundle(_bundle())
+
+    normalized = normalize_sli_bundle(_bundle())
+    assert normalized["commag_exp"].shape == (2, 2, 3)
+
+
+def test_validate_commag_bundle_rejects_missing_metric_key():
+    bundle = _bundle()
+    del bundle["commag_ctrl"]
+
+    with pytest.raises(ValueError, match="missing COM-magnitude keys"):
+        validate_commag_bundle(bundle)
+
+
+def test_validate_commag_bundle_rejects_metric_shape_mismatch():
+    with pytest.raises(ValueError, match=r"commag_exp\.shape=\(2, 2, 2\)"):
+        validate_commag_bundle(_bundle(commag_exp=np.ones((2, 2, 2), dtype=float)))
+
+
+def test_validate_commag_bundle_rejects_bad_magnitudes():
+    with pytest.raises(ValueError, match="negative values"):
+        validate_commag_bundle(
+            _bundle(
+                commag_exp=np.asarray(
+                    [
+                        [[1.0, -2.0, np.nan], [3.0, 4.0, 5.0]],
+                        [[np.nan, 1.5, 2.5], [2.0, np.nan, 3.0]],
+                    ]
+                )
+            )
+        )
+
+    with pytest.raises(ValueError, match="infinite values"):
+        validate_commag_bundle(
+            _bundle(
+                commag_exp=np.asarray(
+                    [
+                        [[1.0, np.inf, np.nan], [3.0, 4.0, 5.0]],
+                        [[np.nan, 1.5, 2.5], [2.0, np.nan, 3.0]],
+                    ]
+                )
+            )
+        )
+
+
+def test_validate_commag_bundle_rejects_bad_counts():
+    with pytest.raises(ValueError, match="negative values"):
+        validate_commag_bundle(
+            _bundle(
+                commagN_exp=np.asarray(
+                    [[[1, -1, 0], [1, 1, 1]], [[0, 1, 1], [1, 0, 1]]]
+                )
+            )
+        )
+
+    with pytest.raises(ValueError, match="non-integer values"):
+        validate_commag_bundle(
+            _bundle(
+                commagN_exp=np.asarray(
+                    [[[1, 1.5, 0], [1, 1, 1]], [[0, 1, 1], [1, 0, 1]]]
+                )
+            )
+        )
+
+
+def test_validate_commag_bundle_rejects_finite_value_with_insufficient_count():
+    with pytest.raises(ValueError, match="finite commag_exp where count is below 1"):
+        validate_commag_bundle(
+            _bundle(
+                commag_exp=np.asarray(
+                    [
+                        [[1.0, 2.0, 2.0], [3.0, 4.0, 5.0]],
+                        [[np.nan, 1.5, 2.5], [2.0, np.nan, 3.0]],
+                    ]
+                ),
+                commagN_exp=np.asarray(
+                    [[[1, 1, 0], [1, 1, 1]], [[0, 1, 1], [1, 0, 1]]]
+                ),
+            )
+        )
+
+    with pytest.raises(ValueError, match="finite commag_ctrl where count is below 2"):
+        validate_commag_bundle(
+            _bundle(
+                btw_rwd_sync_bucket_min_trajectories=np.array(2, dtype=int),
+                commagN_exp=np.asarray(
+                    [[[2, 2, 0], [2, 2, 2]], [[0, 2, 2], [2, 0, 2]]]
+                ),
+                commag_ctrl=np.asarray(
+                    [
+                        [[1.0, np.nan, 2.0], [3.0, 4.0, np.nan]],
+                        [[np.nan, np.nan, 1.0], [2.0, 2.5, 3.0]],
+                    ],
+                    dtype=float,
+                ),
+                commagN_ctrl=np.asarray(
+                    [[[2, 0, 1], [2, 2, 0]], [[0, 0, 2], [2, 2, 2]]]
+                ),
+            )
+        )
+
+
+def test_validate_commag_bundle_allows_nan_values_explained_by_zero_or_low_counts():
+    validate_commag_bundle(
+        _bundle(
+            btw_rwd_sync_bucket_min_trajectories=np.array(2, dtype=int),
+            commag_exp=np.asarray(
+                [
+                    [[1.0, np.nan, np.nan], [3.0, 4.0, 5.0]],
+                    [[np.nan, np.nan, 2.5], [2.0, np.nan, 3.0]],
+                ]
+            ),
+            commagN_exp=np.asarray([[[2, 1, 0], [2, 2, 2]], [[0, 1, 2], [2, 0, 2]]]),
+            commag_ctrl=np.asarray(
+                [
+                    [[1.0, np.nan, np.nan], [3.0, 4.0, np.nan]],
+                    [[np.nan, np.nan, 1.0], [2.0, 2.5, 3.0]],
+                ]
+            ),
+            commagN_ctrl=np.asarray([[[2, 0, 1], [2, 2, 0]], [[0, 0, 2], [2, 2, 2]]]),
+        )
+    )
+
+
+def test_validate_commag_bundle_rejects_bad_bucket_metadata():
+    with pytest.raises(ValueError, match="invalid bucket_len_min"):
+        validate_commag_bundle(_bundle(bucket_len_min=np.array(np.nan)))
+
+    with pytest.raises(
+        ValueError, match="negative btw_rwd_sync_bucket_min_trajectories"
+    ):
+        validate_commag_bundle(
+            _bundle(btw_rwd_sync_bucket_min_trajectories=np.array(-1))
+        )

--- a/test/paper_metrics/test_commag_regression_manifest.py
+++ b/test/paper_metrics/test_commag_regression_manifest.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+import pytest
+
+from src.analysis.sli_bundle_utils import load_sli_bundle
+from src.validation.bundle_digest import check_manifest, load_manifest
+
+
+MANIFEST = Path("test/reference/bundles/commag_paper_manifest.json")
+
+
+def test_paper_commag_bundle_manifest_matches_available_exports():
+    manifest = load_manifest(MANIFEST)
+    missing = [
+        bundle["path"]
+        for bundle in manifest["bundles"]
+        if not Path(bundle["path"]).exists()
+    ]
+    if missing:
+        pytest.skip(
+            "Paper COM-distance export bundles are not available locally: "
+            + ", ".join(missing)
+        )
+
+    for bundle in manifest["bundles"]:
+        load_sli_bundle(bundle["path"])
+
+    assert check_manifest(MANIFEST) == []

--- a/test/paper_metrics/test_commag_truth.py
+++ b/test/paper_metrics/test_commag_truth.py
@@ -1,0 +1,181 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+from src.analysis.video_analysis import VideoAnalysis
+from src.exporting.com_sli_bundle import _extract_commag_arrays
+
+
+class _Trajectory:
+    def __init__(self, x, y, *, bad=False, f=0):
+        self.x = np.asarray(x, dtype=float)
+        self.y = np.asarray(y, dtype=float)
+        self._bad = bool(bad)
+        self.f = int(f)
+
+
+class _Training:
+    start = 0
+
+    def __init__(self, *, stop=20, center=(10.0, 20.0)):
+        self.stop = int(stop)
+        self._center = tuple(center)
+
+    def name(self):
+        return "T1"
+
+    def circles(self, _fly_idx):
+        cx, cy = self._center
+        return [(float(cx), float(cy), 5.0)]
+
+
+class _COMVideo:
+    def __init__(self, *, trx, on_by_fly, df=5, n_buckets=1, opts=None):
+        self.trx = list(trx)
+        self.trns = [_Training()]
+        self.flies = list(range(len(self.trx)))
+        self.opts = opts or SimpleNamespace(
+            com_exclude_wall_contact=False,
+            com_sli_debug=False,
+            btw_rwd_com_exclude_reward_endpoints=False,
+            btw_rwd_sync_bucket_min_trajectories=0,
+        )
+        self.xf = SimpleNamespace(fctr=1.0)
+        self.ct = SimpleNamespace(pxPerMmFloor=lambda: 2.0)
+        self._on_by_fly = {
+            int(k): np.asarray(v, dtype=int) for k, v in on_by_fly.items()
+        }
+        self._df = int(df)
+        self._n_buckets = int(n_buckets)
+
+    def _getOn(self, _trn, _include_ctrl, f=0):
+        return self._on_by_fly.get(int(f))
+
+    def _numRewardsMsg(self, *_args, **_kwargs):
+        return self._df
+
+    def _syncBucket(self, _trn, _df):
+        return 0, self._n_buckets, None
+
+    def _iter_between_reward_segment_com(self, trn, fly_idx, **kwargs):
+        yield from VideoAnalysis._iter_between_reward_segment_com(
+            self, trn, fly_idx, **kwargs
+        )
+
+
+def _iter_segments(va, **kwargs):
+    defaults = dict(
+        fi=0,
+        df=va._df,
+        n_buckets=va._n_buckets,
+        complete=[True] * va._n_buckets,
+        relative_to_reward=True,
+        per_segment_min_meddist_mm=0.0,
+        exclude_wall=False,
+    )
+    defaults.update(kwargs)
+    return list(
+        VideoAnalysis._iter_between_reward_segment_com(va, va.trns[0], 0, **defaults)
+    )
+
+
+def test_commag_segment_is_distance_of_mean_segment_position_from_reward_center():
+    va = _COMVideo(
+        trx=[_Trajectory(x=[12, 14, 16], y=[20, 22, 24])], on_by_fly={0: [0, 3]}
+    )
+
+    [seg] = _iter_segments(va)
+
+    assert seg.b_idx == 0
+    assert seg.s == 0
+    assert seg.e == 3
+    assert seg.mx_mm == 2.0
+    assert seg.my_mm == 1.0
+    np.testing.assert_allclose(seg.mag_mm, np.sqrt(5.0))
+
+
+def test_commag_segment_assignment_uses_between_reward_start_frame():
+    va = _COMVideo(
+        trx=[_Trajectory(x=np.arange(9), y=np.full(9, 20.0))],
+        on_by_fly={0: [0, 5, 8]},
+        df=5,
+        n_buckets=2,
+    )
+
+    segments = _iter_segments(va, complete=[True, True])
+
+    assert [(seg.s, seg.e, seg.b_idx) for seg in segments] == [(0, 5, 0), (5, 8, 1)]
+
+
+def test_commag_endpoint_exclusion_removes_both_reward_endpoint_frames():
+    va = _COMVideo(
+        trx=[_Trajectory(x=[100, 14, 18], y=[100, 20, 20])], on_by_fly={0: [0, 3]}
+    )
+
+    [seg] = _iter_segments(va, exclude_reward_endpoints=True)
+
+    assert seg.mx_mm == 2.0
+    assert seg.my_mm == 0.0
+    assert seg.mag_mm == 2.0
+
+
+def test_commag_segment_filters_nonfinite_coordinates_meddist_and_wall_contact():
+    finite_va = _COMVideo(
+        trx=[_Trajectory(x=[12, np.nan, 16], y=[20, 20, 24])], on_by_fly={0: [0, 3]}
+    )
+    [seg] = _iter_segments(finite_va)
+    assert seg.mx_mm == 2.0
+    assert seg.my_mm == 1.0
+
+    meddist_va = _COMVideo(
+        trx=[_Trajectory(x=[11, 11, 11], y=[20, 20, 20])], on_by_fly={0: [0, 3]}
+    )
+    [skip] = _iter_segments(
+        meddist_va, per_segment_min_meddist_mm=1.0, yield_skips=True
+    )
+    assert skip.why == "meddist_filtered"
+
+    wall_va = _COMVideo(
+        trx=[_Trajectory(x=[12, 14, 16], y=[20, 22, 24])], on_by_fly={0: [0, 3]}
+    )
+    [skip] = _iter_segments(
+        wall_va,
+        exclude_wall=True,
+        wc=np.asarray([False, True, False]),
+        yield_skips=True,
+    )
+    assert skip.why == "wall_contact"
+
+
+def test_by_sync_bucket_com_averages_segment_magnitudes_not_component_mean_vector():
+    va = _COMVideo(
+        trx=[
+            _Trajectory(x=[12, 12, 8, 8, 16, 16], y=[20, 20, 20, 20, 20, 20]),
+            _Trajectory(x=[10, 10, 10, 10, 10, 10], y=[22, 22, 22, 22, 22, 22]),
+        ],
+        on_by_fly={0: [0, 2, 4], 1: [0, 2, 4]},
+        df=5,
+        n_buckets=1,
+    )
+
+    VideoAnalysis.bySyncBucketCOM(va, relative_to_reward=True, store_mag=True)
+
+    assert va.syncCOMMagN[0]["exp"] == [2]
+    assert va.syncCOMMag[0]["exp"] == [1.0]
+    assert va.syncCOMMag[0]["ctrl"] == [1.0]
+
+
+def test_extract_commag_arrays_applies_min_segment_count_masking():
+    va = SimpleNamespace(
+        syncCOMMag=[{"exp": [1.0, 2.0], "ctrl": [3.0, 4.0]}],
+        syncCOMMagN=[{"exp": [2, 1], "ctrl": [0, 3]}],
+    )
+
+    exp, ctrl, n_exp, n_ctrl = _extract_commag_arrays(
+        [va], SimpleNamespace(btw_rwd_sync_bucket_min_trajectories=2)
+    )
+
+    np.testing.assert_allclose(exp, [[[1.0, np.nan]]])
+    np.testing.assert_allclose(ctrl, [[[np.nan, 4.0]]])
+    np.testing.assert_array_equal(n_exp, [[[2, 1]]])
+    np.testing.assert_array_equal(n_ctrl, [[[0, 3]]])

--- a/test/reference/bundles/commag_paper_manifest.json
+++ b/test/reference/bundles/commag_paper_manifest.json
@@ -1,0 +1,685 @@
+{
+  "bundles": [
+    {
+      "arrays": {
+        "btw_rwd_sync_bucket_min_trajectories": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "f13ee6ed54ea2aae9fc49a9faeb5da6e8ddef0e12ed5d30d35a624ae813e0485",
+          "shape": []
+        },
+        "bucket_len_min": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "24b1f4ef66b650ff816e519b01742ff1753733d36e1b4c3e3b52743168915b1f",
+          "shape": []
+        },
+        "commagN_ctrl": {
+          "dtype": "int64",
+          "finite_count": 1242,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "ed8b08355536777e67814aa38f63b3ba4f1cf2ca624e2546029615f7884810b0",
+          "shape": [
+            69,
+            3,
+            6
+          ]
+        },
+        "commagN_exp": {
+          "dtype": "int64",
+          "finite_count": 1242,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "d5b8a0ad01b0787edf332b493dbab4cb05254c81c3bc38498605e1a8d48bb02e",
+          "shape": [
+            69,
+            3,
+            6
+          ]
+        },
+        "commag_ctrl": {
+          "dtype": "float64",
+          "finite_count": 878,
+          "kind": "numeric",
+          "nan_count": 364,
+          "sha256": "cee35303fc52c4d6eb1a94cac20b1b99dd6ea919e761a178b058ea284e56694c",
+          "shape": [
+            69,
+            3,
+            6
+          ]
+        },
+        "commag_exp": {
+          "dtype": "float64",
+          "finite_count": 919,
+          "kind": "numeric",
+          "nan_count": 323,
+          "sha256": "35ddb79e0cea4ef994c722998ab722973b5964cdaf63d27e209c4fd629ff1592",
+          "shape": [
+            69,
+            3,
+            6
+          ]
+        },
+        "group_label": {
+          "dtype": "object",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "3d08ba1cb0dff4442a18ba6258e18780ad45f5802d65ad029a519bc4817d171c",
+          "shape": []
+        },
+        "sli": {
+          "dtype": "float64",
+          "finite_count": 62,
+          "kind": "numeric",
+          "nan_count": 7,
+          "sha256": "31fdbb97d3b48656fd3f11913c909063984a407f43dcd919cd7d010b31caef37",
+          "shape": [
+            69
+          ]
+        },
+        "sli_select_keep_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "sli_select_skip_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "sli_training_idx": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "sli_ts": {
+          "dtype": "float64",
+          "finite_count": 847,
+          "kind": "numeric",
+          "nan_count": 395,
+          "sha256": "d0c722c678aba09e7409135f820bc1b95b4938c0ccb9b87cd7658ba6d3230cec",
+          "shape": [
+            69,
+            3,
+            6
+          ]
+        },
+        "sli_use_training_mean": {
+          "dtype": "bool",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "a2709fcbfdeb023a70c53c31628d48d9306c5f4772ab12de7b67b66f3bf34fa7",
+          "shape": []
+        },
+        "training_names": {
+          "dtype": "object",
+          "finite_count": 3,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "4860b8926b4845ace4d18e00fcbf676c260d49d4d5ebe5df07e1aee6693e70f2",
+          "shape": [
+            3
+          ]
+        },
+        "video_ids": {
+          "dtype": "<U77",
+          "finite_count": 69,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "9242d4fcf88dee42c16d3fd736097f56281fbee20201cd164caa753a22b91071",
+          "shape": [
+            69
+          ]
+        }
+      },
+      "keys": [
+        "btw_rwd_sync_bucket_min_trajectories",
+        "bucket_len_min",
+        "commagN_ctrl",
+        "commagN_exp",
+        "commag_ctrl",
+        "commag_exp",
+        "group_label",
+        "sli",
+        "sli_select_keep_first_sync_buckets",
+        "sli_select_skip_first_sync_buckets",
+        "sli_training_idx",
+        "sli_ts",
+        "sli_use_training_mean",
+        "training_names",
+        "video_ids"
+      ],
+      "name": "intact_ctrl_2026_04_13",
+      "path": "exports/com_dist_intact_ctrlKir_flatLgc_inclWall_meanMag_2026-04-13.npz",
+      "sha256": "d15f7aef79878b090c9ad3ccc886c943da8a046841bf96bdd5bc20bbd78b51ec"
+    },
+    {
+      "arrays": {
+        "btw_rwd_sync_bucket_min_trajectories": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "f13ee6ed54ea2aae9fc49a9faeb5da6e8ddef0e12ed5d30d35a624ae813e0485",
+          "shape": []
+        },
+        "bucket_len_min": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "24b1f4ef66b650ff816e519b01742ff1753733d36e1b4c3e3b52743168915b1f",
+          "shape": []
+        },
+        "commagN_ctrl": {
+          "dtype": "int64",
+          "finite_count": 1098,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "3b2954377765a389116bc0f5b35755972f139aa163d3c62d9d9c47718361a96a",
+          "shape": [
+            61,
+            3,
+            6
+          ]
+        },
+        "commagN_exp": {
+          "dtype": "int64",
+          "finite_count": 1098,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "2f5d9ac8f1e557b160b4caf8f1df68e9734b498432ff302970ae2e0c7f60f31d",
+          "shape": [
+            61,
+            3,
+            6
+          ]
+        },
+        "commag_ctrl": {
+          "dtype": "float64",
+          "finite_count": 676,
+          "kind": "numeric",
+          "nan_count": 422,
+          "sha256": "18e253798e816d53dc733b90b12057df300f24f2227f56a3b9df1874a5f51897",
+          "shape": [
+            61,
+            3,
+            6
+          ]
+        },
+        "commag_exp": {
+          "dtype": "float64",
+          "finite_count": 731,
+          "kind": "numeric",
+          "nan_count": 367,
+          "sha256": "fdc1ec4c9e13f13830d5ac53e31f55ace8b93fa3cfe46c4111b914e32686feed",
+          "shape": [
+            61,
+            3,
+            6
+          ]
+        },
+        "group_label": {
+          "dtype": "object",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "eb680b0cb9588cbc38734cb626aa8cbba8c339b765b7608fd311292fe1cb2cc1",
+          "shape": []
+        },
+        "sli": {
+          "dtype": "float64",
+          "finite_count": 52,
+          "kind": "numeric",
+          "nan_count": 9,
+          "sha256": "6f8aec8a03575bd0f377321fbda947f9b2bb137a4a7d02d19abfc5108263c6ca",
+          "shape": [
+            61
+          ]
+        },
+        "sli_select_keep_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "sli_select_skip_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "sli_training_idx": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "sli_ts": {
+          "dtype": "float64",
+          "finite_count": 698,
+          "kind": "numeric",
+          "nan_count": 400,
+          "sha256": "f5342732a54f3cb0c3c3884976e0e5d0bd15138d5ae0b3f1172b081e117c4646",
+          "shape": [
+            61,
+            3,
+            6
+          ]
+        },
+        "sli_use_training_mean": {
+          "dtype": "bool",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "a2709fcbfdeb023a70c53c31628d48d9306c5f4772ab12de7b67b66f3bf34fa7",
+          "shape": []
+        },
+        "training_names": {
+          "dtype": "object",
+          "finite_count": 3,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "4860b8926b4845ace4d18e00fcbf676c260d49d4d5ebe5df07e1aee6693e70f2",
+          "shape": [
+            3
+          ]
+        },
+        "video_ids": {
+          "dtype": "<U77",
+          "finite_count": 61,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "abf0dc060c8feb451a3d022a7f25453b53789fa16b561d0ef5ef2091680dca6e",
+          "shape": [
+            61
+          ]
+        }
+      },
+      "keys": [
+        "btw_rwd_sync_bucket_min_trajectories",
+        "bucket_len_min",
+        "commagN_ctrl",
+        "commagN_exp",
+        "commag_ctrl",
+        "commag_exp",
+        "group_label",
+        "sli",
+        "sli_select_keep_first_sync_buckets",
+        "sli_select_skip_first_sync_buckets",
+        "sli_training_idx",
+        "sli_ts",
+        "sli_use_training_mean",
+        "training_names",
+        "video_ids"
+      ],
+      "name": "intact_pfn_2026_04_13",
+      "path": "exports/com_dist_intact_pfnKir_flatLgc_inclWall_meanMag_2026-04-13.npz",
+      "sha256": "47fee62049b6bbcac1ac9cedac0be62a131be9fbb36dba30620bc5f4810ace5a"
+    },
+    {
+      "arrays": {
+        "btw_rwd_sync_bucket_min_trajectories": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "f13ee6ed54ea2aae9fc49a9faeb5da6e8ddef0e12ed5d30d35a624ae813e0485",
+          "shape": []
+        },
+        "bucket_len_min": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "24b1f4ef66b650ff816e519b01742ff1753733d36e1b4c3e3b52743168915b1f",
+          "shape": []
+        },
+        "commagN_ctrl": {
+          "dtype": "int64",
+          "finite_count": 1188,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "16a3b41a669b7de46bc12500c5c25370d55d2328db28fdc02bc653856ce9ff31",
+          "shape": [
+            66,
+            3,
+            6
+          ]
+        },
+        "commagN_exp": {
+          "dtype": "int64",
+          "finite_count": 1188,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "825d5ca4341d0f38c7d4b504e6a04d83a1e71cd57b3852288257670f73c9b32f",
+          "shape": [
+            66,
+            3,
+            6
+          ]
+        },
+        "commag_ctrl": {
+          "dtype": "float64",
+          "finite_count": 719,
+          "kind": "numeric",
+          "nan_count": 469,
+          "sha256": "5a07fbdba63bd49b24b90aea2014d03d09770f21ae30129d4d9e4177f19b699c",
+          "shape": [
+            66,
+            3,
+            6
+          ]
+        },
+        "commag_exp": {
+          "dtype": "float64",
+          "finite_count": 737,
+          "kind": "numeric",
+          "nan_count": 451,
+          "sha256": "c81d427d6f04fd846d44fa23ad6fccb33ce59edbffb7d46fd31d58464c5586a6",
+          "shape": [
+            66,
+            3,
+            6
+          ]
+        },
+        "group_label": {
+          "dtype": "object",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "eca1741183edc24ddf780d8e55ddf93a54b4aa8a8f233054a97357765f01cab2",
+          "shape": []
+        },
+        "sli": {
+          "dtype": "float64",
+          "finite_count": 55,
+          "kind": "numeric",
+          "nan_count": 11,
+          "sha256": "a8196f842f5c6fcf023d7bb3e3d6e825e165dde52ac6da721d70cef063cd0553",
+          "shape": [
+            66
+          ]
+        },
+        "sli_select_keep_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "sli_select_skip_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "sli_training_idx": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "sli_ts": {
+          "dtype": "float64",
+          "finite_count": 714,
+          "kind": "numeric",
+          "nan_count": 474,
+          "sha256": "a05bc6b4630ede45a61d098b7f71e3ff9c709731ea20869503b9b78c35bee2fa",
+          "shape": [
+            66,
+            3,
+            6
+          ]
+        },
+        "sli_use_training_mean": {
+          "dtype": "bool",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "a2709fcbfdeb023a70c53c31628d48d9306c5f4772ab12de7b67b66f3bf34fa7",
+          "shape": []
+        },
+        "training_names": {
+          "dtype": "object",
+          "finite_count": 3,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "4860b8926b4845ace4d18e00fcbf676c260d49d4d5ebe5df07e1aee6693e70f2",
+          "shape": [
+            3
+          ]
+        },
+        "video_ids": {
+          "dtype": "<U77",
+          "finite_count": 66,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "b08398ff7eed90d810d604ccae4cf8f80597ffc45c14ad4a90d57238fc3c22d0",
+          "shape": [
+            66
+          ]
+        }
+      },
+      "keys": [
+        "btw_rwd_sync_bucket_min_trajectories",
+        "bucket_len_min",
+        "commagN_ctrl",
+        "commagN_exp",
+        "commag_ctrl",
+        "commag_exp",
+        "group_label",
+        "sli",
+        "sli_select_keep_first_sync_buckets",
+        "sli_select_skip_first_sync_buckets",
+        "sli_training_idx",
+        "sli_ts",
+        "sli_use_training_mean",
+        "training_names",
+        "video_ids"
+      ],
+      "name": "ar_ctrl_2026_04_28",
+      "path": "exports/com_dist_ar_ctrlKir_flatLgc_inclWall_meanMag_2026-04-28.npz",
+      "sha256": "bdc7845e78c985aad8b476b0b8529ad69338341a14351efe7559b4a612356585"
+    },
+    {
+      "arrays": {
+        "btw_rwd_sync_bucket_min_trajectories": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "f13ee6ed54ea2aae9fc49a9faeb5da6e8ddef0e12ed5d30d35a624ae813e0485",
+          "shape": []
+        },
+        "bucket_len_min": {
+          "dtype": "float64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "24b1f4ef66b650ff816e519b01742ff1753733d36e1b4c3e3b52743168915b1f",
+          "shape": []
+        },
+        "commagN_ctrl": {
+          "dtype": "int64",
+          "finite_count": 1098,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "3b2954377765a389116bc0f5b35755972f139aa163d3c62d9d9c47718361a96a",
+          "shape": [
+            61,
+            3,
+            6
+          ]
+        },
+        "commagN_exp": {
+          "dtype": "int64",
+          "finite_count": 1098,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "2f5d9ac8f1e557b160b4caf8f1df68e9734b498432ff302970ae2e0c7f60f31d",
+          "shape": [
+            61,
+            3,
+            6
+          ]
+        },
+        "commag_ctrl": {
+          "dtype": "float64",
+          "finite_count": 676,
+          "kind": "numeric",
+          "nan_count": 422,
+          "sha256": "18e253798e816d53dc733b90b12057df300f24f2227f56a3b9df1874a5f51897",
+          "shape": [
+            61,
+            3,
+            6
+          ]
+        },
+        "commag_exp": {
+          "dtype": "float64",
+          "finite_count": 731,
+          "kind": "numeric",
+          "nan_count": 367,
+          "sha256": "fdc1ec4c9e13f13830d5ac53e31f55ace8b93fa3cfe46c4111b914e32686feed",
+          "shape": [
+            61,
+            3,
+            6
+          ]
+        },
+        "group_label": {
+          "dtype": "object",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "eb680b0cb9588cbc38734cb626aa8cbba8c339b765b7608fd311292fe1cb2cc1",
+          "shape": []
+        },
+        "sli": {
+          "dtype": "float64",
+          "finite_count": 52,
+          "kind": "numeric",
+          "nan_count": 9,
+          "sha256": "6f8aec8a03575bd0f377321fbda947f9b2bb137a4a7d02d19abfc5108263c6ca",
+          "shape": [
+            61
+          ]
+        },
+        "sli_select_keep_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+          "shape": []
+        },
+        "sli_select_skip_first_sync_buckets": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "sli_training_idx": {
+          "dtype": "int64",
+          "finite_count": 1,
+          "kind": "numeric",
+          "nan_count": 0,
+          "sha256": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+          "shape": []
+        },
+        "sli_ts": {
+          "dtype": "float64",
+          "finite_count": 698,
+          "kind": "numeric",
+          "nan_count": 400,
+          "sha256": "f5342732a54f3cb0c3c3884976e0e5d0bd15138d5ae0b3f1172b081e117c4646",
+          "shape": [
+            61,
+            3,
+            6
+          ]
+        },
+        "sli_use_training_mean": {
+          "dtype": "bool",
+          "finite_count": 1,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "a2709fcbfdeb023a70c53c31628d48d9306c5f4772ab12de7b67b66f3bf34fa7",
+          "shape": []
+        },
+        "training_names": {
+          "dtype": "object",
+          "finite_count": 3,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "4860b8926b4845ace4d18e00fcbf676c260d49d4d5ebe5df07e1aee6693e70f2",
+          "shape": [
+            3
+          ]
+        },
+        "video_ids": {
+          "dtype": "<U77",
+          "finite_count": 61,
+          "kind": "string",
+          "nan_count": 0,
+          "sha256": "abf0dc060c8feb451a3d022a7f25453b53789fa16b561d0ef5ef2091680dca6e",
+          "shape": [
+            61
+          ]
+        }
+      },
+      "keys": [
+        "btw_rwd_sync_bucket_min_trajectories",
+        "bucket_len_min",
+        "commagN_ctrl",
+        "commagN_exp",
+        "commag_ctrl",
+        "commag_exp",
+        "group_label",
+        "sli",
+        "sli_select_keep_first_sync_buckets",
+        "sli_select_skip_first_sync_buckets",
+        "sli_training_idx",
+        "sli_ts",
+        "sli_use_training_mean",
+        "training_names",
+        "video_ids"
+      ],
+      "name": "intact_pfn_2026_04_28",
+      "path": "exports/com_dist_intact_pfnKir_flatLgc_inclWall_meanMag_2026-04-28.npz",
+      "sha256": "47fee62049b6bbcac1ac9cedac0be62a131be9fbb36dba30620bc5f4810ace5a"
+    }
+  ],
+  "schema_version": 1
+}


### PR DESCRIPTION
## Summary

Adds the three-layer correctness-check rollout for the sync-bucket COM magnitude + SLI bundles used by the COM-distance paper panels.

Layer 1:
- Adds focused COM truth tests for between-reward segment COM semantics.
- Covers reward-center-relative mean segment position, bucket assignment by segment start, endpoint exclusion, finite-coordinate filtering, median-distance filtering, wall-contact filtering, mean-magnitude bucket aggregation, and min-count masking.

Layer 2:
- Adds COM magnitude regression digest keys.
- Adds a paper COM-distance bundle manifest covering the Panel 9/10/24/25 exports.
- Adds a manifest regression wrapper using the existing bundle digest infrastructure.

Layer 3:
- Adds COM-specific runtime bundle validation.
- Validates COM bundles on export and during SLI bundle load/normalization.
- Checks COM value/count shape alignment, finite nonnegative magnitudes, count array integrity, count-threshold masking semantics, SLI metadata alignment, and bucket/min-count metadata sanity.

## Tests

- `pytest test/paper_metrics -q`