### PR TITLE
Add exp-minus-yoked rewards-per-distance correlation plot

### DIFF
--- a/src/plotting/cross_fly_correlations.py
+++ b/src/plotting/cross_fly_correlations.py
@@ -399,6 +399,60 @@ def _add_significant_trend_line(
     return True
 
 
+def _shrink_clipped_ylabels(fig, *, min_scale: float = 0.72, pad_px: float = 2.0) -> bool:
+    """
+    Reduce oversized Y-axis labels only when their rendered bbox is clipped.
+    """
+    try:
+        fig.canvas.draw()
+        renderer = fig.canvas.get_renderer()
+        fig_bbox = fig.get_window_extent(renderer=renderer)
+    except Exception:
+        return False
+
+    changed = False
+    for ax in fig.get_axes():
+        label = ax.yaxis.get_label()
+        if not label.get_visible() or not label.get_text():
+            continue
+
+        original_size = float(label.get_fontsize())
+        min_size = original_size * float(min_scale)
+        for _ in range(10):
+            bbox = label.get_window_extent(renderer=renderer)
+            clipped = (
+                float(bbox.x0) < float(fig_bbox.x0) + pad_px
+                or float(bbox.y0) < float(fig_bbox.y0) + pad_px
+                or float(bbox.y1) > float(fig_bbox.y1) - pad_px
+            )
+            if not clipped:
+                break
+
+            current_size = float(label.get_fontsize())
+            next_size = max(min_size, current_size * 0.94)
+            if next_size >= current_size:
+                break
+            label.set_fontsize(next_size)
+            changed = True
+            fig.canvas.draw()
+            renderer = fig.canvas.get_renderer()
+
+    return changed
+
+
+def _finalize_correlation_layout(fig, customizer: PlotCustomizer, *, rect=None) -> None:
+    customizer.adjust_padding_proportionally()
+    if rect is None:
+        fig.tight_layout()
+    else:
+        fig.tight_layout(rect=rect)
+    if _shrink_clipped_ylabels(fig):
+        if rect is None:
+            fig.tight_layout()
+        else:
+            fig.tight_layout(rect=rect)
+
+
 def _place_legend_without_point_overlap(
     ax,
     handles,
@@ -1070,8 +1124,7 @@ def plot_selected_group_scatter(
     )
     _add_smart_stats_box(ax, "\n".join(lines), x_f, y_f)
 
-    customizer.adjust_padding_proportionally()
-    fig.tight_layout(rect=(0, 0, 1, 0.98))
+    _finalize_correlation_layout(fig, customizer, rect=(0, 0, 1, 0.98))
     out_path = _correlation_out_path(out_dir, filename, image_format)
     writeImage(str(out_path), format=image_format)
     plt.close(fig)
@@ -1116,8 +1169,7 @@ def _scatter_with_corr(
     _add_significant_trend_line(ax, x_f, y_f, p, color=cfg.dot_color)
     _add_smart_stats_box(ax, _format_corr_annotation(r, p, x_f.size), x_f, y_f)
 
-    customizer.adjust_padding_proportionally()
-    fig.tight_layout()
+    _finalize_correlation_layout(fig, customizer)
     out_path = _correlation_out_path(cfg.out_dir, filename, cfg.image_format)
     writeImage(str(out_path), format=cfg.image_format)
     _export_scatter_npz(
@@ -1614,9 +1666,7 @@ def plot_fast_vs_strong_scatter(
     _add_smart_stats_box(ax, "\n".join(lines), x_f, y_f)
 
     # Optional proportional padding
-    customizer.adjust_padding_proportionally()
-
-    fig.tight_layout(rect=(0, 0, 1, 0.96))
+    _finalize_correlation_layout(fig, customizer, rect=(0, 0, 1, 0.96))
     out_path = _correlation_out_path(out_dir, "scatter_fast_vs_strong", image_format)
     writeImage(str(out_path), format=image_format)
     plt.close(fig)
@@ -1773,7 +1823,7 @@ def plot_pre_reward_pi_vs_T1_first_bucket_reward_pi_fast_slow(
 
     _add_smart_stats_box(ax, "\n".join(lines), x_f, y_f)
 
-    customizer.adjust_padding_proportionally()
+    _finalize_correlation_layout(fig, customizer)
 
     out_path = _correlation_out_path(
         out_dir,

--- a/src/plotting/cross_fly_correlations.py
+++ b/src/plotting/cross_fly_correlations.py
@@ -1798,6 +1798,7 @@ def plot_cross_fly_correlations(
     )  # always SB1
 
     rpd_vals = []
+    rpd_exp_minus_yoked_vals = []
     rpt_vals = []
     med_train_vals = []
     pre_pi_diff_vals = []
@@ -1807,9 +1808,10 @@ def plot_cross_fly_correlations(
     for va in vas:
         # --- Reward per distance (final bucket of training_idx) ---
         if _ensure_rewards_per_distance(va):
-            row_idx = 2 * training_idx  # exp row
-            if 0 <= row_idx < len(va.rwdsPerDist):
-                exp_row = va.rwdsPerDist[row_idx]
+            exp_row_idx = 2 * training_idx
+            yoked_row_idx = exp_row_idx + 1
+            if 0 <= exp_row_idx < len(va.rwdsPerDist):
+                exp_row = va.rwdsPerDist[exp_row_idx]
                 rpd_val = _reduce_sync_bucket_series(
                     exp_row,
                     bucket_idx=sli_bucket_idx,
@@ -1819,8 +1821,21 @@ def plot_cross_fly_correlations(
                 )
             else:
                 rpd_val = np.nan
+            if 0 <= yoked_row_idx < len(va.rwdsPerDist):
+                yoked_row = va.rwdsPerDist[yoked_row_idx]
+                rpd_yoked_val = _reduce_sync_bucket_series(
+                    yoked_row,
+                    bucket_idx=sli_bucket_idx,
+                    average_over_buckets=bool(sli_ctx.average_over_buckets),
+                    skip_first_sync_buckets=skip_k,
+                    keep_first_sync_buckets=keep_k,
+                )
+            else:
+                rpd_yoked_val = np.nan
         else:
             rpd_val = np.nan
+            rpd_yoked_val = np.nan
+        rpd_exp_minus_yoked_val = rpd_val - rpd_yoked_val
 
         # --- Reward per time (may use a different training/window from SLI) ---
         if reward_first_n > 0:
@@ -1923,6 +1938,7 @@ def plot_cross_fly_correlations(
             total_rewards = np.nan
 
         rpd_vals.append(rpd_val)
+        rpd_exp_minus_yoked_vals.append(rpd_exp_minus_yoked_val)
         rpt_vals.append(rpt_val)
         med_train_vals.append(med_train)
         pre_pi_diff_vals.append(pre_diff)
@@ -1930,6 +1946,7 @@ def plot_cross_fly_correlations(
         pre_coverage_vals.append(coverage)
 
     rpd_vals = np.asarray(rpd_vals, float)
+    rpd_exp_minus_yoked_vals = np.asarray(rpd_exp_minus_yoked_vals, float)
     rpt_vals = np.asarray(rpt_vals, float)
     med_train_vals = np.asarray(med_train_vals, float)
     pre_pi_diff_vals = np.asarray(pre_pi_diff_vals, float)
@@ -1972,6 +1989,10 @@ def plot_cross_fly_correlations(
                 rpt_suffix = f"{rpt_suffix}__maxtime{cutoff_suffix:g}s"
 
     rpd_y_label = sli_ctx.metric_axis_label("Rewards per distance", unit="$m^{-1}$")
+    rpd_diff_y_label = sli_ctx.metric_axis_label(
+        "Rewards per distance, exp - yok",
+        unit="$m^{-1}$",
+    )
     if reward_first_n > 0:
         rpt_y_label = _first_n_reward_rate_label(
             first_n_rewards=reward_first_n,
@@ -2025,7 +2046,66 @@ def plot_cross_fly_correlations(
             image_format=cfg.image_format,
         )
 
-    # --- Plot 1b: SLI_final vs reward-per-time (SLI on Y axis) ---
+    # --- Plot 1b: SLI_final vs exp-minus-yoked reward-per-distance ---
+    _scatter_with_corr(
+        x=sli_vals,
+        y=rpd_exp_minus_yoked_vals,
+        title="Δ rewards per distance vs SLI",
+        x_label=x_label_sli,
+        y_label=rpd_diff_y_label,
+        cfg=_cfg_with_plot_color(
+            cfg,
+            "rewards_per_distance_exp_minus_yoked_vs_sli",
+        ),
+        filename=f"corr_rpd_exp_minus_yoked_vs_sli_{rpd_suffix}",
+        customizer=customizer,
+    )
+    if selected_mode is not None:
+        if selected_mode == "top":
+            title_1b_sel = (
+                "Exp-minus-yoked rewards per distance vs SLI "
+                "(top SLI-selected learners)"
+            )
+            filename_1b_sel = (
+                f"corr_rpd_exp_minus_yoked_vs_sli_{rpd_suffix}_top_selected"
+            )
+        elif selected_mode == "bottom":
+            title_1b_sel = (
+                "Exp-minus-yoked rewards per distance vs SLI "
+                "(bottom SLI-selected learners)"
+            )
+            filename_1b_sel = (
+                f"corr_rpd_exp_minus_yoked_vs_sli_{rpd_suffix}_bottom_selected"
+            )
+        else:
+            title_1b_sel = (
+                "Exp-minus-yoked rewards per distance vs SLI "
+                "(top vs bottom SLI-selected learners)"
+            )
+            filename_1b_sel = (
+                f"corr_rpd_exp_minus_yoked_vs_sli_{rpd_suffix}_selected_extremes"
+            )
+
+        plot_selected_group_scatter(
+            x=sli_vals,
+            y=rpd_exp_minus_yoked_vals,
+            bottom_idx=selected_bottom_idx,
+            top_idx=selected_top_idx,
+            mode=selected_mode,
+            title=title_1b_sel,
+            x_label=x_label_sli,
+            y_label=rpd_diff_y_label,
+            filename=filename_1b_sel,
+            out_dir=out_dir,
+            customizer=customizer,
+            top_label=top_sel_label,
+            bottom_label=bottom_sel_label,
+            xlim=cfg.xlim,
+            ylim=cfg.ylim,
+            image_format=cfg.image_format,
+        )
+
+    # --- Plot 1c: SLI_final vs reward-per-time (SLI on Y axis) ---
     _scatter_with_corr(
         x=rpt_vals,
         y=sli_vals,
@@ -2038,14 +2118,14 @@ def plot_cross_fly_correlations(
     )
     if selected_mode is not None:
         if selected_mode == "top":
-            title_1b_sel = "SLI vs rewards per minute (top SLI-selected learners)"
-            filename_1b_sel = f"corr_sli_vs_rpt_{rpt_suffix}_top_selected"
+            title_1c_sel = "SLI vs rewards per minute (top SLI-selected learners)"
+            filename_1c_sel = f"corr_sli_vs_rpt_{rpt_suffix}_top_selected"
         elif selected_mode == "bottom":
-            title_1b_sel = "SLI vs rewards per minute (bottom SLI-selected learners)"
-            filename_1b_sel = f"corr_sli_vs_rpt_{rpt_suffix}_bottom_selected"
+            title_1c_sel = "SLI vs rewards per minute (bottom SLI-selected learners)"
+            filename_1c_sel = f"corr_sli_vs_rpt_{rpt_suffix}_bottom_selected"
         else:
-            title_1b_sel = "SLI vs rewards per minute (top vs bottom SLI-selected learners)"
-            filename_1b_sel = f"corr_sli_vs_rpt_{rpt_suffix}_selected_extremes"
+            title_1c_sel = "SLI vs rewards per minute (top vs bottom SLI-selected learners)"
+            filename_1c_sel = f"corr_sli_vs_rpt_{rpt_suffix}_selected_extremes"
 
         plot_selected_group_scatter(
             x=rpt_vals,
@@ -2053,10 +2133,10 @@ def plot_cross_fly_correlations(
             bottom_idx=selected_bottom_idx,
             top_idx=selected_top_idx,
             mode=selected_mode,
-            title=title_1b_sel,
+            title=title_1c_sel,
             x_label=str(corr_sli_vs_rpt_xlabel_override or rpt_y_label),
             y_label=str(corr_sli_vs_rpt_ylabel_override or y_label_sli),
-            filename=filename_1b_sel,
+            filename=filename_1c_sel,
             out_dir=out_dir,
             customizer=customizer,
             top_label=top_sel_label,

--- a/src/plotting/cross_fly_correlations.py
+++ b/src/plotting/cross_fly_correlations.py
@@ -2171,6 +2171,12 @@ def plot_cross_fly_correlations(
     rpd_diff_y_label = sli_ctx.metric_axis_label(
         "Rewards per distance, exp - yok",
         unit="$m^{-1}$",
+    ).replace(
+        ", mean over ",
+        ",\nmean over ",
+    ).replace(
+        ", at ",
+        ",\nat ",
     )
     if reward_first_n > 0:
         rpt_y_label = _first_n_reward_rate_label(

--- a/src/plotting/palettes.py
+++ b/src/plotting/palettes.py
@@ -237,6 +237,7 @@ METRIC_PALETTES = {
 # accents. This lets us keep a stable semantic color per plot type.
 CORRELATION_PLOT_COLORS = {
     "rewards_per_distance_vs_sli": ACCENT_BLUE,
+    "rewards_per_distance_exp_minus_yoked_vs_sli": ACCENT_TEAL,
     "rewards_per_minute_vs_sli": ACCENT_ORANGE,
     "first_n_reward_rate_vs_sli": ACCENT_TEAL,
     "median_distance_vs_sli": ACCENT_GREEN,


### PR DESCRIPTION
## Summary
- Add a new cross-fly correlation plot for experimental-minus-yoked rewards per distance vs SLI
- Compute the new Y variable from matched experimental and yoked rewards-per-distance rows using the selected training/SB window
- Add selected top/bottom learner variants for the new plot
- Use a dedicated correlation-plot color for the new exp-minus-yoked RPD variant
- Improve large-font handling for long Y-axis labels, including the new exp-minus-yok label

## Validation
- Ran `python -m py_compile src/plotting/cross_fly_correlations.py src/plotting/palettes.py`
- Manually checked regenerated correlation plots