### PR TITLE
Update pre-period SLI correlation labels

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -781,13 +781,13 @@ g.add_argument(
     "--corr-pre-reward-pi-vs-sli-xlabel",
     type=str,
     default=None,
-    help="Optional x-axis label override for the 'Baseline PI vs SLI' correlation plot family.",
+    help="Optional x-axis label override for the 'Pre-period SLI and SLI' correlation plot family.",
 )
 g.add_argument(
     "--corr-pre-reward-pi-vs-sli-ylabel",
     type=str,
     default=None,
-    help="Optional y-axis label override for the 'Baseline PI vs SLI' correlation plot family.",
+    help="Optional y-axis label override for the 'Pre-period SLI and SLI' correlation plot family.",
 )
 g.add_argument(
     "--corr-pre-floor-exploration-vs-sli-xlabel",

--- a/src/plotting/cross_fly_correlations.py
+++ b/src/plotting/cross_fly_correlations.py
@@ -2345,15 +2345,12 @@ def plot_cross_fly_correlations(
         customizer=customizer,
     )
 
-    # --- Plot 3: Pre-training reward PI (exp − yoked) vs SLI_final ---
+    # --- Plot 3: Pre-period SLI vs SLI_final ---
     _scatter_with_corr(
         x=pre_pi_diff_vals,
         y=sli_vals,
-        title="Baseline PI vs SLI",
-        x_label=str(
-            corr_pre_reward_pi_vs_sli_xlabel_override
-            or "Baseline PI\n(exp − yok, pre-training)"
-        ),
+        title="Pre-period SLI and SLI",
+        x_label=str(corr_pre_reward_pi_vs_sli_xlabel_override or "Pre-period SLI"),
         y_label=str(corr_pre_reward_pi_vs_sli_ylabel_override or y_label_sli),
         cfg=_cfg_with_plot_color(cfg, "baseline_pi_vs_sli"),
         filename="corr_pre_reward_pi_vs_sli",


### PR DESCRIPTION
## Summary
- Rename the baseline PI-to-SLI correlation plot to `Pre-period SLI and SLI`
- Update the default x-axis label to `Pre-period SLI`
- Preserve the existing dynamic SLI y-axis label
- Update CLI help text for the pre-period SLI correlation label overrides

## Validation
- Ran `python -m py_compile src/plotting/cross_fly_correlations.py analyze.py`
- Manually checked regenerated correlation plots