### PR TITLE
Add opt-in behavior state analysis and trajectory plots

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -4357,6 +4357,52 @@ g.add_argument(
     ),
 )
 g.add_argument(
+    "--behavior-state-plots",
+    action="store_true",
+    help=(
+        "Write color-coded trajectory plots for opt-in behavior states. "
+        "Implies --behavior-state-analysis."
+    ),
+)
+g.add_argument(
+    "--behavior-state-plot-minimal",
+    action="store_true",
+    help="Render behavior-state trajectory plots in minimal mode.",
+)
+g.add_argument(
+    "--behavior-state-plot-trn",
+    type=int,
+    default=None,
+    help=(
+        "1-based training index to plot for behavior-state trajectories. "
+        "If omitted and no explicit frame window is supplied, the whole trajectory is plotted."
+    ),
+)
+g.add_argument(
+    "--behavior-state-plot-start-frame",
+    type=int,
+    default=None,
+    help="Optional start frame for behavior-state trajectory plots.",
+)
+g.add_argument(
+    "--behavior-state-plot-stop-frame",
+    type=int,
+    default=None,
+    help="Optional stop frame for behavior-state trajectory plots.",
+)
+g.add_argument(
+    "--behavior-state-plot-pad",
+    type=int,
+    default=0,
+    help="Frames of context to add on both sides of behavior-state trajectory plots.",
+)
+g.add_argument(
+    "--behavior-state-plot-out-dir",
+    type=str,
+    default="imgs/behavior_states",
+    help="Output directory for behavior-state trajectory plots.",
+)
+g.add_argument(
     "--turn-dir",
     action="store_true",
     help="analyze directionality of agarose- and/or boundary-anchored turns",
@@ -10215,6 +10261,47 @@ def _generate_between_reward_plots(vas, *, saved_bottom=None, saved_top=None):
                     )
 
 
+def _generate_behavior_state_plots(vas):
+    if not getattr(opts, "behavior_state_plots", False):
+        return
+
+    trn_index = (
+        int(opts.behavior_state_plot_trn) - 1
+        if getattr(opts, "behavior_state_plot_trn", None) is not None
+        else None
+    )
+    start_frame = getattr(opts, "behavior_state_plot_start_frame", None)
+    stop_frame = getattr(opts, "behavior_state_plot_stop_frame", None)
+    out_dir = getattr(opts, "behavior_state_plot_out_dir", "imgs/behavior_states")
+
+    for va in vas:
+        for trj in va.trx:
+            if va._bad(trj.f):
+                continue
+
+            try:
+                role_idx = va.flies.index(trj.f)
+            except Exception:
+                role_idx = int(trj.f)
+
+            plotter = EventChainPlotter(
+                trj,
+                va,
+                y_bounds=None,
+                image_format=opts.imageFormat,
+            )
+            plotter.plot_behavior_state_trajectory(
+                trn_index=trn_index,
+                start_frame=start_frame,
+                stop_frame=stop_frame,
+                pad=int(getattr(opts, "behavior_state_plot_pad", 0) or 0),
+                minimal=bool(getattr(opts, "behavior_state_plot_minimal", False)),
+                out_dir=out_dir,
+                image_format=opts.imageFormat,
+                role_idx=role_idx,
+            )
+
+
 def _iter_group_vas(vas, gis, gls):
     ng = int(gis.max()) + 1 if len(gis) else 0
     for gi in range(ng):
@@ -10326,6 +10413,7 @@ def _emit_default_between_reward_sli_plots(vas, gis, gls):
 
 def postAnalyze(vas):
     if len(vas) <= 1:
+        _generate_behavior_state_plots(vas)
         _generate_between_reward_plots(vas)
         return
 
@@ -10710,6 +10798,7 @@ def postAnalyze(vas):
         saved_bottom=saved_bottom,
         saved_top=saved_top,
     )
+    _generate_behavior_state_plots(vas)
 
     for tc in tcs:
         tp, calc = typeCalc(tc)
@@ -14347,6 +14436,9 @@ if __name__ == "__main__":
         opts.turn.remove("reward")
     else:
         opts.rTurnAnlyz = False
+
+    if getattr(opts, "behavior_state_plots", False):
+        opts.behavior_state_analysis = True
 
     # If polar wants wall-contact exclusion, we must compute wall contact
     if getattr(opts, "btw_rwd_polar_exclude_wall_contact", False):

