### PR TITLE
Update pre-period exploration correlation labels

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -793,13 +793,13 @@ g.add_argument(
     "--corr-pre-floor-exploration-vs-sli-xlabel",
     type=str,
     default=None,
-    help="Optional x-axis label override for the 'Pre-training exploration vs SLI' correlation plot family.",
+    help="Optional x-axis label override for the 'Pre-period exploration and SLI' correlation plot family.",
 )
 g.add_argument(
     "--corr-pre-floor-exploration-vs-sli-ylabel",
     type=str,
     default=None,
-    help="Optional y-axis label override for the 'Pre-training exploration vs SLI' correlation plot family.",
+    help="Optional y-axis label override for the 'Pre-period exploration and SLI' correlation plot family.",
 )
 g.add_argument(
     "--corr-fast-vs-strong-xlabel",

--- a/src/plotting/cross_fly_correlations.py
+++ b/src/plotting/cross_fly_correlations.py
@@ -2187,6 +2187,10 @@ def plot_cross_fly_correlations(
         )
     else:
         rpt_y_label = _windowed_metric_label("rewards per minute", reward_rate_ctx)
+    pre_period_exploration_title = "Pre-period exploration and SLI"
+    pre_period_exploration_xlabel = (
+        "Fraction of floor explored during pre period (exp fly)"
+    )
 
     # --- Plot 1: SLI_final vs reward-per-distance ---
     _scatter_with_corr(
@@ -2360,15 +2364,15 @@ def plot_cross_fly_correlations(
         customizer=customizer,
     )
 
-    # --- Plot 3b: Pre-training exploration vs SLI at T1, first sync bucket ---
+    # --- Plot 3b: Pre-period exploration vs SLI at T1, first sync bucket ---
     if reward_pi_training_vals is not None:
         _scatter_with_corr(
             x=pre_coverage_vals,
             y=reward_pi_training_vals,
-            title="Pre-training exploration vs early SLI",
+            title=pre_period_exploration_title,
             x_label=str(
                 corr_pre_floor_exploration_vs_sli_xlabel_override
-                or "Fraction of floor explored during pre-training\n(exp fly)"
+                or pre_period_exploration_xlabel
             ),
             y_label=str(
                 corr_pre_floor_exploration_vs_sli_ylabel_override or early_lbl
@@ -2380,18 +2384,23 @@ def plot_cross_fly_correlations(
         if selected_mode is not None:
             if selected_mode == "top":
                 title_3b_sel = (
-                    "Pre-training exploration vs early SLI (top SLI-selected learners)"
+                    f"{pre_period_exploration_title} (top SLI-selected learners)"
                 )
                 filename_3b_sel = (
                     "corr_pre_floor_exploration_vs_sli_T1_first_top_selected"
                 )
             elif selected_mode == "bottom":
-                title_3b_sel = "Pre-training exploration vs early SLI (bottom SLI-selected learners)"
+                title_3b_sel = (
+                    f"{pre_period_exploration_title} (bottom SLI-selected learners)"
+                )
                 filename_3b_sel = (
                     "corr_pre_floor_exploration_vs_sli_T1_first_bottom_selected"
                 )
             else:
-                title_3b_sel = "Pre-training exploration vs early SLI (top vs bottom SLI-selected learners)"
+                title_3b_sel = (
+                    f"{pre_period_exploration_title} "
+                    "(top vs bottom SLI-selected learners)"
+                )
                 filename_3b_sel = (
                     "corr_pre_floor_exploration_vs_sli_T1_first_selected_extremes"
                 )
@@ -2405,7 +2414,7 @@ def plot_cross_fly_correlations(
                 title=title_3b_sel,
                 x_label=str(
                     corr_pre_floor_exploration_vs_sli_xlabel_override
-                    or "Fraction of floor explored during pre-training\n(exp fly)"
+                    or pre_period_exploration_xlabel
                 ),
                 y_label=str(
                     corr_pre_floor_exploration_vs_sli_ylabel_override or early_lbl
@@ -2422,17 +2431,17 @@ def plot_cross_fly_correlations(
     else:
         print(
             "[correlations] WARNING: missing reward_pi_training_vals; "
-            "skipping pre-training exploration vs early SLI plot"
+            "skipping pre-period exploration vs early SLI plot"
         )
 
-    # --- Plot 3c: Pre-training exploration vs SLI_final (training {trn_label_idx}) ---
+    # --- Plot 3c: Pre-period exploration vs SLI_final (training {trn_label_idx}) ---
     _scatter_with_corr(
         x=pre_coverage_vals,
         y=sli_vals,
-        title="Pre-training exploration vs SLI",
+        title=pre_period_exploration_title,
         x_label=str(
             corr_pre_floor_exploration_vs_sli_xlabel_override
-            or "Fraction of floor explored during pre-training\n(exp fly)"
+            or pre_period_exploration_xlabel
         ),
         y_label=str(corr_pre_floor_exploration_vs_sli_ylabel_override or y_label_sli),
         cfg=_cfg_with_plot_color(cfg, "pre_training_exploration_vs_sli"),
@@ -2442,16 +2451,19 @@ def plot_cross_fly_correlations(
 
     if selected_mode is not None:
         if selected_mode == "top":
-            title_3c_sel = "Pre-training exploration vs SLI (top SLI-selected learners)"
+            title_3c_sel = (
+                f"{pre_period_exploration_title} (top SLI-selected learners)"
+            )
             filename_3c_sel = "corr_pre_floor_exploration_vs_sli_final_top_selected"
         elif selected_mode == "bottom":
             title_3c_sel = (
-                "Pre-training exploration vs SLI (bottom SLI-selected learners)"
+                f"{pre_period_exploration_title} (bottom SLI-selected learners)"
             )
             filename_3c_sel = "corr_pre_floor_exploration_vs_sli_final_bottom_selected"
         else:
             title_3c_sel = (
-                "Pre-training exploration vs SLI (top vs bottom SLI-selected learners)"
+                f"{pre_period_exploration_title} "
+                "(top vs bottom SLI-selected learners)"
             )
             filename_3c_sel = (
                 "corr_pre_floor_exploration_vs_sli_final_selected_extremes"
@@ -2466,7 +2478,7 @@ def plot_cross_fly_correlations(
             title=title_3c_sel,
             x_label=str(
                 corr_pre_floor_exploration_vs_sli_xlabel_override
-                or "Fraction of floor explored during pre-training\n(exp fly)"
+                or pre_period_exploration_xlabel
             ),
             y_label=str(
                 corr_pre_floor_exploration_vs_sli_ylabel_override or y_label_sli

--- a/src/plotting/cross_fly_correlations.py
+++ b/src/plotting/cross_fly_correlations.py
@@ -440,12 +440,72 @@ def _shrink_clipped_ylabels(fig, *, min_scale: float = 0.72, pad_px: float = 2.0
     return changed
 
 
+def _split_axis_label_evenly(text: str) -> str:
+    words = text.split()
+    if len(words) < 4:
+        return text
+    mid = len(words) // 2
+    left, right = words[:mid], words[mid:]
+    if len(left) < 2 or len(right) < 2:
+        return text
+    return " ".join(left) + "\n" + " ".join(right)
+
+
+def _wrap_clipped_axis_labels(fig, *, pad_px: float = 2.0) -> bool:
+    """
+    Wrap axis labels only when their rendered bbox exceeds the figure.
+    """
+    try:
+        fig.canvas.draw()
+        renderer = fig.canvas.get_renderer()
+        fig_bbox = fig.get_window_extent(renderer=renderer)
+    except Exception:
+        return False
+
+    changed = False
+    for ax in fig.get_axes():
+        x_label = ax.xaxis.get_label()
+        x_text = x_label.get_text()
+        if x_label.get_visible() and x_text and "\n" not in x_text:
+            bbox = x_label.get_window_extent(renderer=renderer)
+            clipped = (
+                float(bbox.x0) < float(fig_bbox.x0) + pad_px
+                or float(bbox.x1) > float(fig_bbox.x1) - pad_px
+            )
+            if clipped:
+                wrapped = _split_axis_label_evenly(x_text)
+                if wrapped != x_text:
+                    x_label.set_text(wrapped)
+                    changed = True
+
+        y_label = ax.yaxis.get_label()
+        y_text = y_label.get_text()
+        if y_label.get_visible() and y_text and "\n" not in y_text:
+            bbox = y_label.get_window_extent(renderer=renderer)
+            clipped = (
+                float(bbox.y0) < float(fig_bbox.y0) + pad_px
+                or float(bbox.y1) > float(fig_bbox.y1) - pad_px
+            )
+            if clipped:
+                wrapped = _split_axis_label_evenly(y_text)
+                if wrapped != y_text:
+                    y_label.set_text(wrapped)
+                    changed = True
+
+    return changed
+
+
 def _finalize_correlation_layout(fig, customizer: PlotCustomizer, *, rect=None) -> None:
-    customizer.adjust_padding_proportionally()
+    customizer.adjust_padding_proportionally(wrap_axis_labels=False)
     if rect is None:
         fig.tight_layout()
     else:
         fig.tight_layout(rect=rect)
+    if _wrap_clipped_axis_labels(fig):
+        if rect is None:
+            fig.tight_layout()
+        else:
+            fig.tight_layout(rect=rect)
     if _shrink_clipped_ylabels(fig):
         if rect is None:
             fig.tight_layout()


### PR DESCRIPTION
## Summary
- Rename pre-period exploration correlation plots to `Pre-period exploration and SLI`
- Update the default X-axis label to `Fraction of floor explored during pre period (exp fly)`
- Preserve dynamic SLI Y-axis labels for both early-SLI and final/windowed-SLI variants
- Update selected top/bottom variant titles to use the new plot title stem
- Update CLI help text for the pre-period exploration correlation plot family

## Validation
- Ran `python -m py_compile src/plotting/cross_fly_correlations.py analyze.py`
- Manually checked regenerated correlation plots