### PR TITLE
Keep large-font sync-bucket X labels on one line

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -8681,14 +8681,14 @@ def plotRewards(
                 )
     imgFiles["agarose_per_rwd"] = CONTACT_EVENT_PER_RWD_IMG_FILE % ("edge", "agarose")
     if customizer.font_size_customized:
-        wrap_axis_labels = True
+        wrap_x_axis_labels = True
         try:
-            wrap_axis_labels = float(customizer.font_size) < 20.0
+            wrap_x_axis_labels = float(customizer.font_size) < 20.0
         except (TypeError, ValueError):
             pass
         customizer.adjust_padding_proportionally(
             wrap_legend_labels=False,
-            wrap_axis_labels=wrap_axis_labels,
+            wrap_x_axis_labels=wrap_x_axis_labels,
         )
 
     base, ext = os.path.splitext(imgFiles[tp] % blf)

--- a/analyze.py
+++ b/analyze.py
@@ -8681,7 +8681,15 @@ def plotRewards(
                 )
     imgFiles["agarose_per_rwd"] = CONTACT_EVENT_PER_RWD_IMG_FILE % ("edge", "agarose")
     if customizer.font_size_customized:
-        customizer.adjust_padding_proportionally(wrap_legend_labels=False)
+        wrap_axis_labels = True
+        try:
+            wrap_axis_labels = float(customizer.font_size) < 20.0
+        except (TypeError, ValueError):
+            pass
+        customizer.adjust_padding_proportionally(
+            wrap_legend_labels=False,
+            wrap_axis_labels=wrap_axis_labels,
+        )
 
     base, ext = os.path.splitext(imgFiles[tp] % blf)
     suffix_parts = []

--- a/src/plotting/com_sli_bundle_plotter.py
+++ b/src/plotting/com_sli_bundle_plotter.py
@@ -1616,15 +1616,15 @@ def plot_com_sli_bundle_data(
         ax.set_ylim(ylim[0], ylim[1])
 
     if customizer.font_size_customized:
-        wrap_axis_labels = True
+        wrap_x_axis_labels = True
         try:
-            wrap_axis_labels = float(customizer.font_size) < 20.0
+            wrap_x_axis_labels = float(customizer.font_size) < 20.0
         except (TypeError, ValueError):
             pass
         customizer.adjust_padding_proportionally(
             wspace=getattr(opts, "wspace", 0.35),
             wrap_legend_labels=False,
-            wrap_axis_labels=wrap_axis_labels,
+            wrap_x_axis_labels=wrap_x_axis_labels,
         )
 
     # Only promote to suptitle when there is exactly one legend entry and no explicit legend was requested.

--- a/src/plotting/com_sli_bundle_plotter.py
+++ b/src/plotting/com_sli_bundle_plotter.py
@@ -1616,9 +1616,15 @@ def plot_com_sli_bundle_data(
         ax.set_ylim(ylim[0], ylim[1])
 
     if customizer.font_size_customized:
+        wrap_axis_labels = True
+        try:
+            wrap_axis_labels = float(customizer.font_size) < 20.0
+        except (TypeError, ValueError):
+            pass
         customizer.adjust_padding_proportionally(
             wspace=getattr(opts, "wspace", 0.35),
             wrap_legend_labels=False,
+            wrap_axis_labels=wrap_axis_labels,
         )
 
     # Only promote to suptitle when there is exactly one legend entry and no explicit legend was requested.

--- a/src/plotting/plot_customizer.py
+++ b/src/plotting/plot_customizer.py
@@ -124,6 +124,7 @@ class PlotCustomizer:
         wspace=0.08,
         base_hspace=0.35,
         wrap_legend_labels=True,
+        wrap_axis_labels=True,
     ):
         """
         Adjusts the figure size and subplot padding proportionally to the font size.
@@ -139,6 +140,8 @@ class PlotCustomizer:
             Horizontal spacing between subplots, as a fraction of axis width.
         base_hspace : float
             Baseline vertical spacing between subplot rows.
+        wrap_axis_labels : bool
+            Whether to insert newlines into long axis labels at larger font sizes.
         """
         fig = plt.gcf()
 
@@ -263,36 +266,27 @@ class PlotCustomizer:
 
                     ax.yaxis.set_major_formatter(FuncFormatter(_adaptive_fmt))
 
-        # --- Step 5: Add newlines for long texts and axis labels ---
-        font_threshold = 20
+        # --- Step 5: Add newlines for long axis labels ---
+        if wrap_axis_labels:
+            font_threshold = 20
 
-        def split_evenly(s: str) -> str:
-            """Split string into two roughly even parts by word count."""
-            words = s.split()
-            if len(words) < 4:
-                return s
-            mid = len(words) // 2
-            left, right = words[:mid], words[mid:]
-            if len(left) < 2 or len(right) < 2:
-                return s
-            return " ".join(left) + "\n" + " ".join(right)
+            def split_evenly(s: str) -> str:
+                """Split string into two roughly even parts by word count."""
+                words = s.split()
+                if len(words) < 4:
+                    return s
+                mid = len(words) // 2
+                left, right = words[:mid], words[mid:]
+                if len(left) < 2 or len(right) < 2:
+                    return s
+                return " ".join(left) + "\n" + " ".join(right)
 
-        def split_at_colon(s: str) -> str:
-            """Split at the last colon, but only if both sides have ≥2 words."""
-            if ":" not in s:
-                return s
-            head, tail = s.rsplit(":", 1)
-            head_words, tail_words = head.split(), tail.split()
-            if len(head_words) < 2 or len(tail_words) < 2:
-                return s
-            return head + ":\n  " + tail.strip()
-
-        for ax in fig.get_axes():
-            for label in [ax.xaxis.get_label(), ax.yaxis.get_label()]:
-                if label.get_text() and label.get_fontsize() > font_threshold:
-                    s = label.get_text()
-                    if "\n" not in s:
-                        label.set_text(split_evenly(s))
+            for ax in fig.get_axes():
+                for label in [ax.xaxis.get_label(), ax.yaxis.get_label()]:
+                    if label.get_text() and label.get_fontsize() > font_threshold:
+                        s = label.get_text()
+                        if "\n" not in s:
+                            label.set_text(split_evenly(s))
 
         # --- Step 6: Shared axis label logic when font size exceeds the default ---
         axes = fig.get_axes()

--- a/src/plotting/plot_customizer.py
+++ b/src/plotting/plot_customizer.py
@@ -125,6 +125,8 @@ class PlotCustomizer:
         base_hspace=0.35,
         wrap_legend_labels=True,
         wrap_axis_labels=True,
+        wrap_x_axis_labels=None,
+        wrap_y_axis_labels=None,
     ):
         """
         Adjusts the figure size and subplot padding proportionally to the font size.
@@ -142,8 +144,18 @@ class PlotCustomizer:
             Baseline vertical spacing between subplot rows.
         wrap_axis_labels : bool
             Whether to insert newlines into long axis labels at larger font sizes.
+        wrap_x_axis_labels : bool
+            Whether to insert newlines into long X-axis labels. Defaults to
+            wrap_axis_labels.
+        wrap_y_axis_labels : bool
+            Whether to insert newlines into long Y-axis labels. Defaults to
+            wrap_axis_labels.
         """
         fig = plt.gcf()