--- a/analyze.py
+++ b/analyze.py
@@ -4347,6 +4347,16 @@ g.add_argument(
     nargs="+",
 )
 g.add_argument(
+    "--behavior-state-analysis",
+    action="store_true",
+    help=(
+        "Opt in to frame-wise behavior state detection for turn/run/rest. "
+        "This mirrors tmp/behaviorseg.py: turn detection combines angular speed "
+        "with head-body speed difference, then non-turn frames are split into "
+        "run/rest by a Schmitt trigger on body speed."
+    ),
+)
+g.add_argument(
     "--turn-dir",
     action="store_true",
     help="analyze directionality of agarose- and/or boundary-anchored turns",

--- a/src/analysis/behavior_states.py
+++ b/src/analysis/behavior_states.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import IntEnum
+
+import numpy as np
+from scipy.signal import savgol_filter
+
+
+class BehaviorState(IntEnum):
+    REST = 0
+    TURN = 1
+    RUN = 2
+
+
+@dataclass(frozen=True)
+class BehaviorStateConfig:
+    angular_small_turn_rad_s: float = 80.0 * np.pi / 180.0
+    angular_large_turn_rad_s: float = 120.0 * np.pi / 180.0
+    head_body_small_turn_mm_s: float = 1.0
+    head_body_large_turn_mm_s: float = 1.5
+    run_low_mm_s: float = 1.0
+    run_high_mm_s: float = 3.0
+    savgol_order: int = 3
+    savgol_window: int = 5
+    angular_mask_shift_frames: int = 2
+    head_body_shift_frames: int = 4
+    turn_score_threshold: float = 1.8
+    head_vertex_axis_fraction: float = 0.5
+
+
+DEFAULT_BEHAVIOR_STATE_CONFIG = BehaviorStateConfig()
+
+
+def _reference_savgol_filter(
+    values: np.ndarray,
+    *,
+    order: int = DEFAULT_BEHAVIOR_STATE_CONFIG.savgol_order,
+    window: int = DEFAULT_BEHAVIOR_STATE_CONFIG.savgol_window,
+) -> np.ndarray:
+    out = np.asarray(values, dtype=np.float64).copy()
+    finite = np.isfinite(out)
+    if np.count_nonzero(finite) > window:
+        out[finite] = savgol_filter(out[finite], window, order)
+    return out
+
+
+def _shift_left_zero_tail(values: np.ndarray, frames: int) -> np.ndarray:
+    out = np.roll(values, -frames)
+    if frames > 0:
+        out[-frames:] = 0
+    return out
+
+
+def schmitt(values: np.ndarray, *, high: float, low: float) -> np.ndarray:
+    values = np.asarray(values, dtype=np.float64)
+    out = (values > high).astype(np.int8)
+    out[values < low] = -1
+
+    nonzero = np.flatnonzero(out)
+    if nonzero.size == 0:
+        return np.zeros_like(out, dtype=np.int8)
+
+    out[0] = out[nonzero[0]]
+    for i in np.floatnonzero(out == 0):
+        out[i] = out[i - 1]
+    out[out == -1] = 0
+    return out.astype(np.int8)
+
+
+def translational_speed_mm_s(
+    x_px: np.ndarray,
+    y_px: np.ndarray,
+    *,
+    fps: float,
+    px_per_mm: float,
+    dt_s: np.ndarray | None = None,
+    config: BehaviorStateConfig = DEFAULT_BEHAVIOR_STATE_CONFIG,
+):
+    x = np.asarray(x_px, dtype=np.float64)
+    y = np.asarray(y_px, dtype=np.float64)
+    dr_px = np.hypos(np.diff(x), np.diff(y))
+    dr_px = np.append(dr_px[0] if dr_px.size else np.nan, dr_px)
+    if dt_s is None:
+        dt = np.full_like(dr_px, 1.0 / float(fps), dtype=np.float64)
+    else:
+        dt = np.asarray(dt_s, dtype=np.float64)
+    speed = dr_px / dt / float(px_per_mm)
+    return _reference_savgol_filter(
+        speed, order=config.savgol_order, window=config.savgol_window
+    )
+
+
+def rotational_speed_rad_s(
+    heading_deg: np.ndarray,
+    *,
+    fps: float,
+    dt_s: np.ndarray | None = None,
+    config: BehaviorStateConfig = DEFAULT_BEHAVIOR_STATE_CONFIG,
+) -> np.ndarray:
+    heading = np.deg2rad(np.asarray(heading_deg, dtype=np.float64))
+    da = np.append(0.0, np.diff(heading))
+    da[da > np.pi] -= 2 * np.pi
+    da[da < -np.pi] += 2 * np.pi
+    if dt_s is None:
+        dt = np.full_like(da, 1.0 / float(fps), dtype=np.float64)
+    else:
+        dt = np.asarray(dt_s, dtype=np.float64)
+    return _reference_savgol_filter(
+        da / dt, order=config.savgol_order, window=config.savgol_window
+    )
+
+
+def head_vertex_xy_px(
+    x_px: np.ndarray,
+    y_px: np.ndarray,
+    major_axis_px: np.ndarray,
+    heading_deg: np.ndarray,
+    *,
+    config: BehaviorStateConfig = DEFAULT_BEHAVIOR_STATE_CONFIG,
+) -> tuple[np.ndarray, np.ndarray]:
+    x = np.asarray(x_px, dtype=np.float64)
+    y = np.asarray(y_px, dtype=np.float64)
+    major = np.asarray(major_axis_px, dtype=np.float64)
+    theta = np.deg2rad(np.asarray(heading_deg, dtype=np.float64))
+    radius = major * float(config.head_vertex_axis_fraction)
+    return x + radius * np.sin(theta), y - radius * np.cos(theta)
+
+
+def find_turns(
+    angular_speed_rad_s: np.ndarray,
+    head_speed_mm_s: np.ndarray,
+    body_speed_mm_s: np.ndarray,
+    *,
+    config: BehaviorStateConfig = DEFAULT_BEHAVIOR_STATE_CONFIG,
+) -> np.ndarray:
+    angular_speed = np.asarray(angular_speed_rad_s, dtype=np.float64)
+    head_speed = np.asarray(head_speed_mm_s, dtype=np.float64)
+    body_speed = np.asarray(body_speed_mm_s, dtype=np.float64)
+
+    turns_mask1 = (np.abs(angular_speed) > config.angular_small_turn_rad_s).astype(
+        float
+    ) + 1.5 * (np.abs(angular_speed) > config.angular_large_turn_rad_s).astype(float)
+    turns_mask1 = _shift_left_zero_tail(turns_mask1, config.angular_mask_shift_frames)
+
+    head_body_diff = _shift_left_zero_tail(
+        head_speed - body_speed, config.head_body_shift_frames
+    )
+    turns_mask2 = 0.5 * (head_body_diff > config.head_body_small_turn_mm_s).astype(
+        float
+    ) + (head_body_diff > config.head_body_large_turn_mm_s).astype(float)
+
+    turn_score = _reference_savgol_filter(
+        turns_mask1, order=config.savgol_order, window=config.savgol_window
+    ) + _reference_savgol_filter(
+        turns_mask2, order=config.savgol_order, window=config.savgol_window
+    )
+    return turn_score >= config.turn_score_threshold
+
+
+def classify_behavior_states(
+    body_speed_mm_s: np.ndarray,
+    angular_speed_rad_s: np.ndarray,
+    head_speed_mm_s: np.ndarray,
+    *,
+    config: BehaviorStateConfig = DEFAULT_BEHAVIOR_STATE_CONFIG,
+) -> np.ndarray:
+    states = np.full(len(body_speed_mm_s), BehaviorState.REST, dtype=np.int8)
+    turn_mask = find_turns(
+        angular_speed_rad_s, head_speed_mm_s, body_speed_mm_s, config=config
+    )
+    states[turn_mask] = BehaviorState.TURN
+
+    speed = _reference_savgol_filter(
+        body_speed_mm_s, order=config.savgol_order, window=config.savgol_window
+    )
+    walking = schmitt(speed, high=config.run_high_mm_s, low=config.run_low_mm_s)
+    run_mask = (states != BehaviorState.TURN) & (walking > 0)
+    states[run_mask] = BehaviorState.RUN
+    return states
+
+
+def analyze_trajectory_behavior_states(
+    trj, *, config: BehaviorStateConfig = DEFAULT_BEHAVIOR_STATE_CONFIG
+) -> np.ndarray | None:
+    if trj.bad() or trj.theta is None or trj.h is None or not trj.va:
+        return None
+
+    px_per_mm = trj.va.ct.pxPerMmFloor() * getattr(trj.va.xf, "fctr", 1.0)
+    dt_s = _trajectory_dt_s(trj)
+    body_speed = translational_speed_mm_s(
+        trj.x, trj.y, fps=trj.va.fps, px_per_mm=px_per_mm, dt_s=dt_s, config=config
+    )
+    head_x, head_y = head_vertex_xy_px(trj.x, trj.y, trj.h, trj.theta, config=config)
+    head_speed = translational_speed_mm_s(
+        head_x, head_y, fps=trj.va.fps, px_per_mm=px_per_mm, dt_s=dt_s, config=config
+    )
+    angular_speed = rotational_speed_rad_s(
+        trj.theta, fps=trj.va.fps, dt_s=dt_s, config=config
+    )
+    trj.behavior_body_speed_mm_s = body_speed
+    trj.behavior_head_speed_mm_s = head_speed
+    trj.behavior_angular_speed_rad_s = angular_speed
+    trj.behavior_turn_mask = find_turns(
+        angular_speed, head_speed, body_speed, config=config
+    )
+    trj.behavior_state = classify_behavior_states(
+        body_speed, angular_speed, head_speed, config=config
+    )
+    return trj.behavior_state
+
+
+def _trajectory_dt_s(trj) -> np.ndarray | None:
+    ts = getattr(trj, "ts", None)
+    if ts is None:
+        return None
+
+    ts = np.asarray(ts, dtype=np.float64)
+    if ts.shape != np.asarray(trj.x).shape or ts.size == 0:
+        return None
+
+    fallback_dt = 1.0 / float(trj.va.fps)
+    dt = np.empty_like(ts, dtype=np.float64)
+    dt[0] = fallback_dt
+    if ts.size > 1:
+        dt[1:] = np.diff(ts)
+    bad = ~np.isfinite(dt) | (dt <= 0)
+    if np.any(bad):
+        dt[bad] = fallback_dt
+    return dt

--- a/src/analysis/behavior_states.py
+++ b/src/analysis/behavior_states.py
@@ -62,7 +62,7 @@ def schmitt(values: np.ndarray, *, high: float, low: float) -> np.ndarray:
         return np.zeros_like(out, dtype=np.int8)
 
     out[0] = out[nonzero[0]]
-    for i in np.floatnonzero(out == 0):
+    for i in np.flatnonzero(out == 0):
         out[i] = out[i - 1]
     out[out == -1] = 0
     return out.astype(np.int8)
@@ -79,7 +79,7 @@ def translational_speed_mm_s(
 ):
     x = np.asarray(x_px, dtype=np.float64)
     y = np.asarray(y_px, dtype=np.float64)
-    dr_px = np.hypos(np.diff(x), np.diff(y))
+    dr_px = np.hypot(np.diff(x), np.diff(y))
     dr_px = np.append(dr_px[0] if dr_px.size else np.nan, dr_px)
     if dt_s is None:
         dt = np.full_like(dr_px, 1.0 / float(fps), dtype=np.float64)

--- a/src/analysis/video_analysis.py
+++ b/src/analysis/video_analysis.py
@@ -80,6 +80,7 @@ from src.analysis.contact_event_training_comparison import (
 from src.analysis.between_reward_filters import (
     min_between_reward_sync_bucket_trajectories,
 )
+from src.analysis.behavior_states import analyze_trajectory_behavior_states
 from src.analysis.ellipse_to_boundary_dist import (
     TrjDataContainer,
     VaDataContainer,
@@ -227,7 +228,7 @@ class VideoAnalysis:
         needs_tp = (
             opts.contact_geometry == "horizontal" and opts.turn_prob_by_dist
         ) or (opts.contact_geometry == "circular" and opts.outside_circle_radii)
-        if needs_tp:
+        if needs_tp or getattr(opts, "behavior_state_analysis", False):
             opts.chooseOrientations = True
 
         if (
@@ -245,6 +246,8 @@ class VideoAnalysis:
         self._initTrx()
         self._initSlots()
         self._readNoteFile(fn)  # possibly overrides whether trajectories bad
+        if getattr(opts, "behavior_state_analysis", False):
+            self._analyzeBehaviorStates()
         if opts.circle:
             self._analyzeCircularAndTurningMotion()
         self.runBoundaryContactAnalyses()
@@ -2568,6 +2571,32 @@ class VideoAnalysis:
         collator = DataCombiner(self, self.opts)
         collator.combineCircleResults()
         collator.combineTurnResults()
+
+    def _analyzeBehaviorStates(self):
+        """
+        Opt-in frame-wise turn/run/rest classification.
+
+        The detector mirrors the reference behaviorseg.py method: turns are scored
+        from angular speed and the head-body speed difference; non-turn frames are
+        split into run/rest with a Schmitt trigger on body speed.
+        """
+        print("\nanalyzing behavior states (turn/run/rest)...")
+        self.behavior_state_counts = []
+        for trj in self.trx:
+            states = analyze_trajectory_behavior_states(trj)
+            if states is None:
+                self.behavior_state_counts.append({})
+                continue
+            counts = {
+                "rest": int(np.count_nonzero(states == 0)),
+                "turn": int(np.count_nonzero(states == 1)),
+                "run": int(np.count_nonzero(states == 2)),
+            }
+            self.behavior_state_counts.append(counts)
+            print(
+                "  f%d: rest=%d, turn=%d, run=%d"
+                % (trj.f + 1, counts["rest"], counts["turn"], counts["run"])
+            )
 
     def calcOnRegionVisitDurationsForCsv(self, region_label):
         """

--- a/src/plotting/event_chain_plotter.py
+++ b/src/plotting/event_chain_plotter.py
@@ -9,6 +9,10 @@ import matplotlib.patches as patches
 import matplotlib.pyplot as plt
 import numpy as np
 
+from src.analysis.behavior_states import (
+    BehaviorState,
+    analyze_trajectory_behavior_states,
+)
 from src.utils.common import writeImage
 from src.utils.constants import CONTACT_BUFFER_OFFSETS
 
@@ -4481,6 +4485,326 @@ class EventChainPlotter:
         plt.close(fig)
 
         print(f"[plot_between_reward_interval] wrote {out_path}")
+
+    def plot_behavior_state_trajectory(
+        self,
+        *,
+        trn_index: int | None = None,
+        start_frame: int | None = None,
+        stop_frame: int | None = None,
+        pad: int = 0,
+        minimal: bool = False,
+        out_dir: str | None = None,
+        image_format: str | None = None,
+        role_idx: int | None = None,
+    ):
+        """
+        Plot a trajectory window color-coded by behavior state.
+
+        States are expected on ``trj.behavior_state`` and are generated on demand
+        if absent. Colors follow the opt-in detector labels:
+        rest = grey, turn = orange/red, run = blue/green.
+        """
+        image_format = image_format or self.image_format
+        states = getattr(self.trj, "behavior_state", None)
+        if states is None:
+            states = analyze_trajectory_behavior_states(self.trj)
+        if states is None:
+            print(
+                f"[plot_behavior_state_trajectory] No behavior states for fly {self.trj.f}; skipping."
+            )
+            return
+
+        states = np.asarray(states, dtype=np.int8)
+        n_frames = min(len(self.x), len(self.y), len(states))
+        if n_frames < 2:
+            print("[plot_behavior_state_trajectory] Too few frames to plot; skipping.")
+            return
+
+        if start_frame is None or stop_frame is None:
+            if trn_index is not None:
+                if trn_index < 0 or trn_index >= len(self.va.trns):
+                    print(
+                        f"[plot_behavior_state_trajectory] Invalid trn_index={trn_index}; "
+                        f"valid range is 0..{len(self.va.trns) - 1}"
+                    )
+                    return
+                trn = self.va.trns[trn_index]
+                if start_frame is None:
+                    start_frame = int(trn.start)
+                if stop_frame is None:
+                    stop_frame = int(trn.stop)
+            else:
+                if start_frame is None:
+                    start_frame = 0
+                if stop_frame is None:
+                    stop_frame = n_frames - 1
+
+        start_frame = max(0, int(start_frame) - int(pad))
+        stop_frame = min(n_frames - 1, int(stop_frame) + int(pad))
+        if stop_frame <= start_frame:
+            print(
+                f"[plot_behavior_state_trajectory] Empty frame window "
+                f"{start_frame}-{stop_frame}; skipping."
+            )
+            return
+
+        floor_coords = list(
+            self.va.ct.floor(self.va.xf, f=self.va.nef * (self.trj.f) + self.va.ef)
+        )
+        top_left, bottom_right = floor_coords[0], floor_coords[1]
+        padding_x = (bottom_right[0] - top_left[0]) * 0.1
+        padding_y = (top_left[1] - bottom_right[1]) * 0.1
+        contact_buffer_px = (
+            self.va.ct.pxPerMmFloor()
+            * self.va.xf.fctr
+            * CONTACT_BUFFER_OFFSETS["wall"]["max"]
+        )
+
+        reward_circles = []
+        seen_reward_circle_keys = set()
+        for ti, trn in enumerate(getattr(self.va, "trns", [])):
+            if int(getattr(trn, "stop", -1)) < start_frame:
+                continue
+            if int(getattr(trn, "start", n_frames)) > stop_frame:
+                continue
+            try:
+                circle = trn.circles(self.trj.f)[0]
+            except Exception:
+                continue
+            if circle is None:
+                continue
+            try:
+                cx, cy, r = (float(v) for v in circle)
+            except Exception:
+                continue
+            if not np.all(np.isfinite([cx, cy, r])):
+                continue
+
+            key = tuple(np.round([cx, cy, r], 3))
+            if key in seen_reward_circle_keys:
+                for entry in reward_circles:
+                    if entry["key"] == key:
+                        entry["trainings"].append(ti)
+                        break
+                continue
+            seen_reward_circle_keys.add(key)
+            reward_circles.append(
+                {
+                    "key": key,
+                    "circle": (cx, cy, r),
+                    "trainings": [ti],
+                }
+            )
+
+        colors = {
+            BehaviorState.REST: "#5a3d8f",
+            BehaviorState.TURN: "#d95f02",
+            BehaviorState.RUN: "#1f77b4",
+        }
+        labels = {
+            BehaviorState.REST: "Rest",
+            BehaviorState.TURN: "Turn",
+            BehaviorState.RUN: "Run",
+        }
+
+        fig, ax = plt.subplots(1, 1, figsize=(6.5, 6.5) if minimal else (7.5, 6.5))
+        plt.sca(ax)
+
+        rect = patches.FancyBboxPatch(
+            (top_left[0], top_left[1]),
+            bottom_right[0] - top_left[0],
+            bottom_right[1] - top_left[1],
+            boxstyle="round,pad=0.05,rounding_size=2",
+            linewidth=1,
+            edgecolor="black",
+            facecolor="none",
+            zorder=2,
+        )
+        ax.add_patch(rect)
+
+        try:
+            self._draw_sidewall_contact_region(
+                lower_left_x=top_left[0],
+                lower_left_y=top_left[1],
+                top_left=top_left,
+                bottom_right=bottom_right,
+                contact_buffer_px=contact_buffer_px,
+            )
+        except Exception as e:
+            print(
+                f"[plot_behavior_state_trajectory] Warning: failed to draw contact region: {e}"
+            )
+
+        for ci, entry in enumerate(reward_circles):
+            rcx, rcy, rcr = entry["circle"]
+            trn_nums = [idx + 1 for idx in entry["trainings"]]
+            if len(trn_nums) == 1:
+                circle_label = f"Reward circle T{trn_nums[0]}"
+            else:
+                circle_label = "Reward circle T%s" % ",".join(
+                    str(n) for n in trn_nums
+                )
+            ax.add_patch(
+                plt.Circle(
+                    (rcx, rcy),
+                    rcr,
+                    color=self.reward_circle_color,
+                    fill=False,
+                    linestyle="-",
+                    linewidth=1.5,
+                    zorder=3 + ci,
+                    label=None if minimal else circle_label,
+                )
+            )
+
+        window_states = states[start_frame : stop_frame + 1]
+        used_state_labels = set()
+        for i in range(start_frame, stop_frame):
+            if (
+                np.isnan(self.x[i])
+                or np.isnan(self.y[i])
+                or np.isnan(self.x[i + 1])
+                or np.isnan(self.y[i + 1])
+            ):
+                continue
+
+            state = BehaviorState(int(states[i]))
+            x_start = max(min(self.x[i], bottom_right[0]), top_left[0])
+            x_end = max(min(self.x[i + 1], bottom_right[0]), top_left[0])
+            y_start, y_end = self.y[i], self.y[i + 1]
+            label = None
+            if not minimal and state not in used_state_labels:
+                label = labels[state]
+                used_state_labels.add(state)
+            ax.plot(
+                [x_start, x_end],
+                [y_start, y_end],
+                color=colors[state],
+                linewidth=(
+                    1.35
+                    if state == BehaviorState.TURN
+                    else 1.05 if state == BehaviorState.REST else 0.85
+                ),
+                alpha=(
+                    0.98
+                    if state == BehaviorState.TURN
+                    else 0.95 if state == BehaviorState.REST else 0.86
+                ),
+                solid_capstyle="round",
+                zorder=5 if state != BehaviorState.RUN else 4,
+                label=label,
+            )
+
+        rest_frames = np.arange(start_frame, stop_frame + 1, dtype=int)
+        rest_frames = rest_frames[window_states == int(BehaviorState.REST)]
+        rest_frames = rest_frames[
+            np.isfinite(self.x[rest_frames]) & np.isfinite(self.y[rest_frames])
+        ]
+        if rest_frames.size:
+            marker_step = max(1, int(np.ceil(rest_frames.size / 350)))
+            rest_markers = rest_frames[::marker_step]
+            ax.scatter(
+                self.x[rest_markers],
+                self.y[rest_markers],
+                s=8 if minimal else 12,
+                color=colors[BehaviorState.REST],
+                edgecolors="white" if not minimal else "none",
+                linewidths=0.35 if not minimal else 0.0,
+                alpha=0.95,
+                zorder=6,
+                label=(
+                    None
+                    if minimal or BehaviorState.REST in used_state_labels
+                    else labels[BehaviorState.REST]
+                ),
+            )
+
+        ax.plot(
+            self.x[start_frame],
+            self.y[start_frame],
+            marker="o",
+            color="#2ca02c",
+            markersize=5 if minimal else 7,
+            zorder=7,
+            label=None if minimal else "Window start",
+        )
+        ax.plot(
+            self.x[stop_frame],
+            self.y[stop_frame],
+            marker="o",
+            color="#b22222",
+            markersize=5 if minimal else 7,
+            zorder=7,
+            label=None if minimal else "Window stop",
+        )
+
+        ax.set_xlim(top_left[0] - padding_x, bottom_right[0] + padding_x)
+        ax.set_ylim(bottom_right[1] - padding_y, top_left[1] + padding_y)
+        ax.set_aspect("equal", adjustable="box")
+        ax.axis("off")
+
+        video_id = os.path.splitext(os.path.basename(self.va.fn))[0]
+        fly_idx = self.va.f
+        if role_idx is None:
+            try:
+                role_idx = self.va.flies.index(self.trj.f)
+            except Exception:
+                role_idx = int(self.trj.f)
+        fly_role = "exp" if role_idx == 0 else "yok"
+
+        counts = {
+            state: int(np.count_nonzero(window_states == int(state)))
+            for state in (BehaviorState.REST, BehaviorState.TURN, BehaviorState.RUN)
+        }
+
+        if not minimal:
+            total = max(1, sum(counts.values()))
+            count_text = ", ".join(
+                f"{labels[state].lower()} {counts[state] / total:.1%}"
+                for state in (BehaviorState.REST, BehaviorState.TURN, BehaviorState.RUN)
+            )
+            title_trn = (
+                f" | trn {trn_index + 1}" if trn_index is not None else ""
+            )
+            fig.suptitle(
+                "Behavior-state trajectory\n"
+                f"{video_id}, fly {fly_idx}, {fly_role}{title_trn} | "
+                f"frames {start_frame}-{stop_frame}\n"
+                f"{count_text}",
+                fontsize=12,
+            )
+
+            handles, leg_labels = ax.get_legend_handles_labels()
+            if handles:
+                ax.legend(
+                    handles=handles,
+                    labels=leg_labels,
+                    loc="lower center",
+                    bbox_to_anchor=(0.5, -0.08),
+                    fancybox=True,
+                    shadow=True,
+                    ncol=4,
+                    fontsize=9,
+                )
+
+        if minimal:
+            fig.subplots_adjust(left=0.01, right=0.99, top=0.99, bottom=0.01)
+        else:
+            fig.subplots_adjust(left=0.04, right=0.98, top=0.86, bottom=0.16)
+
+        out_dir = out_dir or os.path.join("imgs", "behavior_states")
+        os.makedirs(out_dir, exist_ok=True)
+        trn_tag = f"trn{trn_index + 1}" if trn_index is not None else "frames"
+        minimal_tag = "_minimal" if minimal else ""
+        out_path = os.path.join(
+            out_dir,
+            f"{video_id}__fly{fly_idx}_role{role_idx}_{trn_tag}_"
+            f"{start_frame}-{stop_frame}{minimal_tag}.{image_format}",
+        )
+        writeImage(out_path, format=image_format)
+        plt.close(fig)
+        print(f"[plot_behavior_state_trajectory] wrote {out_path}")
 
     def plot_between_reward_chain(
         self,

--- a/test/test_behavior_states.py
+++ b/test/test_behavior_states.py
@@ -3,7 +3,7 @@ import numpy as np
 from src.analysis.behavior_states import (
     BehaviorState,
     DEFAULT_BEHAVIOR_STATE_CONFIG,
-    _savgol_like_reference,
+    _reference_savgol_filter,
     analyze_trajectory_behavior_states,
     classify_behavior_states,
     find_turns,
@@ -27,8 +27,8 @@ def _reference_find_turns(angular_speed, head_speed, body_speed):
         + (hbdiff > cfg.head_body_large_turn_mm_s).astype(float)
     )
     return (
-        _savgol_like_reference(turns_mask1)
-        + _savgol_like_reference(turns_mask2)
+        _reference_savgol_filter(turns_mask1)
+        + _reference_savgol_filter(turns_mask2)
         >= cfg.turn_score_threshold
     )
 
@@ -60,7 +60,7 @@ def test_classify_behavior_states_uses_turns_before_run_schmitt():
 
     states = classify_behavior_states(body_speed, angular_speed, head_speed)
     turn_mask = find_turns(angular_speed, head_speed, body_speed)
-    walking = schmitt(_savgol_like_reference(body_speed), high=3.0, low=1.0) > 0
+    walking = schmitt(_reference_savgol_filter(body_speed), high=3.0, low=1.0) > 0
 
     np.testing.assert_array_equal(states == BehaviorState.TURN, turn_mask)
     np.testing.assert_array_equal(states == BehaviorState.RUN, walking & ~turn_mask)

--- a/test/test_behavior_states.py
+++ b/test/test_behavior_states.py
@@ -1,0 +1,102 @@
+import numpy as np
+
+from src.analysis.behavior_states import (
+    BehaviorState,
+    DEFAULT_BEHAVIOR_STATE_CONFIG,
+    _savgol_like_reference,
+    analyze_trajectory_behavior_states,
+    classify_behavior_states,
+    find_turns,
+    schmitt,
+)
+
+
+def _reference_find_turns(angular_speed, head_speed, body_speed):
+    cfg = DEFAULT_BEHAVIOR_STATE_CONFIG
+    turns_mask1 = (
+        (np.abs(angular_speed) > cfg.angular_small_turn_rad_s).astype(float)
+        + 1.5 * (np.abs(angular_speed) > cfg.angular_large_turn_rad_s).astype(float)
+    )
+    turns_mask1 = np.roll(turns_mask1, -2)
+    turns_mask1[-2:] = 0
+
+    hbdiff = np.roll(head_speed - body_speed, -4)
+    hbdiff[-4:] = 0
+    turns_mask2 = (
+        0.5 * (hbdiff > cfg.head_body_small_turn_mm_s).astype(float)
+        + (hbdiff > cfg.head_body_large_turn_mm_s).astype(float)
+    )
+    return (
+        _savgol_like_reference(turns_mask1)
+        + _savgol_like_reference(turns_mask2)
+        >= cfg.turn_score_threshold
+    )
+
+
+def test_find_turns_matches_reference_two_signal_scoring():
+    n = 24
+    angular_speed = np.zeros(n)
+    head_speed = np.ones(n)
+    body_speed = np.ones(n)
+
+    angular_speed[8:11] = DEFAULT_BEHAVIOR_STATE_CONFIG.angular_large_turn_rad_s + 0.2
+    head_speed[10:14] = body_speed[10:14] + 2.0
+
+    expected = _reference_find_turns(angular_speed, head_speed, body_speed)
+
+    np.testing.assert_array_equal(
+        find_turns(angular_speed, head_speed, body_speed), expected
+    )
+    assert np.any(expected)
+
+
+def test_classify_behavior_states_uses_turns_before_run_schmitt():
+    n = 32
+    body_speed = np.r_[np.zeros(8), np.full(16, 4.0), np.zeros(8)]
+    head_speed = body_speed.copy()
+    angular_speed = np.zeros(n)
+    angular_speed[12:15] = DEFAULT_BEHAVIOR_STATE_CONFIG.angular_large_turn_rad_s + 0.2
+    head_speed[14:18] = body_speed[14:18] + 2.0
+
+    states = classify_behavior_states(body_speed, angular_speed, head_speed)
+    turn_mask = find_turns(angular_speed, head_speed, body_speed)
+    walking = schmitt(_savgol_like_reference(body_speed), high=3.0, low=1.0) > 0
+
+    np.testing.assert_array_equal(states == BehaviorState.TURN, turn_mask)
+    np.testing.assert_array_equal(states == BehaviorState.RUN, walking & ~turn_mask)
+    np.testing.assert_array_equal(states == BehaviorState.REST, ~(walking | turn_mask))
+
+
+def test_analyze_trajectory_behavior_states_attaches_reference_signals():
+    class ChamberType:
+        def pxPerMmFloor(self):
+            return 10.0
+
+    class Xformer:
+        fctr = 1.0
+
+    class Video:
+        fps = 10.0
+        ct = ChamberType()
+        xf = Xformer()
+
+    class Trajectory:
+        va = Video()
+        x = np.arange(20, dtype=float)
+        y = np.zeros(20, dtype=float)
+        h = np.full(20, 4.0)
+        theta = np.r_[np.zeros(10), np.full(10, 90.0)]
+
+        def bad(self):
+            return False
+
+    trj = Trajectory()
+
+    states = analyze_trajectory_behavior_states(trj)
+
+    assert states is trj.behavior_state
+    assert states.shape == trj.x.shape
+    assert trj.behavior_body_speed_mm_s.shape == trj.x.shape
+    assert trj.behavior_head_speed_mm_s.shape == trj.x.shape
+    assert trj.behavior_angular_speed_rad_s.shape == trj.x.shape
+    assert trj.behavior_turn_mask.dtype == bool


### PR DESCRIPTION
## Summary
- Add opt-in turn/run/rest behavior state detection based on the reference behaviorseg.py method (from [Haberkern lab repo](https://github.com/degoldschmidt/foraging-processing))
- Store per-frame behavior state and derived speed signals on trajectories
- Add behavior-state trajectory plots with minimal mode and reward-circle overlays
- Add CLI flags for running the analysis and generating visual QA plots
- Add focused tests for the detector logic

## Testing
- pytest -q test/test_behavior_states.py
- python -m py_compile src/analysis/behavior_states.py src/plotting/event_chain_plotter.py analyze.py