### PR TITLE
Refine reward-rate correlation labels and wrapping

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -769,13 +769,13 @@ g.add_argument(
     "--corr-sli-vs-rpt-xlabel",
     type=str,
     default=None,
-    help="Optional x-axis label override for the 'rewards per minute vs SLI' correlation plot family.",
+    help="Optional x-axis label override for the 'reward rate vs SLI' correlation plot family.",
 )
 g.add_argument(
     "--corr-sli-vs-rpt-ylabel",
     type=str,
     default=None,
-    help="Optional y-axis label override for the 'rewards per minute vs SLI' correlation plot family.",
+    help="Optional y-axis label override for the 'reward rate vs SLI' correlation plot family.",
 )
 g.add_argument(
     "--corr-pre-reward-pi-vs-sli-xlabel",
@@ -819,7 +819,7 @@ g.add_argument(
     default=None,
     help=(
         "Training session to use for the reward-rate axis in the "
-        "'rewards per minute vs SLI' correlation plot. If omitted, "
+        "'reward rate vs SLI' correlation plot. If omitted, "
         "inherits the SLI training/window."
     ),
 )
@@ -829,7 +829,7 @@ g.add_argument(
     default=None,
     help=(
         "Exclude the first K sync buckets when computing reward rate for the "
-        "'rewards per minute vs SLI' correlation plot. If omitted, inherits "
+        "'reward rate vs SLI' correlation plot. If omitted, inherits "
         "the SLI window."
     ),
 )
@@ -839,7 +839,7 @@ g.add_argument(
     default=None,
     help=(
         "Cap reward-rate computation to the first K sync buckets (after skip) "
-        "for the 'rewards per minute vs SLI' correlation plot. If omitted, "
+        "for the 'reward rate vs SLI' correlation plot. If omitted, "
         "inherits the SLI window."
     ),
 )
@@ -851,7 +851,7 @@ g.add_argument(
     default=None,
     help=(
         "Use the mean reward rate across the selected reward-rate window in the "
-        "'rewards per minute vs SLI' correlation plot. If omitted, inherits the "
+        "'reward rate vs SLI' correlation plot. If omitted, inherits the "
         "SLI reduction mode."
     ),
 )
@@ -863,7 +863,7 @@ g.add_argument(
     default=None,
     help=(
         "Use the last valid reward-rate sync bucket within the selected reward-rate "
-        "window in the 'rewards per minute vs SLI' correlation plot. If omitted, "
+        "window in the 'reward rate vs SLI' correlation plot. If omitted, "
         "inherits the SLI reduction mode."
     ),
 )
@@ -872,7 +872,7 @@ g.add_argument(
     type=int,
     default=0,
     help=(
-        "For the 'rewards per minute vs SLI' correlation plot, compute reward rate "
+        "For the 'reward rate vs SLI' correlation plot, compute reward rate "
         "from the first N calculated rewards of the experimental fly within the "
         "selected reward-rate window, using N / time-to-Nth-reward. "
         "Use 0 to keep the existing sync-bucket-based reward-rate calculation."

--- a/src/plotting/cross_fly_correlations.py
+++ b/src/plotting/cross_fly_correlations.py
@@ -440,12 +440,61 @@ def _shrink_clipped_ylabels(fig, *, min_scale: float = 0.72, pad_px: float = 2.0
     return changed
 
 
+def _wrap_clipped_xlabels(fig, *, pad_px: float = 2.0) -> bool:
+    """
+    Wrap X-axis labels only when their rendered bbox exceeds the figure width.
+    """
+    try:
+        fig.canvas.draw()
+        renderer = fig.canvas.get_renderer()
+        fig_bbox = fig.get_window_extent(renderer=renderer)
+    except Exception:
+        return False
+
+    def _split_evenly(text: str) -> str:
+        words = text.split()
+        if len(words) < 4:
+            return text
+        mid = len(words) // 2
+        left, right = words[:mid], words[mid:]
+        if len(left) < 2 or len(right) < 2:
+            return text
+        return " ".join(left) + "\n" + " ".join(right)
+
+    changed = False
+    for ax in fig.get_axes():
+        label = ax.xaxis.get_label()
+        text = label.get_text()
+        if not label.get_visible() or not text or "\n" in text:
+            continue
+
+        bbox = label.get_window_extent(renderer=renderer)
+        clipped = (
+            float(bbox.x0) < float(fig_bbox.x0) + pad_px
+            or float(bbox.x1) > float(fig_bbox.x1) - pad_px
+        )
+        if not clipped:
+            continue
+
+        wrapped = _split_evenly(text)
+        if wrapped != text:
+            label.set_text(wrapped)
+            changed = True
+
+    return changed
+
+
 def _finalize_correlation_layout(fig, customizer: PlotCustomizer, *, rect=None) -> None:
-    customizer.adjust_padding_proportionally()
+    customizer.adjust_padding_proportionally(wrap_axis_labels=False)
     if rect is None:
         fig.tight_layout()
     else:
         fig.tight_layout(rect=rect)
+    if _wrap_clipped_xlabels(fig):
+        if rect is None:
+            fig.tight_layout()
+        else:
+            fig.tight_layout(rect=rect)
     if _shrink_clipped_ylabels(fig):
         if rect is None:
             fig.tight_layout()
@@ -2186,7 +2235,10 @@ def plot_cross_fly_correlations(
             time_basis=reward_first_n_time_basis,
         )
     else:
-        rpt_y_label = _windowed_metric_label("rewards per minute", reward_rate_ctx)
+        rpt_y_label = reward_rate_ctx.metric_axis_label(
+            "Reward rate",
+            unit="$min^{-1}$",
+        )
 
     # --- Plot 1: SLI_final vs reward-per-distance ---
     _scatter_with_corr(
@@ -2294,7 +2346,7 @@ def plot_cross_fly_correlations(
     _scatter_with_corr(
         x=sli_vals,
         y=rpt_vals,
-        title="Rewards per minute vs SLI",
+        title="Reward rate vs SLI",
         x_label=str(corr_sli_vs_rpt_xlabel_override or x_label_sli),
         y_label=str(corr_sli_vs_rpt_ylabel_override or rpt_y_label),
         cfg=_cfg_with_plot_color(cfg, "rewards_per_minute_vs_sli"),
@@ -2303,13 +2355,13 @@ def plot_cross_fly_correlations(
     )
     if selected_mode is not None:
         if selected_mode == "top":
-            title_1c_sel = "Rewards per minute vs SLI (top SLI-selected learners)"
+            title_1c_sel = "Reward rate vs SLI (top SLI-selected learners)"
             filename_1c_sel = f"corr_rpt_vs_sli_{rpt_suffix}_top_selected"
         elif selected_mode == "bottom":
-            title_1c_sel = "Rewards per minute vs SLI (bottom SLI-selected learners)"
+            title_1c_sel = "Reward rate vs SLI (bottom SLI-selected learners)"
             filename_1c_sel = f"corr_rpt_vs_sli_{rpt_suffix}_bottom_selected"
         else:
-            title_1c_sel = "Rewards per minute vs SLI (top vs bottom SLI-selected learners)"
+            title_1c_sel = "Reward rate vs SLI (top vs bottom SLI-selected learners)"
             filename_1c_sel = f"corr_rpt_vs_sli_{rpt_suffix}_selected_extremes"
 
         plot_selected_group_scatter(


### PR DESCRIPTION
## Summary
- Rename the rewards-per-minute correlation plot title to `Reward rate vs SLI`
- Update the default reward-rate Y-axis label to use selected-window wording, e.g. `Reward rate, mean over T2 SB2–5 ($min^{-1}$)`
- Keep the existing dynamic SLI X-axis label
- Avoid premature axis-label wrapping in correlation plots by wrapping only when rendered labels would clip
- Update CLI help text for the reward-rate correlation plot family

## Validation
- Ran `python -m py_compile src/plotting/cross_fly_correlations.py analyze.py`
- Manually checked regenerated correlation plots