+        if wrap_x_axis_labels is None:
+            wrap_x_axis_labels = wrap_axis_labels
+        if wrap_y_axis_labels is None:
+            wrap_y_axis_labels = wrap_axis_labels
 
         # --- Step 1: Optionally wrap long legend labels instead of shrinking legend font ---
         renderer = None
@@ -267,7 +279,7 @@ class PlotCustomizer:
                     ax.yaxis.set_major_formatter(FuncFormatter(_adaptive_fmt))
 
         # --- Step 5: Add newlines for long axis labels ---
-        if wrap_axis_labels:
+        if wrap_x_axis_labels or wrap_y_axis_labels:
             font_threshold = 20
 
             def split_evenly(s: str) -> str:
@@ -282,7 +294,12 @@ class PlotCustomizer:
                 return " ".join(left) + "\n" + " ".join(right)
 
             for ax in fig.get_axes():
-                for label in [ax.xaxis.get_label(), ax.yaxis.get_label()]:
+                labels = []
+                if wrap_x_axis_labels:
+                    labels.append(ax.xaxis.get_label())
+                if wrap_y_axis_labels:
+                    labels.append(ax.yaxis.get_label())
+                for label in labels:
                     if label.get_text() and label.get_fontsize() > font_threshold:
                         s = label.get_text()
                         if "\n" not in s:


### PR DESCRIPTION
## Summary
- Add X/Y-specific axis-label wrapping controls to `PlotCustomizer`
- Disable automatic X-axis label wrapping for large-font (`fontSize >= 20`) reward plots
- Apply the same large-font X-label behavior to COM/SLI bundle plots

## Motivation
At presentation-scale fonts, labels like `10-min sync-bucket endpoint (min)` were being auto-wrapped, which made some PDFs look inconsistent. This keeps the existing wrapping behavior available, but prevents X-axis wrapping in the large-font plotting paths where the single-line bucket endpoint label is preferred.

## Validation
- `python -m py_compile analyze.py src/plotting/plot_customizer.py src/plotting/com_sli_bundle_plotter.py`
- Manually checked generated PDFs including:
  - `reward_pi__10_min_buckets.pdf`
  - `med_dist_to_rwd_ctr__10_min_buckets.pdf`