### PR TITLE
Orient reward-rate correlation plot with SLI on the x-axis

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -769,13 +769,13 @@ g.add_argument(
     "--corr-sli-vs-rpt-xlabel",
     type=str,
     default=None,
-    help="Optional x-axis label override for the 'SLI vs rewards per minute' correlation plot family.",
+    help="Optional x-axis label override for the 'rewards per minute vs SLI' correlation plot family.",
 )
 g.add_argument(
     "--corr-sli-vs-rpt-ylabel",
     type=str,
     default=None,
-    help="Optional y-axis label override for the 'SLI vs rewards per minute' correlation plot family.",
+    help="Optional y-axis label override for the 'rewards per minute vs SLI' correlation plot family.",
 )
 g.add_argument(
     "--corr-pre-reward-pi-vs-sli-xlabel",
@@ -819,7 +819,7 @@ g.add_argument(
     default=None,
     help=(
         "Training session to use for the reward-rate axis in the "
-        "'SLI vs rewards per minute' correlation plot. If omitted, "
+        "'rewards per minute vs SLI' correlation plot. If omitted, "
         "inherits the SLI training/window."
     ),
 )
@@ -829,7 +829,7 @@ g.add_argument(
     default=None,
     help=(
         "Exclude the first K sync buckets when computing reward rate for the "
-        "'SLI vs rewards per minute' correlation plot. If omitted, inherits "
+        "'rewards per minute vs SLI' correlation plot. If omitted, inherits "
         "the SLI window."
     ),
 )
@@ -839,7 +839,7 @@ g.add_argument(
     default=None,
     help=(
         "Cap reward-rate computation to the first K sync buckets (after skip) "
-        "for the 'SLI vs rewards per minute' correlation plot. If omitted, "
+        "for the 'rewards per minute vs SLI' correlation plot. If omitted, "
         "inherits the SLI window."
     ),
 )
@@ -851,7 +851,7 @@ g.add_argument(
     default=None,
     help=(
         "Use the mean reward rate across the selected reward-rate window in the "
-        "'SLI vs rewards per minute' correlation plot. If omitted, inherits the "
+        "'rewards per minute vs SLI' correlation plot. If omitted, inherits the "
         "SLI reduction mode."
     ),
 )
@@ -863,7 +863,7 @@ g.add_argument(
     default=None,
     help=(
         "Use the last valid reward-rate sync bucket within the selected reward-rate "
-        "window in the 'SLI vs rewards per minute' correlation plot. If omitted, "
+        "window in the 'rewards per minute vs SLI' correlation plot. If omitted, "
         "inherits the SLI reduction mode."
     ),
 )
@@ -872,7 +872,7 @@ g.add_argument(
     type=int,
     default=0,
     help=(
-        "For the 'SLI vs rewards per minute' correlation plot, compute reward rate "
+        "For the 'rewards per minute vs SLI' correlation plot, compute reward rate "
         "from the first N calculated rewards of the experimental fly within the "
         "selected reward-rate window, using N / time-to-Nth-reward. "
         "Use 0 to keep the existing sync-bucket-based reward-rate calculation."

--- a/src/plotting/cross_fly_correlations.py
+++ b/src/plotting/cross_fly_correlations.py
@@ -2290,37 +2290,37 @@ def plot_cross_fly_correlations(
             image_format=cfg.image_format,
         )
 
-    # --- Plot 1c: SLI_final vs reward-per-time (SLI on Y axis) ---
+    # --- Plot 1c: SLI_final vs reward-per-time ---
     _scatter_with_corr(
-        x=rpt_vals,
-        y=sli_vals,
-        title="SLI vs rewards per minute",
-        x_label=str(corr_sli_vs_rpt_xlabel_override or rpt_y_label),
-        y_label=str(corr_sli_vs_rpt_ylabel_override or y_label_sli),
+        x=sli_vals,
+        y=rpt_vals,
+        title="Rewards per minute vs SLI",
+        x_label=str(corr_sli_vs_rpt_xlabel_override or x_label_sli),
+        y_label=str(corr_sli_vs_rpt_ylabel_override or rpt_y_label),
         cfg=_cfg_with_plot_color(cfg, "rewards_per_minute_vs_sli"),
-        filename=f"corr_sli_vs_rpt_{rpt_suffix}",
+        filename=f"corr_rpt_vs_sli_{rpt_suffix}",
         customizer=customizer,
     )
     if selected_mode is not None:
         if selected_mode == "top":
-            title_1c_sel = "SLI vs rewards per minute (top SLI-selected learners)"
-            filename_1c_sel = f"corr_sli_vs_rpt_{rpt_suffix}_top_selected"
+            title_1c_sel = "Rewards per minute vs SLI (top SLI-selected learners)"
+            filename_1c_sel = f"corr_rpt_vs_sli_{rpt_suffix}_top_selected"
         elif selected_mode == "bottom":
-            title_1c_sel = "SLI vs rewards per minute (bottom SLI-selected learners)"
-            filename_1c_sel = f"corr_sli_vs_rpt_{rpt_suffix}_bottom_selected"
+            title_1c_sel = "Rewards per minute vs SLI (bottom SLI-selected learners)"
+            filename_1c_sel = f"corr_rpt_vs_sli_{rpt_suffix}_bottom_selected"
         else:
-            title_1c_sel = "SLI vs rewards per minute (top vs bottom SLI-selected learners)"
-            filename_1c_sel = f"corr_sli_vs_rpt_{rpt_suffix}_selected_extremes"
+            title_1c_sel = "Rewards per minute vs SLI (top vs bottom SLI-selected learners)"
+            filename_1c_sel = f"corr_rpt_vs_sli_{rpt_suffix}_selected_extremes"
 
         plot_selected_group_scatter(
-            x=rpt_vals,
-            y=sli_vals,
+            x=sli_vals,
+            y=rpt_vals,
             bottom_idx=selected_bottom_idx,
             top_idx=selected_top_idx,
             mode=selected_mode,
             title=title_1c_sel,
-            x_label=str(corr_sli_vs_rpt_xlabel_override or rpt_y_label),
-            y_label=str(corr_sli_vs_rpt_ylabel_override or y_label_sli),
+            x_label=str(corr_sli_vs_rpt_xlabel_override or x_label_sli),
+            y_label=str(corr_sli_vs_rpt_ylabel_override or rpt_y_label),
             filename=filename_1c_sel,
             out_dir=out_dir,
             customizer=customizer,


### PR DESCRIPTION
## Summary
- Swap the rewards-per-minute correlation plot so SLI is on the x-axis and reward rate is on the y-axis
- Update plot titles and output filename prefixes from `corr_sli_vs_rpt` to `corr_rpt_vs_sli`
- Update selected top/bottom variants to use the same axis orientation
- Refresh CLI help text to describe the new rewards-per-minute vs SLI orientation

## Validation
- Ran `python -m py_compile src/plotting/cross_fly_correlations.py analyze.py`
- Manually checked regenerated correlation plots