### PR TITLE
Avoid spurious y-limit expansion in reward time-course plots

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -8507,22 +8507,25 @@ def plotRewards(
         # Convert legend bbox to figure coords
         legend_bbox = legend.get_window_extent(fig.canvas.renderer)
         legend_bbox_fig = legend_bbox.transformed(fig.transFigure.inverted())
-        legend_y0, legend_y1 = legend_bbox_fig.y0, legend_bbox_fig.y1
+        legend_y_mid = 0.5 * (legend_bbox_fig.y0 + legend_bbox_fig.y1)
 
-        # Find approximate top position of all star texts (using axis transforms)
-        top_star_y, bottom_star_y = None, None
+        # Check rendered label boxes against the legend box. A y-only check can
+        # falsely trigger from annotations in neighboring subplots.
+        overlapping_label_centers = []
         for ax in all_axes:
             for txt in ax.texts:
                 s = txt.get_text()
                 if "*" in s or s == "ns" or re.fullmatch(r"\d+", s):
-                    # transform data coords to figure coords
-                    xy_fig = ax.transData.transform(txt.get_position())
-                    xy_fig = fig.transFigure.inverted().transform(xy_fig)
-                    y_fig = xy_fig[1]
-                    if top_star_y is None or y_fig > top_star_y:
-                        top_star_y = y_fig
-                    if bottom_star_y is None or y_fig < bottom_star_y:
-                        bottom_star_y = y_fig
+                    try:
+                        text_bbox_fig = txt.get_window_extent(
+                            renderer=fig.canvas.renderer
+                        ).transformed(fig.transFigure.inverted())
+                    except Exception:
+                        continue
+                    if text_bbox_fig.overlaps(legend_bbox_fig):
+                        overlapping_label_centers.append(
+                            0.5 * (text_bbox_fig.y0 + text_bbox_fig.y1)
+                        )
 
         # Compute all axes’ y-lims
         ylim_vals = [ax.get_ylim() for ax in all_axes]
@@ -8530,8 +8533,7 @@ def plotRewards(
         mean_span = np.mean(y_spans)
         med_span = np.median(y_spans)
 
-        # Compare in same figure coordinate space
-        if top_star_y is not None and legend_y0 < top_star_y < legend_y1:
+        if overlapping_label_centers and max(overlapping_label_centers) >= legend_y_mid:
             # Legend overlaps top labels → expand upward
             delta_y_global = min(0.2 * mean_span, 0.3 * med_span)
             ymin_global = min(y0 for (y0, _) in ylim_vals)
@@ -8539,7 +8541,7 @@ def plotRewards(
             for ax in all_axes:
                 ax.set_ylim(ymin_global, ymax_global)
             ylim[0], ylim[1] = ymin_global, ymax_global
-        elif bottom_star_y is not None and legend_y0 < bottom_star_y < legend_y1:
+        elif overlapping_label_centers:
             # Legend overlaps bottom labels → shift downward
             delta_y_global = min(0.35 * mean_span, 0.35 * med_span)
             ymin_global = min(y0 for (y0, _) in ylim_vals) - delta_y_global

--- a/src/plotting/annotation_layout.py
+++ b/src/plotting/annotation_layout.py
@@ -21,6 +21,23 @@ def _move_text_by_display_dy(ax, text, dy_px: float) -> float:
     return float(y_new)
 
 
+def _expand_ylim_if_text_exceeds_top(ax, text, bbox, ylim, *, pad_px: float) -> None:
+    fig = ax.figure
+    renderer = fig.canvas.get_renderer()
+    axes_bbox = ax.get_window_extent(renderer=renderer)
+    excess_px = float(bbox.y1) + float(pad_px) - float(axes_bbox.y1)
+    if excess_px <= 0.0:
+        return
+
+    x, _y = text.get_position()
+    _x_disp, top_disp = ax.transData.transform((float(x), float(ylim[1])))
+    _x_new, y_needed = ax.transData.inverted().transform(
+        (_x_disp, top_disp + excess_px)
+    )
+    if np.isfinite(y_needed):
+        ylim[1] = max(float(ylim[1]), float(y_needed))
+
+
 def resolve_annotation_text_overlaps(ax, texts, ylim, *, pad_px=None, max_iter=16):
     """
     Resolve annotation collisions using rendered text extents.
@@ -67,16 +84,19 @@ def resolve_annotation_text_overlaps(ax, texts, ylim, *, pad_px=None, max_iter=1
                     needed_shift_px = max(needed_shift_px, overlap_px + pad_px)
 
             if needed_shift_px > 0.0:
-                y_new = _move_text_by_display_dy(ax, text, needed_shift_px)
-                ylim[1] = max(
-                    float(ylim[1]),
-                    y_new + 0.05 * (float(ylim[1]) - float(ylim[0])),
-                )
+                _move_text_by_display_dy(ax, text, needed_shift_px)
                 moved = True
                 fig.canvas.draw()
                 bbox = _expanded_text_bbox(
                     text.get_window_extent(renderer=fig.canvas.get_renderer()),
                     pad_px,
+                )
+                _expand_ylim_if_text_exceeds_top(
+                    ax,
+                    text,
+                    bbox,
+                    ylim,
+                    pad_px=pad_px,
                 )
 
             placed.append(bbox)


### PR DESCRIPTION
## Summary

This PR tightens the automatic y-limit expansion logic used by reward/time-course plot annotations.

Previously, y-limits could be expanded even when the plotted data and annotation text still fit comfortably inside the default axis range. This was especially visible for `--rpd` plots, where the default y-limit is `[0, 80]`, but the plot could be bumped upward despite the reward-per-distance curves staying far below that ceiling.

## Technical Details

There were two separate over-expansion paths:

1. `resolve_annotation_text_overlaps()` expanded `ylim[1]` whenever it nudged annotation text upward to avoid rendered text collisions.
   - This happened even if the shifted text still remained inside the axes.
   - The helper now checks the rendered text bounding box against the top of the axes and only expands `ylim[1]` when the text actually protrudes past the visible plot area.

2. `plotRewards()` had a legacy legend-protection check that compared annotation positions to the legend using only vertical figure coordinates.
   - This could falsely detect an overlap when text in another subplot happened to sit in the same vertical band as the legend.
   - The check now compares actual rendered bounding boxes in figure coordinates, so y-limits are adjusted only when annotation text physically overlaps the legend.

## Impact

- Keeps default y-limits intact when annotations fit within the existing plot area.
- Preserves automatic expansion when annotations truly need additional space.
- Improves `--rpd` reward-per-distance plots and other time-dependent reward plots that share the same annotation layout path.

## Validation

- Ran:

```bash
  python -m py_compile analyze.py src/plotting/annotation_layout.py src/plotting/com_sli_bundle_plotter.py
```

- Manually verified with an `--rpd` plotting command that the y-axis no longer expands unnecessarily when the data and annotations fit under the default max.