### PR TITLE
Apply metric-specific episode-count filters across paper metrics

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -4488,16 +4488,37 @@ g.add_argument(
 g.add_argument(
     "--agarose-dual-circle-min-total",
     type=int,
-    default=10,
+    default=None,
     help=(
-        "minimum number of dual-circle agarose episodes required to report a ratio "
-        "for a fly/window; smaller totals are left as NaN (use 0 for legacy behavior)"
+        "Deprecated alias for --min-agarose-episodes: minimum number of "
+        "dual-circle agarose episodes required to report a ratio for a fly/window; "
+        "smaller totals are left as NaN (use 0 to disable this filter)"
+    ),
+)
+g.add_argument(
+    "--min-agarose-episodes",
+    type=int,
+    default=None,
+    metavar="N",
+    help=(
+        "Minimum number of outer-circle entry/re-exit episodes required for one "
+        "fly/window before reporting agarose-avoidance metrics. Default: 5."
     ),
 )
 g.add_argument(
     "--turnback-dual-circle",
     action="store_true",
     help="analyze dual-circle reward turn-back metric",
+)
+g.add_argument(
+    "--min-turnback-episodes",
+    type=int,
+    default=None,
+    metavar="N",
+    help=(
+        "Minimum number of inner-circle exit/re-entry episodes required for one "
+        "fly/window before reporting turnback metrics. Default: 5."
+    ),
 )
 g.add_argument(
     "--turnback-inner-radius-mm",
@@ -4683,10 +4704,20 @@ g.add_argument(
     default=5,
     metavar="N",
     help=(
-        "Minimum number of between-reward trajectories required for one fly in "
-        "one sync bucket before reporting between-reward sync-bucket metrics "
-        "(mean max distance, return-leg distance, and per-segment COM). "
-        "Use 0 to disable this filter. Default: %(default)s."
+        "Deprecated alias for --min-between-reward-trajectories: minimum number "
+        "of between-reward trajectories required for one fly in one sync bucket "
+        "before reporting between-reward sync-bucket metrics. Use 0 to disable "
+        "this filter. Default: %(default)s."
+    ),
+)
+g.add_argument(
+    "--min-between-reward-trajectories",
+    type=int,
+    default=None,
+    metavar="N",
+    help=(
+        "Minimum number of between-reward trajectories required for one fly/window "
+        "before reporting between-reward trajectory metrics. Default: 5."
     ),
 )
 g.add_argument(

--- a/src/analysis/between_reward_filters.py
+++ b/src/analysis/between_reward_filters.py
@@ -1,23 +1,20 @@
 from __future__ import annotations
 
-import numpy as np
+from src.analysis.episode_filters import (
+    DEFAULT_MIN_EPISODES,
+    EPISODE_TYPE_BETWEEN_REWARD_TRAJECTORY,
+    mask_metric_by_min_episode_count,
+    min_episode_count_for_type,
+)
 
 
-DEFAULT_MIN_BETWEEN_REWARD_SYNC_BUCKET_TRAJECTORIES = 5
+DEFAULT_MIN_BETWEEN_REWARD_SYNC_BUCKET_TRAJECTORIES = DEFAULT_MIN_EPISODES
 BTW_RWD_MIN_TRAJECTORIES_OPT = "btw_rwd_sync_bucket_min_trajectories"
 
 
 def min_between_reward_sync_bucket_trajectories(opts) -> int:
     """Return the per-fly, per-sync-bucket between-reward trajectory threshold."""
-    raw = getattr(
-        opts,
-        BTW_RWD_MIN_TRAJECTORIES_OPT,
-        DEFAULT_MIN_BETWEEN_REWARD_SYNC_BUCKET_TRAJECTORIES,
-    )
-    try:
-        return max(0, int(raw or 0))
-    except (TypeError, ValueError):
-        return DEFAULT_MIN_BETWEEN_REWARD_SYNC_BUCKET_TRAJECTORIES
+    return min_episode_count_for_type(opts, EPISODE_TYPE_BETWEEN_REWARD_TRAJECTORY)
 
 
 def mask_metric_by_min_between_reward_trajectories(
@@ -31,9 +28,4 @@ def mask_metric_by_min_between_reward_trajectories(
     The filter is per fly/condition and per sync bucket. Counts are returned separately
     by callers so they remain the raw number of contributing trajectories.
     """
-    arr = np.asarray(values, dtype=float)
-    n = np.asarray(counts, dtype=int)
-    min_n = max(0, int(min_trajectories or 0))
-    if min_n <= 0:
-        return arr
-    return np.where(n >= min_n, arr, np.nan)
+    return mask_metric_by_min_episode_count(values, counts, min_trajectories)

--- a/src/analysis/episode_filters.py
+++ b/src/analysis/episode_filters.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+import numpy as np
+
+
+EPISODE_TYPE_BETWEEN_REWARD_TRAJECTORY = "between_reward_trajectory"
+EPISODE_TYPE_INNER_EXIT_REENTRY = "inner_exit_reentry"
+EPISODE_TYPE_OUTER_ENTRY_REEXIT = "outer_entry_reexit"
+
+DEFAULT_MIN_EPISODES = 5
+
+
+@dataclass(frozen=True)
+class EpisodeFilterSpec:
+    episode_type: str
+    primary_opt: str
+    default_min_episodes: int = DEFAULT_MIN_EPISODES
+    legacy_opts: tuple[str, ...] = ()
+
+
+EPISODE_FILTER_SPECS: Mapping[str, EpisodeFilterSpec] = {
+    EPISODE_TYPE_BETWEEN_REWARD_TRAJECTORY: EpisodeFilterSpec(
+        episode_type=EPISODE_TYPE_BETWEEN_REWARD_TRAJECTORY,
+        primary_opt="min_between_reward_trajectories",
+        legacy_opts=("btw_rwd_sync_bucket_min_trajectories",),
+    ),
+    EPISODE_TYPE_INNER_EXIT_REENTRY: EpisodeFilterSpec(
+        episode_type=EPISODE_TYPE_INNER_EXIT_REENTRY,
+        primary_opt="min_turnback_episodes",
+    ),
+    EPISODE_TYPE_OUTER_ENTRY_REEXIT: EpisodeFilterSpec(
+        episode_type=EPISODE_TYPE_OUTER_ENTRY_REEXIT,
+        primary_opt="min_agarose_episodes",
+        legacy_opts=("agarose_dual_circle_min_total",),
+    ),
+}
+
+
+def _normalize_min_episode_count(raw, *, default: int) -> int:
+    try:
+        return max(0, int(raw if raw is not None else default))
+    except (TypeError, ValueError):
+        return max(0, int(default))
+
+
+def min_episode_count_for_type(opts, episode_type: str) -> int:
+    """
+    Resolve the minimum episode count for a metric episode type.
+
+    Primary option names win when present and non-None. Legacy option names are
+    checked next so older CLI flags remain functional while metric code can move
+    toward episode-type-level configuration.
+    """
+    spec = EPISODE_FILTER_SPECS.get(str(episode_type))
+    if spec is None:
+        raise ValueError(f"unknown episode filter type: {episode_type!r}")
+
+    raw = getattr(opts, spec.primary_opt, None)
+    if raw is None:
+        for opt_name in spec.legacy_opts:
+            raw = getattr(opts, opt_name, None)
+            if raw is not None:
+                break
+
+    return _normalize_min_episode_count(raw, default=spec.default_min_episodes)
+
+
+def eligible_by_min_episode_count(counts, min_episodes: int) -> np.ndarray:
+    """Return a boolean mask of entries whose episode count passes the threshold."""
+    n = np.asarray(counts, dtype=int)
+    min_n = max(0, int(min_episodes or 0))
+    if min_n <= 0:
+        return np.ones(n.shape, dtype=bool)
+    return n >= min_n
+
+
+def mask_metric_by_min_episode_count(values, counts, min_episodes: int):
+    """
+    Mask metric values whose contributing episode count is too low.
+
+    The function intentionally returns masked metric values only; callers should
+    keep raw counts beside those values for diagnostics and pooled reductions.
+    """
+    arr = np.asarray(values, dtype=float)
+    keep = eligible_by_min_episode_count(counts, min_episodes)
+    return np.where(keep, arr, np.nan)

--- a/src/analysis/episode_filters.py
+++ b/src/analysis/episode_filters.py
@@ -87,3 +87,44 @@ def mask_metric_by_min_episode_count(values, counts, min_episodes: int):
     arr = np.asarray(values, dtype=float)
     keep = eligible_by_min_episode_count(counts, min_episodes)
     return np.where(keep, arr, np.nan)
+
+
+def episode_filter_accounting(counts, min_episodes: int, *, observed=None) -> dict:
+    """
+    Summarize how an episode-count threshold partitions metric units.
+
+    A "unit" is whatever shape the caller passes in: a fly for pooled scalar
+    metrics, or a fly/training/sync-bucket cell for time-dependent metrics.
+    """
+    n = np.asarray(counts, dtype=int)
+    if observed is None:
+        observed_mask = np.ones(n.shape, dtype=bool)
+    else:
+        observed_mask = np.asarray(observed, dtype=bool)
+        if observed_mask.shape != n.shape:
+            observed_mask = np.broadcast_to(observed_mask, n.shape)
+
+    min_n = max(0, int(min_episodes or 0))
+    eligible = eligible_by_min_episode_count(n, min_n)
+    considered = n[observed_mask].reshape(-1)
+    included = eligible[observed_mask].reshape(-1)
+    excluded_counts = considered[~included]
+
+    return {
+        "min_episodes": np.array(min_n, dtype=int),
+        "unit_count": np.array(considered.size, dtype=int),
+        "included_count": np.array(int(np.count_nonzero(included)), dtype=int),
+        "excluded_count": np.array(int(np.count_nonzero(~included)), dtype=int),
+        "episode_counts": np.asarray(considered, dtype=int),
+        "excluded_episode_counts": np.asarray(excluded_counts, dtype=int),
+    }
+
+
+def episode_filter_accounting_payload(
+    prefix: str, counts, min_episodes: int, *, observed=None
+) -> dict:
+    """Return NPZ-friendly accounting keys prefixed for a metric/scope/group."""
+    summary = episode_filter_accounting(
+        counts, min_episodes, observed=observed
+    )
+    return {f"{prefix}_{key}": value for key, value in summary.items()}

--- a/src/analysis/sli_bundle_utils.py
+++ b/src/analysis/sli_bundle_utils.py
@@ -483,16 +483,26 @@ def validate_turnback_ratio_bundle(bundle: dict, *, path: str | None = None) -> 
     total_ctrl = _validate_3d_distance_count_array(
         bundle, "turnback_total_ctrl", where=where, expected_shape=expected_shape
     )
+    min_total = int(as_scalar(bundle.get("min_turnback_episodes", 1)))
+    if min_total < 0:
+        raise ValueError(f"Bundle {where} has negative min_turnback_episodes")
 
     for key, ratio, total in (
         ("turnback_ratio_exp", ratio_exp, total_exp),
         ("turnback_ratio_ctrl", ratio_ctrl, total_ctrl),
     ):
-        if np.any(~np.isfinite(ratio[total > 0])):
-            raise ValueError(f"Bundle {where} has non-finite {key} where total > 0")
-        if np.any(np.isfinite(ratio[total == 0])):
-            raise ValueError(f"Bundle {where} has finite {key} where total == 0")
-        implied_turns = ratio[total > 0] * total[total > 0]
+        reportable = total >= max(1, min_total)
+        if np.any(~np.isfinite(ratio[reportable])):
+            raise ValueError(
+                f"Bundle {where} has non-finite {key} where total passes "
+                f"reporting threshold {min_total}"
+            )
+        if np.any(np.isfinite(ratio[~reportable])):
+            raise ValueError(
+                f"Bundle {where} has finite {key} where total is below "
+                f"reporting threshold {min_total}"
+            )
+        implied_turns = ratio[reportable] * total[reportable]
         if np.any(np.abs(implied_turns - np.rint(implied_turns)) > 1e-10):
             raise ValueError(
                 f"Bundle {where} has {key} values inconsistent with integer counts"
@@ -1040,6 +1050,9 @@ def validate_turnback_excursion_bin_bundle(
         n_videos=n_videos,
         n_bins=n_bins,
     )
+    min_total = int(as_scalar(bundle.get("min_turnback_episodes", 1)))
+    if min_total < 0:
+        raise ValueError(f"Bundle {where} has negative min_turnback_episodes")
 
     for key, ratio in (
         ("turnback_excursion_bin_ratio_exp", ratio_exp),
@@ -1066,12 +1079,19 @@ def validate_turnback_excursion_bin_bundle(
         ("turnback_excursion_bin_ratio_ctrl", ratio_ctrl, turn_ctrl, total_ctrl),
     ):
         expected = np.full_like(values, np.nan, dtype=float)
-        np.divide(values, total, out=expected, where=(total > 0))
+        reportable = total >= max(1, min_total)
+        np.divide(values, total, out=expected, where=reportable)
         both_finite = np.isfinite(ratio) & np.isfinite(expected)
-        if np.any(~np.isfinite(ratio[total > 0])):
-            raise ValueError(f"Bundle {where} has non-finite {key} where total > 0")
-        if np.any(np.isfinite(ratio[total == 0])):
-            raise ValueError(f"Bundle {where} has finite {key} where total == 0")
+        if np.any(~np.isfinite(ratio[reportable])):
+            raise ValueError(
+                f"Bundle {where} has non-finite {key} where total passes "
+                f"reporting threshold {min_total}"
+            )
+        if np.any(np.isfinite(ratio[~reportable])):
+            raise ValueError(
+                f"Bundle {where} has finite {key} where total is below "
+                f"reporting threshold {min_total}"
+            )
         if np.any(np.abs(ratio[both_finite] - expected[both_finite]) > 1e-10):
             raise ValueError(f"Bundle {where} has inconsistent {key} values")
 

--- a/src/analysis/sli_bundle_utils.py
+++ b/src/analysis/sli_bundle_utils.py
@@ -792,6 +792,12 @@ def validate_return_prob_excursion_bin_bundle(
         n_videos=n_videos,
         n_bins=n_bins,
     )
+    min_segments = int(as_scalar(bundle.get("btw_rwd_sync_bucket_min_trajectories", 1)))
+    if min_segments < 0:
+        raise ValueError(
+            f"Bundle {where} has negative btw_rwd_sync_bucket_min_trajectories"
+        )
+    sufficient_count = max(1, min_segments)
 
     for key, ratio in (
         ("return_prob_excursion_bin_ratio_exp", ratio_exp),
@@ -828,12 +834,19 @@ def validate_return_prob_excursion_bin_bundle(
         ),
     ):
         expected = np.full_like(values, np.nan, dtype=float)
-        np.divide(values, total, out=expected, where=(total > 0))
+        reportable = total >= sufficient_count
+        np.divide(values, total, out=expected, where=reportable)
         both_finite = np.isfinite(ratio) & np.isfinite(expected)
-        if np.any(~np.isfinite(ratio[total > 0])):
-            raise ValueError(f"Bundle {where} has non-finite {key} where total > 0")
-        if np.any(np.isfinite(ratio[total == 0])):
-            raise ValueError(f"Bundle {where} has finite {key} where total == 0")
+        if np.any(~np.isfinite(ratio[reportable])):
+            raise ValueError(
+                f"Bundle {where} has non-finite {key} where total passes "
+                f"reporting threshold {sufficient_count}"
+            )
+        if np.any(np.isfinite(ratio[~reportable])):
+            raise ValueError(
+                f"Bundle {where} has finite {key} where total is below "
+                f"reporting threshold {sufficient_count}"
+            )
         if np.any(np.abs(ratio[both_finite] - expected[both_finite]) > 1e-10):
             raise ValueError(f"Bundle {where} has inconsistent {key} values")
 

--- a/src/analysis/sli_bundle_utils.py
+++ b/src/analysis/sli_bundle_utils.py
@@ -17,6 +17,7 @@ BUNDLE_ARRAY_PREFIXES = (
     "commagN_",
     "between_reward_",
     "cum_reward_sli_",
+    "episode_filter_",
     "weaving_",
     "wallpct_",
     "turnback_",

--- a/src/analysis/sli_bundle_utils.py
+++ b/src/analysis/sli_bundle_utils.py
@@ -616,9 +616,16 @@ def validate_agarose_sli_bundle(bundle: dict, *, path: str | None = None) -> Non
         raise ValueError(f"Bundle {where} is missing agarose ratio keys: {missing}")
 
     expected_shape = _expected_sync_bucket_metric_shape(bundle, where=where)
-    min_total = int(as_scalar(bundle.get("agarose_dual_circle_min_total", 10)))
+    min_total = int(
+        as_scalar(
+            bundle.get(
+                "min_agarose_episodes",
+                bundle.get("agarose_dual_circle_min_total", 10),
+            )
+        )
+    )
     if min_total < 0:
-        raise ValueError(f"Bundle {where} has negative agarose_dual_circle_min_total")
+        raise ValueError(f"Bundle {where} has negative min_agarose_episodes")
 
     for suffix in ("exp", "ctrl"):
         _validate_ratio_count_semantics(

--- a/src/analysis/sli_bundle_utils.py
+++ b/src/analysis/sli_bundle_utils.py
@@ -341,13 +341,23 @@ def validate_between_reward_sync_bucket_distance_bundle(
     count_ctrl = _validate_3d_distance_count_array(
         bundle, count_ctrl_key, where=where, expected_shape=expected_shape
     )
+    min_segments = int(as_scalar(bundle.get("btw_rwd_sync_bucket_min_trajectories", 1)))
+    if min_segments < 0:
+        raise ValueError(
+            f"Bundle {where} has negative btw_rwd_sync_bucket_min_trajectories"
+        )
+    sufficient_count = max(1, min_segments)
 
     for key, values, counts in (
         (value_exp_key, value_exp, count_exp),
         (value_ctrl_key, value_ctrl, count_ctrl),
     ):
-        if np.any(np.isfinite(values[counts == 0])):
-            raise ValueError(f"Bundle {where} has finite {key} where count == 0")
+        finite = np.isfinite(values)
+        if np.any(finite & (counts < sufficient_count)):
+            raise ValueError(
+                f"Bundle {where} has finite {key} where count is below "
+                f"{sufficient_count}"
+            )
 
 
 def validate_between_reward_maxdist_bundle(

--- a/src/analysis/video_analysis.py
+++ b/src/analysis/video_analysis.py
@@ -80,6 +80,11 @@ from src.analysis.contact_event_training_comparison import (
 from src.analysis.between_reward_filters import (
     min_between_reward_sync_bucket_trajectories,
 )
+from src.analysis.episode_filters import (
+    EPISODE_TYPE_INNER_EXIT_REENTRY,
+    EPISODE_TYPE_OUTER_ENTRY_REEXIT,
+    min_episode_count_for_type,
+)
 from src.analysis.behavior_states import analyze_trajectory_behavior_states
 from src.analysis.ellipse_to_boundary_dist import (
     TrjDataContainer,
@@ -1821,6 +1826,9 @@ class VideoAnalysis:
             getattr(self.opts, "turnback_inner_radius_offset_px", 0.0) or 0.0
         )
         debug = bool(getattr(self.opts, "turnback_dual_circle_debug", False))
+        min_total = min_episode_count_for_type(
+            self.opts, EPISODE_TYPE_INNER_EXIT_REENTRY
+        )
 
         sync_ranges = getattr(self, "sync_bucket_ranges", None)
         if sync_ranges is None:
@@ -1888,6 +1896,8 @@ class VideoAnalysis:
                             break
         ratio = np.full_like(turn_counts, np.nan, dtype=float)
         np.divide(turn_counts, total_counts, out=ratio, where=(total_counts > 0))
+        if min_total > 0:
+            ratio[total_counts < min_total] = np.nan
 
         self.reward_turnback_dual_circle_counts = {
             "turnback": turn_counts,
@@ -1907,8 +1917,8 @@ class VideoAnalysis:
                  /
                 (# all such episodes whose entry frame falls in bucket b)
 
-        Ratios are reported as NaN when the denominator is below
-        opts.agarose_dual_circle_min_total.
+        Ratios are reported as NaN when the denominator is below the configured
+        outer entry/re-exit episode threshold.
 
         Results are stored in:
             self.agarose_dual_circle_counts = {
@@ -1924,8 +1934,8 @@ class VideoAnalysis:
         # Allow override but fall back to an option or default
         if delta_mm is None:
             delta_mm = getattr(self.opts, "agarose_outer_delta_mm", 0.5)
-        min_total = max(
-            0, int(getattr(self.opts, "agarose_dual_circle_min_total", 10))
+        min_total = min_episode_count_for_type(
+            self.opts, EPISODE_TYPE_OUTER_ENTRY_REEXIT
         )
 
         sync_ranges = getattr(self, "sync_bucket_ranges", None)
@@ -2025,8 +2035,8 @@ class VideoAnalysis:
         avoid_counts = np.zeros(n_flies, dtype=int)
         total_counts = np.zeros(n_flies, dtype=int)
         ratio = np.full(n_flies, np.nan, dtype=float)
-        min_total = max(
-            0, int(getattr(self.opts, "agarose_dual_circle_min_total", 10))
+        min_total = min_episode_count_for_type(
+            self.opts, EPISODE_TYPE_OUTER_ENTRY_REEXIT
         )
 
         pre_start = np.nan
@@ -2096,8 +2106,8 @@ class VideoAnalysis:
         avoid_counts = np.zeros((n_trn, n_flies), dtype=int)
         total_counts = np.zeros((n_trn, n_flies), dtype=int)
         ratio = np.full((n_trn, n_flies), np.nan, dtype=float)
-        min_total = max(
-            0, int(getattr(self.opts, "agarose_dual_circle_min_total", 10))
+        min_total = min_episode_count_for_type(
+            self.opts, EPISODE_TYPE_OUTER_ENTRY_REEXIT
         )
         pre_start = np.full(n_trn, np.nan, dtype=float)
         pre_stop = np.full(n_trn, np.nan, dtype=float)

--- a/src/exporting/agarose_sli_bundle.py
+++ b/src/exporting/agarose_sli_bundle.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import os
 import numpy as np
 
+from src.analysis.episode_filters import (
+    EPISODE_TYPE_OUTER_ENTRY_REEXIT,
+    min_episode_count_for_type,
+)
 from src.analysis.sli_bundle_utils import validate_agarose_sli_bundle
 from src.exporting.com_sli_bundle import (
     _compute_sli_scalar_and_timeseries_from_rpid,
@@ -438,7 +442,7 @@ def export_agarose_sli_bundle(vas, opts, gls, out_fn):
         "agarose_avoid_exp": avoid_exp,
         "agarose_avoid_ctrl": avoid_ctrl,
         "agarose_dual_circle_min_total": np.array(
-            max(0, int(getattr(opts, "agarose_dual_circle_min_total", 10))),
+            min_episode_count_for_type(opts, EPISODE_TYPE_OUTER_ENTRY_REEXIT),
             dtype=int,
         ),
         "group_label": np.array(group_label, dtype=object),

--- a/src/exporting/agarose_sli_bundle.py
+++ b/src/exporting/agarose_sli_bundle.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from src.analysis.episode_filters import (
     EPISODE_TYPE_OUTER_ENTRY_REEXIT,
+    episode_filter_accounting_payload,
     min_episode_count_for_type,
 )
 from src.analysis.sli_bundle_utils import validate_agarose_sli_bundle
@@ -389,6 +390,10 @@ def export_agarose_sli_bundle(vas, opts, gls, out_fn):
     except Exception:
         video_ids = np.array([f"va_{i}" for i in range(len(vas_ok))], dtype=object)
 
+    min_agarose_episodes = min_episode_count_for_type(
+        opts, EPISODE_TYPE_OUTER_ENTRY_REEXIT
+    )
+
     pre_payload = {}
     if bool(getattr(opts, "agarose_sli_include_pre", False)):
         (
@@ -430,11 +435,27 @@ def export_agarose_sli_bundle(vas, opts, gls, out_fn):
             "agarose_training_pre_label": np.array(
                 "training-specific pre last 10m", dtype=object
             ),
+            **episode_filter_accounting_payload(
+                "episode_filter_agarose_pre_exp",
+                pre_total_exp,
+                min_agarose_episodes,
+            ),
+            **episode_filter_accounting_payload(
+                "episode_filter_agarose_pre_ctrl",
+                pre_total_ctrl,
+                min_agarose_episodes,
+            ),
+            **episode_filter_accounting_payload(
+                "episode_filter_agarose_training_pre_exp",
+                trn_pre_total_exp,
+                min_agarose_episodes,
+            ),
+            **episode_filter_accounting_payload(
+                "episode_filter_agarose_training_pre_ctrl",
+                trn_pre_total_ctrl,
+                min_agarose_episodes,
+            ),
         }
-
-    min_agarose_episodes = min_episode_count_for_type(
-        opts, EPISODE_TYPE_OUTER_ENTRY_REEXIT
-    )
 
     payload = {
         "sli": sli,
@@ -447,6 +468,16 @@ def export_agarose_sli_bundle(vas, opts, gls, out_fn):
         "agarose_avoid_ctrl": avoid_ctrl,
         "min_agarose_episodes": np.array(min_agarose_episodes, dtype=int),
         "agarose_dual_circle_min_total": np.array(min_agarose_episodes, dtype=int),
+        **episode_filter_accounting_payload(
+            "episode_filter_agarose_sync_exp",
+            total_exp,
+            min_agarose_episodes,
+        ),
+        **episode_filter_accounting_payload(
+            "episode_filter_agarose_sync_ctrl",
+            total_ctrl,
+            min_agarose_episodes,
+        ),
         "group_label": np.array(group_label, dtype=object),
         "bucket_len_min": np.array(bucket_len_min, dtype=float),
         "training_names": training_names,

--- a/src/exporting/agarose_sli_bundle.py
+++ b/src/exporting/agarose_sli_bundle.py
@@ -432,6 +432,10 @@ def export_agarose_sli_bundle(vas, opts, gls, out_fn):
             ),
         }
 
+    min_agarose_episodes = min_episode_count_for_type(
+        opts, EPISODE_TYPE_OUTER_ENTRY_REEXIT
+    )
+
     payload = {
         "sli": sli,
         "sli_ts": sli_ts,
@@ -441,10 +445,8 @@ def export_agarose_sli_bundle(vas, opts, gls, out_fn):
         "agarose_total_ctrl": total_ctrl,
         "agarose_avoid_exp": avoid_exp,
         "agarose_avoid_ctrl": avoid_ctrl,
-        "agarose_dual_circle_min_total": np.array(
-            min_episode_count_for_type(opts, EPISODE_TYPE_OUTER_ENTRY_REEXIT),
-            dtype=int,
-        ),
+        "min_agarose_episodes": np.array(min_agarose_episodes, dtype=int),
+        "agarose_dual_circle_min_total": np.array(min_agarose_episodes, dtype=int),
         "group_label": np.array(group_label, dtype=object),
         "bucket_len_min": np.array(bucket_len_min, dtype=float),
         "training_names": training_names,

--- a/src/exporting/between_reward_maxdist_sli_bundle.py
+++ b/src/exporting/between_reward_maxdist_sli_bundle.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 import numpy as np
 
+from src.analysis.between_reward_filters import (
+    mask_metric_by_min_between_reward_trajectories,
+    min_between_reward_sync_bucket_trajectories,
+)
 from src.exporting.bundle_utils import (
     build_metric_plus_sli_bundle,
     save_sli_bundle,
@@ -108,6 +112,14 @@ def _extract_between_reward_maxdist_arrays(vas, opts=None):
             opts,
             f"[between-reward-maxdist-export] {vid}: exp finite={np.isfinite(mean_exp[vi]).sum()} / {mean_exp[vi].size}",
         )
+
+    min_segments = min_between_reward_sync_bucket_trajectories(opts)
+    mean_exp = mask_metric_by_min_between_reward_trajectories(
+        mean_exp, n_exp, min_segments
+    )
+    mean_ctrl = mask_metric_by_min_between_reward_trajectories(
+        mean_ctrl, n_ctrl, min_segments
+    )
 
     return mean_exp, mean_ctrl, n_exp, n_ctrl
 

--- a/src/exporting/return_prob_excursion_bin_sli_bundle.py
+++ b/src/exporting/return_prob_excursion_bin_sli_bundle.py
@@ -4,6 +4,9 @@ import os
 
 import numpy as np
 
+from src.analysis.between_reward_filters import (
+    min_between_reward_sync_bucket_trajectories,
+)
 from src.analysis.sli_bundle_utils import (
     validate_return_prob_excursion_bin_bundle,
     validate_sli_bundle,
@@ -273,6 +276,7 @@ def _compute_return_prob_curves(
     keep_first: int,
     last_sync_buckets: int,
     debug: bool,
+    min_trajectories: int = 0,
 ):
     bin_edges_mm, _open_ended_upper_bin = _resolve_open_ended_upper_edge(
         vas,
@@ -373,6 +377,8 @@ def _compute_return_prob_curves(
 
             ratio = np.full(n_bins, np.nan, dtype=float)
             np.divide(returns, total, out=ratio, where=(total > 0))
+            if min_trajectories > 0:
+                ratio[total < int(min_trajectories)] = np.nan
             if fly_idx == 0:
                 ret_exp[vi, :] = returns
                 total_exp[vi, :] = total
@@ -423,6 +429,7 @@ def export_return_prob_excursion_bin_sli_bundle(vas, opts, gls, out_fn):
         getattr(opts, "return_prob_excursion_bin_border_width_mm", 0.1) or 0.1
     )
     debug = bool(getattr(opts, "return_prob_excursion_bin_debug", False))
+    min_trajectories = min_between_reward_sync_bucket_trajectories(opts)
 
     bin_edges_mm, open_ended_upper_bin = _resolve_open_ended_upper_edge(
         vas_ok,
@@ -435,6 +442,7 @@ def export_return_prob_excursion_bin_sli_bundle(vas, opts, gls, out_fn):
         skip_first=skip_first,
         keep_first=keep_first,
         last_sync_buckets=last_sync_buckets,
+        min_trajectories=min_trajectories,
         debug=debug,
     )
     (
@@ -532,6 +540,9 @@ def export_return_prob_excursion_bin_sli_bundle(vas, opts, gls, out_fn):
         return_prob_excursion_bin_return_ctrl=np.asarray(ret_ctrl, dtype=float),
         return_prob_excursion_bin_total_exp=np.asarray(total_exp, dtype=int),
         return_prob_excursion_bin_total_ctrl=np.asarray(total_ctrl, dtype=int),
+        btw_rwd_sync_bucket_min_trajectories=np.array(
+            min_trajectories, dtype=int
+        ),
         return_prob_excursion_bin_edges_mm=np.asarray(bin_edges_mm, dtype=float),
         return_prob_excursion_bin_radii_mm=np.asarray(
             [] if legacy_bin_edges else bin_edges_mm, dtype=float

--- a/src/exporting/return_prob_outer_radius_sli_bundle.py
+++ b/src/exporting/return_prob_outer_radius_sli_bundle.py
@@ -4,6 +4,9 @@ import os
 
 import numpy as np
 
+from src.analysis.between_reward_filters import (
+    min_between_reward_sync_bucket_trajectories,
+)
 from src.exporting.com_sli_bundle import (
     _compute_sli_scalar_and_timeseries_from_rpid,
     _safe_group_label,
@@ -155,6 +158,7 @@ def _compute_return_prob_curves(
     keep_first: int,
     last_sync_buckets: int,
     debug: bool,
+    min_trajectories: int = 0,
 ):
     n_videos = len(vas)
     n_radii = int(outer_radii_mm.size)
@@ -233,6 +237,8 @@ def _compute_return_prob_curves(
                             returns += 1
 
                 ratio = np.nan if total <= 0 else (float(returns) / float(total))
+                if min_trajectories > 0 and total < int(min_trajectories):
+                    ratio = np.nan
                 if fly_idx == 0:
                     ret_exp[vi, ri] = int(returns)
                     total_exp[vi, ri] = int(total)
@@ -282,6 +288,7 @@ def export_return_prob_outer_radius_sli_bundle(vas, opts, gls, out_fn):
         getattr(opts, "return_prob_border_width_mm", 0.1) or 0.1
     )
     debug = bool(getattr(opts, "return_prob_outer_radius_debug", False))
+    min_trajectories = min_between_reward_sync_bucket_trajectories(opts)
 
     group_label = _safe_group_label(opts, gls)
     _dbg(opts, f"[return-prob-outer-radius] out={out_fn}")
@@ -316,6 +323,7 @@ def export_return_prob_outer_radius_sli_bundle(vas, opts, gls, out_fn):
         skip_first=skip_first,
         keep_first=keep_first,
         last_sync_buckets=last_sync_buckets,
+        min_trajectories=min_trajectories,
         debug=debug,
     )
 
@@ -379,6 +387,9 @@ def export_return_prob_outer_radius_sli_bundle(vas, opts, gls, out_fn):
         return_prob_outer_radius_return_ctrl=np.asarray(ret_ctrl, dtype=int),
         return_prob_outer_radius_total_exp=np.asarray(total_exp, dtype=int),
         return_prob_outer_radius_total_ctrl=np.asarray(total_ctrl, dtype=int),
+        btw_rwd_sync_bucket_min_trajectories=np.array(
+            min_trajectories, dtype=int
+        ),
         return_prob_outer_radius_outer_radii_mm=np.asarray(
             outer_radii_mm, dtype=float
         ),

--- a/src/exporting/turnback_excursion_bin_sli_bundle.py
+++ b/src/exporting/turnback_excursion_bin_sli_bundle.py
@@ -5,6 +5,10 @@ import csv
 
 import numpy as np
 
+from src.analysis.episode_filters import (
+    EPISODE_TYPE_INNER_EXIT_REENTRY,
+    min_episode_count_for_type,
+)
 from src.analysis.sli_bundle_utils import (
     validate_sli_bundle,
     validate_turnback_excursion_bin_bundle,
@@ -319,6 +323,7 @@ def _compute_turnback_curves(
     keep_first: int,
     last_sync_buckets: int,
     debug: bool,
+    min_episodes: int = 0,
 ):
     bin_edges_mm, _open_ended_upper_bin = _resolve_open_ended_upper_edge(
         vas,
@@ -435,6 +440,9 @@ def _compute_turnback_curves(
 
             ratio = np.full(n_bins, np.nan, dtype=float)
             np.divide(turns, total, out=ratio, where=(total > 0))
+            min_n = max(0, int(min_episodes or 0))
+            if min_n > 0:
+                ratio[total < min_n] = np.nan
             if fly_idx == 0:
                 turn_exp[vi, :] = turns
                 total_exp[vi, :] = total
@@ -488,6 +496,7 @@ def _compute_pair_curves(
     keep_first: int,
     last_sync_buckets: int,
     debug: bool,
+    min_episodes: int = 0,
 ):
     n_videos = len(vas)
     n_pairs = int(inner_deltas_mm.size)
@@ -568,7 +577,12 @@ def _compute_pair_curves(
                         if bool(ep.get("turns_back", False)):
                             turns += 1
 
-                ratio = np.nan if total <= 0 else float(turns) / float(total)
+                min_n = max(0, int(min_episodes or 0))
+                ratio = (
+                    np.nan
+                    if total <= 0 or (min_n > 0 and total < min_n)
+                    else float(turns) / float(total)
+                )
                 if fly_idx == 0:
                     turn_exp[vi, pair_idx] = float(turns)
                     total_exp[vi, pair_idx] = int(total)
@@ -788,6 +802,7 @@ def export_turnback_excursion_bin_sli_bundle(vas, opts, gls, out_fn):
         getattr(opts, "turnback_inner_radius_offset_px", 0.0) or 0.0
     )
     debug = bool(getattr(opts, "turnback_excursion_bin_debug", False))
+    min_episodes = min_episode_count_for_type(opts, EPISODE_TYPE_INNER_EXIT_REENTRY)
 
     if pair_deltas_mm is None:
         bin_edges_mm, open_ended_upper_bin = _resolve_open_ended_upper_edge(
@@ -825,6 +840,7 @@ def export_turnback_excursion_bin_sli_bundle(vas, opts, gls, out_fn):
             keep_first=keep_first,
             last_sync_buckets=last_sync_buckets,
             debug=debug,
+            min_episodes=min_episodes,
         )
         pair_inner_deltas_mm = None
         pair_outer_deltas_mm = None
@@ -852,6 +868,7 @@ def export_turnback_excursion_bin_sli_bundle(vas, opts, gls, out_fn):
             keep_first=keep_first,
             last_sync_buckets=last_sync_buckets,
             debug=debug,
+            min_episodes=min_episodes,
         )
 
     n_videos = len(vas_ok)
@@ -951,6 +968,7 @@ def export_turnback_excursion_bin_sli_bundle(vas, opts, gls, out_fn):
             radius_offset_px, dtype=float
         ),
         turnback_excursion_bin_border_width_mm=np.array(border_width_mm, dtype=float),
+        min_turnback_episodes=np.array(min_episodes, dtype=int),
         turnback_excursion_bin_window_summary=window_strings,
         turnback_excursion_bin_description=np.asarray(
             (

--- a/src/exporting/turnback_excursion_bin_sli_bundle.py
+++ b/src/exporting/turnback_excursion_bin_sli_bundle.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from src.analysis.episode_filters import (
     EPISODE_TYPE_INNER_EXIT_REENTRY,
+    episode_filter_accounting_payload,
     min_episode_count_for_type,
 )
 from src.analysis.sli_bundle_utils import (
@@ -943,6 +944,16 @@ def export_turnback_excursion_bin_sli_bundle(vas, opts, gls, out_fn):
         turnback_excursion_bin_turn_ctrl=np.asarray(turn_ctrl, dtype=float),
         turnback_excursion_bin_total_exp=np.asarray(total_exp, dtype=int),
         turnback_excursion_bin_total_ctrl=np.asarray(total_ctrl, dtype=int),
+        **episode_filter_accounting_payload(
+            "episode_filter_turnback_excursion_bin_exp",
+            total_exp,
+            min_episodes,
+        ),
+        **episode_filter_accounting_payload(
+            "episode_filter_turnback_excursion_bin_ctrl",
+            total_ctrl,
+            min_episodes,
+        ),
         turnback_excursion_bin_edges_mm=np.asarray(bin_edges_mm, dtype=float),
         turnback_excursion_bin_radii_mm=np.asarray(
             [] if legacy_bin_edges else bin_edges_mm, dtype=float

--- a/src/exporting/turnback_outer_radius_sli_bundle.py
+++ b/src/exporting/turnback_outer_radius_sli_bundle.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from src.analysis.episode_filters import (
     EPISODE_TYPE_INNER_EXIT_REENTRY,
+    episode_filter_accounting_payload,
     min_episode_count_for_type,
 )
 from src.exporting.com_sli_bundle import (
@@ -388,6 +389,16 @@ def export_turnback_outer_radius_sli_bundle(vas, opts, gls, out_fn):
         turnback_outer_radius_turn_ctrl=np.asarray(turn_ctrl, dtype=int),
         turnback_outer_radius_total_exp=np.asarray(total_exp, dtype=int),
         turnback_outer_radius_total_ctrl=np.asarray(total_ctrl, dtype=int),
+        **episode_filter_accounting_payload(
+            "episode_filter_turnback_outer_radius_exp",
+            total_exp,
+            min_episodes,
+        ),
+        **episode_filter_accounting_payload(
+            "episode_filter_turnback_outer_radius_ctrl",
+            total_ctrl,
+            min_episodes,
+        ),
         turnback_outer_radius_outer_radii_mm=np.asarray(outer_radii_mm, dtype=float),
         turnback_outer_radius_outer_deltas_mm=np.asarray(
             outer_radii_mm if legacy_outer_radii else [], dtype=float

--- a/src/exporting/turnback_outer_radius_sli_bundle.py
+++ b/src/exporting/turnback_outer_radius_sli_bundle.py
@@ -4,6 +4,10 @@ import os
 
 import numpy as np
 
+from src.analysis.episode_filters import (
+    EPISODE_TYPE_INNER_EXIT_REENTRY,
+    min_episode_count_for_type,
+)
 from src.exporting.com_sli_bundle import (
     _compute_sli_scalar_and_timeseries_from_rpid,
     _safe_group_label,
@@ -154,6 +158,7 @@ def _compute_outer_radius_curves(
     keep_first: int,
     last_sync_buckets: int,
     debug: bool,
+    min_episodes: int = 0,
 ):
     n_videos = len(vas)
     n_radii = int(outer_radii_mm.size)
@@ -227,7 +232,12 @@ def _compute_outer_radius_curves(
                         if bool(ep.get("turns_back", False)):
                             turns += 1
 
-                ratio = np.nan if total <= 0 else (float(turns) / float(total))
+                min_n = max(0, int(min_episodes or 0))
+                ratio = (
+                    np.nan
+                    if total <= 0 or (min_n > 0 and total < min_n)
+                    else (float(turns) / float(total))
+                )
                 if fly_idx == 0:
                     turn_exp[vi, ri] = int(turns)
                     total_exp[vi, ri] = int(total)
@@ -278,6 +288,7 @@ def export_turnback_outer_radius_sli_bundle(vas, opts, gls, out_fn):
         getattr(opts, "turnback_inner_radius_offset_px", 0.0) or 0.0
     )
     debug = bool(getattr(opts, "turnback_outer_radius_debug", False))
+    min_episodes = min_episode_count_for_type(opts, EPISODE_TYPE_INNER_EXIT_REENTRY)
 
     group_label = _safe_group_label(opts, gls)
     _dbg(opts, f"[turnback-outer-radius] out={out_fn}")
@@ -314,6 +325,7 @@ def export_turnback_outer_radius_sli_bundle(vas, opts, gls, out_fn):
         keep_first=keep_first,
         last_sync_buckets=last_sync_buckets,
         debug=debug,
+        min_episodes=min_episodes,
     )
 
     try:
@@ -398,6 +410,7 @@ def export_turnback_outer_radius_sli_bundle(vas, opts, gls, out_fn):
             radius_offset_px, dtype=float
         ),
         turnback_outer_radius_border_width_mm=np.array(border_width_mm, dtype=float),
+        min_turnback_episodes=np.array(min_episodes, dtype=int),
         turnback_outer_radius_window_summary=np.asarray(window_strings, dtype=object),
         group_label=np.array(group_label, dtype=object),
         training_names=training_names,

--- a/src/exporting/turnback_sli_bundle.py
+++ b/src/exporting/turnback_sli_bundle.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from src.analysis.episode_filters import (
     EPISODE_TYPE_INNER_EXIT_REENTRY,
+    episode_filter_accounting_payload,
     min_episode_count_for_type,
 )
 from src.analysis.sli_bundle_utils import (
@@ -232,6 +233,10 @@ def export_turnback_sli_bundle(vas, opts, gls, out_fn):
         fly_ids = np.array([-1] * len(vas_ok), dtype=int)
         video_ids = np.array([f"va_{i}" for i in range(len(vas_ok))], dtype=object)
 
+    min_turnback_episodes = min_episode_count_for_type(
+        opts, EPISODE_TYPE_INNER_EXIT_REENTRY
+    )
+
     payload = dict(
         sli=sli,
         sli_ts=sli_ts,
@@ -239,6 +244,16 @@ def export_turnback_sli_bundle(vas, opts, gls, out_fn):
         turnback_ratio_ctrl=ratio_ctrl,
         turnback_total_exp=total_exp,
         turnback_total_ctrl=total_ctrl,
+        **episode_filter_accounting_payload(
+            "episode_filter_turnback_sync_exp",
+            total_exp,
+            min_turnback_episodes,
+        ),
+        **episode_filter_accounting_payload(
+            "episode_filter_turnback_sync_ctrl",
+            total_ctrl,
+            min_turnback_episodes,
+        ),
         group_label=np.array(group_label, dtype=object),
         bucket_len_min=np.array(bucket_len_min, dtype=float),
         training_names=training_names,
@@ -300,10 +315,7 @@ def export_turnback_sli_bundle(vas, opts, gls, out_fn):
         turnback_inner_radius_offset_px=np.array(
             float(getattr(opts, "turnback_inner_radius_offset_px", 0.0)), dtype=float
         ),
-        min_turnback_episodes=np.array(
-            min_episode_count_for_type(opts, EPISODE_TYPE_INNER_EXIT_REENTRY),
-            dtype=int,
-        ),
+        min_turnback_episodes=np.array(min_turnback_episodes, dtype=int),
     )
     validate_sli_bundle(payload, path=out_fn)
     validate_turnback_ratio_bundle(payload, path=out_fn)

--- a/src/exporting/turnback_sli_bundle.py
+++ b/src/exporting/turnback_sli_bundle.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import os
 import numpy as np
 
+from src.analysis.episode_filters import (
+    EPISODE_TYPE_INNER_EXIT_REENTRY,
+    min_episode_count_for_type,
+)
 from src.analysis.sli_bundle_utils import (
     validate_sli_bundle,
     validate_turnback_ratio_bundle,
@@ -295,6 +299,10 @@ def export_turnback_sli_bundle(vas, opts, gls, out_fn):
         ),
         turnback_inner_radius_offset_px=np.array(
             float(getattr(opts, "turnback_inner_radius_offset_px", 0.0)), dtype=float
+        ),
+        min_turnback_episodes=np.array(
+            min_episode_count_for_type(opts, EPISODE_TYPE_INNER_EXIT_REENTRY),
+            dtype=int,
         ),
     )
     validate_sli_bundle(payload, path=out_fn)

--- a/src/plotting/between_reward_tortuosity_mean_swarm.py
+++ b/src/plotting/between_reward_tortuosity_mean_swarm.py
@@ -6,6 +6,9 @@ from typing import Sequence
 import numpy as np
 import matplotlib.pyplot as plt
 
+from src.analysis.between_reward_filters import (
+    min_between_reward_sync_bucket_trajectories,
+)
 from src.plotting.between_reward_segment_binning import sync_bucket_window
 from src.plotting.between_reward_segment_metrics import tortuosity_metric_masked
 from src.plotting.palettes import (
@@ -128,14 +131,18 @@ class BetweenRewardTortuosityMeanSwarmPlotter(TrainingMetricScalarBarsPlotter):
             wwin[: len(wseg)] = wseg > 0
         return ~wwin
 
-    def _collect_values_by_training_per_fly_scalar(
+    def _effective_min_segments_per_fly(self) -> int:
+        shared_min = min_between_reward_sync_bucket_trajectories(self.opts)
+        legacy_min = int(max(1, getattr(self.cfg, "min_segments_per_fly", 1) or 1))
+        return max(shared_min, legacy_min)
+
+    def _collect_tortuosity_aggregates_by_training_per_fly(
         self,
-    ) -> list[list[tuple[str, float]]]:
+    ) -> list[list[tuple[str, float, int]]]:
         n_trn = self._n_trainings()
-        out: list[list[tuple[str, float]]] = [[] for _ in range(n_trn)]
+        out: list[list[tuple[str, float, int]]] = [[] for _ in range(n_trn)]
         warned_missing_wc = [False]
         min_walk_frames = int(max(2, getattr(self.cfg, "min_walk_frames", 2) or 2))
-        min_segments = int(max(1, getattr(self.cfg, "min_segments_per_fly", 1) or 1))
         mode = str(
             getattr(self.cfg, "metric_mode", "path_over_max_radius")
             or "path_over_max_radius"
@@ -275,14 +282,53 @@ class BetweenRewardTortuosityMeanSwarmPlotter(TrainingMetricScalarBarsPlotter):
                         if np.isfinite(val):
                             vals.append(float(val))
 
-                    if len(vals) < min_segments:
+                    if not vals:
                         continue
+                    arr = np.asarray(vals, dtype=float)
                     out[t_idx].append(
                         (
                             self._unit_id(va, f=f),
-                            float(np.nanmean(np.asarray(vals, dtype=float))),
+                            float(np.nansum(arr)),
+                            int(np.sum(np.isfinite(arr))),
                         )
                     )
+        return out
+
+    def _collect_values_by_training_per_fly_scalar(
+        self,
+    ) -> list[list[tuple[str, float]]]:
+        min_segments = self._effective_min_segments_per_fly()
+        out: list[list[tuple[str, float]]] = []
+
+        for panel in self._collect_tortuosity_aggregates_by_training_per_fly():
+            vals: list[tuple[str, float]] = []
+            for uid, total, count in panel:
+                if count >= min_segments and count > 0:
+                    vals.append((uid, float(total) / float(count)))
+                elif count > 0:
+                    vals.append((uid, np.nan))
+            out.append(vals)
+
+        return out
+
+    def _collect_pooled_values_per_fly_scalar(self, training_indices):
+        min_segments = self._effective_min_segments_per_fly()
+        by_training = self._collect_tortuosity_aggregates_by_training_per_fly()
+        sums: dict[str, float] = {}
+        counts: dict[str, int] = {}
+
+        for t_idx in training_indices:
+            if t_idx < 0 or t_idx >= len(by_training):
+                continue
+            for uid, total, count in by_training[t_idx]:
+                sums[uid] = sums.get(uid, 0.0) + float(total)
+                counts[uid] = counts.get(uid, 0) + int(count)
+
+        out: list[tuple[str, float]] = []
+        for uid in sorted(sums):
+            count = counts.get(uid, 0)
+            if count >= min_segments and count > 0:
+                out.append((uid, float(sums[uid]) / float(count)))
         return out
 
     def compute_scalar_panels(self) -> dict:
@@ -306,9 +352,7 @@ class BetweenRewardTortuosityMeanSwarmPlotter(TrainingMetricScalarBarsPlotter):
                     getattr(self.cfg, "exclude_reward_endpoints", False)
                 ),
                 "min_walk_frames": int(getattr(self.cfg, "min_walk_frames", 2) or 2),
-                "min_segments_per_fly": int(
-                    getattr(self.cfg, "min_segments_per_fly", 1) or 1
-                ),
+                "min_segments_per_fly": int(self._effective_min_segments_per_fly()),
                 "min_displacement_mm": float(
                     getattr(self.cfg, "min_displacement_mm", 0.0) or 0.0
                 ),

--- a/src/plotting/btw_rwd_return_leg_dist_collectors.py
+++ b/src/plotting/btw_rwd_return_leg_dist_collectors.py
@@ -72,19 +72,20 @@ class ReturnLegDistPerFlyCollector:
             pass
         return None
 
-    def _collect_return_leg_means_by_training_per_fly(
+    def _collect_return_leg_aggregates_by_training_per_fly(
         self,
-    ) -> list[list[tuple[str, float]]]:
+    ) -> list[list[tuple[str, float, int]]]:
         """
         Returns
         -------
-        list[list[tuple[str, float]]]
+        list[list[tuple[str, float, int]]]
             Outer list length n_trainings.
             For each training t:
-              out[t] is a list of (unit_id, mean_dt_tail_mm_per_segment) for flies with >=1 valid segment.
+              out[t] is a list of (unit_id, sum_dt_tail_mm, n_segments) for flies
+              with >=1 valid segment.
         """
         n_trn = self._n_trainings()
-        out: list[list[tuple[str, float]]] = [[] for _ in range(n_trn)]
+        out: list[list[tuple[str, float, int]]] = [[] for _ in range(n_trn)]
 
         # Shared knobs (same names/behavior as the binned disttrav plotter)
         exclude_wall = bool(getattr(self.opts, "com_exclude_wall_contact", False))
@@ -192,10 +193,52 @@ class ReturnLegDistPerFlyCollector:
                     if not tail_vals:
                         continue
 
+                    vals = np.asarray(tail_vals, dtype=float)
                     uid = self._unit_id(va, f=f)
-                    out[t_idx].append(
-                        (uid, float(np.mean(np.asarray(tail_vals, dtype=float))))
-                    )
+                    out[t_idx].append((uid, float(np.sum(vals)), int(vals.size)))
+        return out
+
+    def _collect_return_leg_means_by_training_per_fly(
+        self,
+    ) -> list[list[tuple[str, float]]]:
+        """
+        Return per-training scalar means after applying the selected episode filter.
+        """
+        min_segments = min_between_reward_sync_bucket_trajectories(self.opts)
+        out: list[list[tuple[str, float]]] = []
+        for panel in self._collect_return_leg_aggregates_by_training_per_fly():
+            vals: list[tuple[str, float]] = []
+            for uid, total, count in panel:
+                if count >= min_segments and count > 0:
+                    vals.append((uid, float(total) / float(count)))
+                elif count > 0:
+                    vals.append((uid, np.nan))
+            out.append(vals)
+        return out
+
+    def _collect_return_leg_pooled_means_per_fly(
+        self, training_indices
+    ) -> list[tuple[str, float]]:
+        """
+        Return one scalar per fly after pooling selected trainings at episode level.
+        """
+        min_segments = min_between_reward_sync_bucket_trajectories(self.opts)
+        by_training = self._collect_return_leg_aggregates_by_training_per_fly()
+        sums: dict[str, float] = {}
+        counts: dict[str, int] = {}
+
+        for t_idx in training_indices:
+            if t_idx < 0 or t_idx >= len(by_training):
+                continue
+            for uid, total, count in by_training[t_idx]:
+                sums[uid] = sums.get(uid, 0.0) + float(total)
+                counts[uid] = counts.get(uid, 0) + int(count)
+
+        out: list[tuple[str, float]] = []
+        for uid in sorted(sums):
+            count = counts.get(uid, 0)
+            if count >= min_segments and count > 0:
+                out.append((uid, float(sums[uid]) / float(count)))
         return out
 
     def collect_return_leg_sync_bucket_arrays(

--- a/src/plotting/btw_rwd_return_leg_dist_totals.py
+++ b/src/plotting/btw_rwd_return_leg_dist_totals.py
@@ -32,3 +32,6 @@ class ReturnLegDistTotalsPlotter(
 
     def _collect_values_by_training_per_fly_scalar(self):
         return self._collect_return_leg_means_by_training_per_fly()
+
+    def _collect_pooled_values_per_fly_scalar(self, training_indices):
+        return self._collect_return_leg_pooled_means_per_fly(training_indices)

--- a/src/plotting/training_metric_scalar_bars.py
+++ b/src/plotting/training_metric_scalar_bars.py
@@ -118,6 +118,39 @@ class TrainingMetricScalarBarsPlotter:
             "trainings_ignored": False,
         }
 
+    def _pooled_training_indices(self, n_panels: int):
+        t = self.cfg.trainings
+        if not t:
+            return list(range(n_panels)), {
+                "trainings_user": None,
+                "trainings_effective": list(range(1, n_panels + 1)),
+                "trainings_dropped_out_of_range": [],
+                "trainings_ignored": False,
+            }
+
+        keep = []
+        dropped = []
+        seen = set()
+        for x in t:
+            try:
+                idx0 = int(x) - 1
+            except Exception:
+                continue
+            if idx0 < 0 or idx0 >= n_panels:
+                dropped.append(int(x))
+                continue
+            if idx0 not in seen:
+                keep.append(idx0)
+                seen.add(idx0)
+
+        keep.sort()
+        return keep, {
+            "trainings_user": list(t),
+            "trainings_effective": [i + 1 for i in keep],
+            "trainings_dropped_out_of_range": sorted(set(dropped)),
+            "trainings_ignored": False,
+        }
+
     def _collect_values_by_training_per_fly_scalar(
         self,
     ) -> list[list[tuple[str, float]]]:
@@ -126,6 +159,17 @@ class TrainingMetricScalarBarsPlotter:
           out[t] = list of (unit_id, scalar_value)
         """
         raise NotImplementedError
+
+    def _collect_pooled_values_per_fly_scalar(
+        self, training_indices: Sequence[int]
+    ) -> list[tuple[str, float]] | None:
+        """
+        Optionally return one scalar per unit after pooling selected trainings.
+
+        Subclasses that need denominator-aware pooling can override this. Returning
+        None keeps the legacy fallback, which combines already-reduced scalars.
+        """
+        return None
 
     def compute_scalar_panels(self) -> dict[str, Any]:
         vals_by_trn = self._collect_values_by_training_per_fly_scalar()
@@ -142,27 +186,35 @@ class TrainingMetricScalarBarsPlotter:
             }
 
         if self.cfg.pool_trainings:
-            acc = defaultdict(float)
-            for panel in vals_by_trn:
-                for uid, v in panel:
-                    if v is None:
+            pool_indices, sel_info = self._pooled_training_indices(len(vals_by_trn))
+            pooled_values = self._collect_pooled_values_per_fly_scalar(pool_indices)
+            if pooled_values is not None:
+                vals_by_panel = [list(pooled_values)]
+            else:
+                acc = defaultdict(float)
+                for i in pool_indices:
+                    if i < 0 or i >= len(vals_by_trn):
                         continue
-                    try:
-                        vv = float(v)
-                    except Exception:
-                        continue
-                    if np.isfinite(vv):
-                        acc[uid] += vv
+                    panel = vals_by_trn[i]
+                    for uid, v in panel:
+                        if v is None:
+                            continue
+                        try:
+                            vv = float(v)
+                        except Exception:
+                            continue
+                        if np.isfinite(vv):
+                            acc[uid] += vv
 
-            pooled_ids = sorted(acc.keys())
-            vals_by_panel = [[(uid, float(acc[uid])) for uid in pooled_ids]]
-            panel_labels = ["All trainings combined"]
-            sel_info = {
-                "trainings_ignored": True,
-                "trainings_user": (
-                    list(self.cfg.trainings) if self.cfg.trainings else None
-                ),
-            }
+                pooled_ids = sorted(acc.keys())
+                vals_by_panel = [[(uid, float(acc[uid])) for uid in pooled_ids]]
+            panel_labels = [
+                (
+                    "All trainings combined"
+                    if not self.cfg.trainings
+                    else "Selected trainings combined"
+                )
+            ]
         else:
             vals_by_panel = vals_by_trn
             panel_labels = self._training_labels(len(vals_by_panel))

--- a/src/plotting/wall_contacts_per_reward_interval_totals.py
+++ b/src/plotting/wall_contacts_per_reward_interval_totals.py
@@ -5,6 +5,9 @@ import os
 
 import numpy as np
 
+from src.analysis.between_reward_filters import (
+    min_between_reward_sync_bucket_trajectories,
+)
 from src.plotting.between_reward_segment_binning import sync_bucket_window
 from src.plotting.training_metric_scalar_bars import (
     TrainingMetricScalarBarsConfig,
@@ -104,11 +107,17 @@ class WallContactsPerRewardIntervalPerFlyCollector:
 
         return counts
 
-    def _collect_wall_contact_interval_means_by_training_per_fly(
+    def _collect_wall_contact_interval_aggregates_by_training_per_fly(
         self,
-    ) -> list[list[tuple[str, float]]]:
+    ) -> list[list[tuple[str, float, int]]]:
+        """
+        Return wall-contact sums and interval counts per fly/training.
+
+        The count is the number of valid between-reward intervals in the selected
+        sync-bucket window, so it is also the denominator for the episode filter.
+        """
         n_trn = self._n_trainings()
-        out: list[list[tuple[str, float]]] = [[] for _ in range(n_trn)]
+        out: list[list[tuple[str, float, int]]] = [[] for _ in range(n_trn)]
 
         for va in self.vas:
             if getattr(va, "_skipped", False):
@@ -153,8 +162,59 @@ class WallContactsPerRewardIntervalPerFlyCollector:
                         continue
 
                     uid = self._unit_id(va, f=f)
-                    out[t_idx].append((uid, float(np.mean(counts.astype(float)))))
+                    out[t_idx].append(
+                        (
+                            uid,
+                            float(np.sum(counts.astype(float))),
+                            int(counts.size),
+                        )
+                    )
 
+        return out
+
+    def _collect_wall_contact_interval_means_by_training_per_fly(
+        self,
+    ) -> list[list[tuple[str, float]]]:
+        """
+        Return per-training means after applying the between-reward episode filter.
+        """
+        min_intervals = min_between_reward_sync_bucket_trajectories(self.opts)
+        out: list[list[tuple[str, float]]] = []
+
+        for panel in self._collect_wall_contact_interval_aggregates_by_training_per_fly():
+            vals: list[tuple[str, float]] = []
+            for uid, total, count in panel:
+                if count >= min_intervals and count > 0:
+                    vals.append((uid, float(total) / float(count)))
+                elif count > 0:
+                    vals.append((uid, np.nan))
+            out.append(vals)
+
+        return out
+
+    def _collect_wall_contact_interval_pooled_means_per_fly(
+        self, training_indices
+    ) -> list[tuple[str, float]]:
+        """
+        Return one scalar per fly after pooling selected trainings at episode level.
+        """
+        min_intervals = min_between_reward_sync_bucket_trajectories(self.opts)
+        by_training = self._collect_wall_contact_interval_aggregates_by_training_per_fly()
+        sums: dict[str, float] = {}
+        counts: dict[str, int] = {}
+
+        for t_idx in training_indices:
+            if t_idx < 0 or t_idx >= len(by_training):
+                continue
+            for uid, total, count in by_training[t_idx]:
+                sums[uid] = sums.get(uid, 0.0) + float(total)
+                counts[uid] = counts.get(uid, 0) + int(count)
+
+        out: list[tuple[str, float]] = []
+        for uid in sorted(sums):
+            count = counts.get(uid, 0)
+            if count >= min_intervals and count > 0:
+                out.append((uid, float(sums[uid]) / float(count)))
         return out
 
 
@@ -182,3 +242,6 @@ class WallContactsPerRewardIntervalTotalsPlotter(
 
     def _collect_values_by_training_per_fly_scalar(self):
         return self._collect_wall_contact_interval_means_by_training_per_fly()
+
+    def _collect_pooled_values_per_fly_scalar(self, training_indices):
+        return self._collect_wall_contact_interval_pooled_means_per_fly(training_indices)

--- a/test/paper_metrics/test_agarose_avoidance_bundle_invariants.py
+++ b/test/paper_metrics/test_agarose_avoidance_bundle_invariants.py
@@ -24,6 +24,7 @@ def _bundle(**overrides):
         "sli_use_training_mean": np.array(True),
         "sli_select_skip_first_sync_buckets": np.array(1, dtype=int),
         "sli_select_keep_first_sync_buckets": np.array(0, dtype=int),
+        "min_agarose_episodes": np.array(2, dtype=int),
         "agarose_dual_circle_min_total": np.array(2, dtype=int),
         "agarose_ratio_exp": np.asarray(
             [
@@ -75,6 +76,23 @@ def test_validate_agarose_bundle_accepts_valid_shapes_counts_and_metadata():
 
     normalized = normalize_sli_bundle(_bundle())
     assert normalized["agarose_ratio_exp"].shape == (2, 2, 3)
+
+
+def test_validate_agarose_bundle_accepts_legacy_min_total_metadata():
+    bundle = _bundle()
+    del bundle["min_agarose_episodes"]
+
+    validate_agarose_sli_bundle(bundle)
+
+
+def test_validate_agarose_bundle_prefers_primary_min_episode_metadata():
+    with pytest.raises(ValueError, match="where total is below reporting threshold"):
+        validate_agarose_sli_bundle(
+            _bundle(
+                min_agarose_episodes=np.array(3, dtype=int),
+                agarose_dual_circle_min_total=np.array(2, dtype=int),
+            )
+        )
 
 
 def test_validate_agarose_bundle_rejects_missing_metric_key():

--- a/test/paper_metrics/test_agarose_avoidance_truth.py
+++ b/test/paper_metrics/test_agarose_avoidance_truth.py
@@ -85,7 +85,8 @@ def test_agarose_ratio_uses_avoid_over_total_and_min_total_masks_ratio():
         ct=CT.large,
         opts=SimpleNamespace(
             agarose_outer_delta_mm=1.0,
-            agarose_dual_circle_min_total=2,
+            min_agarose_episodes=2,
+            agarose_dual_circle_min_total=1,
             agarose_dual_circle_debug_csv=None,
         ),
         sync_bucket_ranges=[[(0, 5), (5, 10)]],
@@ -118,7 +119,7 @@ def test_agarose_episode_assignment_uses_episode_start_frame_for_sync_bucket():
         ct=CT.large,
         opts=SimpleNamespace(
             agarose_outer_delta_mm=1.0,
-            agarose_dual_circle_min_total=1,
+            min_agarose_episodes=1,
             agarose_dual_circle_debug_csv=None,
         ),
         sync_bucket_ranges=[[(0, 5), (5, 10)], [(10, 15)]],
@@ -147,7 +148,7 @@ def test_agarose_pre_windows_use_episode_start_frame():
         {"start": 29, "stop": 31, "avoids_inner": False},
     ]
     va = _video_analysis_stub(
-        opts=SimpleNamespace(agarose_dual_circle_min_total=1),
+        opts=SimpleNamespace(min_agarose_episodes=1),
         trx=[SimpleNamespace(_bad=False)],
         trns=[
             _Training(start=10, stop=20, name="T1"),
@@ -218,7 +219,8 @@ def test_agarose_bundle_export_records_min_total_metadata(tmp_path, monkeypatch)
         sli_use_training_mean=True,
         sli_select_skip_first_sync_buckets=0,
         sli_select_keep_first_sync_buckets=0,
-        agarose_dual_circle_min_total=2,
+        min_agarose_episodes=2,
+        agarose_dual_circle_min_total=1,
         agarose_sli_include_pre=False,
     )
     out = tmp_path / "agarose_bundle.npz"
@@ -226,4 +228,5 @@ def test_agarose_bundle_export_records_min_total_metadata(tmp_path, monkeypatch)
     export_agarose_sli_bundle([va], opts, gls=None, out_fn=str(out))
 
     with np.load(out, allow_pickle=True) as bundle:
+        assert int(bundle["min_agarose_episodes"]) == 2
         assert int(bundle["agarose_dual_circle_min_total"]) == 2

--- a/test/paper_metrics/test_agarose_avoidance_truth.py
+++ b/test/paper_metrics/test_agarose_avoidance_truth.py
@@ -230,3 +230,13 @@ def test_agarose_bundle_export_records_min_total_metadata(tmp_path, monkeypatch)
     with np.load(out, allow_pickle=True) as bundle:
         assert int(bundle["min_agarose_episodes"]) == 2
         assert int(bundle["agarose_dual_circle_min_total"]) == 2
+        assert int(bundle["episode_filter_agarose_sync_exp_min_episodes"]) == 2
+        assert int(bundle["episode_filter_agarose_sync_exp_unit_count"]) == 2
+        assert int(bundle["episode_filter_agarose_sync_exp_included_count"]) == 1
+        assert int(bundle["episode_filter_agarose_sync_exp_excluded_count"]) == 1
+        np.testing.assert_array_equal(
+            bundle["episode_filter_agarose_sync_exp_episode_counts"], [2, 1]
+        )
+        np.testing.assert_array_equal(
+            bundle["episode_filter_agarose_sync_exp_excluded_episode_counts"], [1]
+        )

--- a/test/paper_metrics/test_between_reward_distance_bundle_invariants.py
+++ b/test/paper_metrics/test_between_reward_distance_bundle_invariants.py
@@ -175,3 +175,32 @@ def test_validate_between_reward_distance_bundle_rejects_finite_value_with_zero_
                 ),
             )
         )
+
+
+def test_validate_between_reward_distance_bundle_rejects_finite_value_below_threshold():
+    with pytest.raises(
+        ValueError, match="finite between_reward_maxdist_exp where count is below 2"
+    ):
+        validate_between_reward_maxdist_bundle(
+            _maxdist_bundle(
+                btw_rwd_sync_bucket_min_trajectories=np.array(2, dtype=int),
+                between_reward_maxdist_exp=np.asarray(
+                    [
+                        [[1.0, np.nan, np.nan], [3.0, 4.0, 5.0]],
+                        [[np.nan, 1.5, 2.5], [2.0, np.nan, 3.0]],
+                    ],
+                    dtype=float,
+                ),
+                between_reward_maxdistN_exp=np.asarray(
+                    [[[2, 1, 0], [2, 2, 2]], [[0, 1, 2], [2, 0, 2]]],
+                    dtype=int,
+                ),
+                between_reward_maxdistN_ctrl=np.asarray(
+                    [
+                        [[2, 0, 2], [2, 2, 0]],
+                        [[0, 0, 2], [2, 2, 2]],
+                    ],
+                    dtype=int,
+                ),
+            )
+        )

--- a/test/paper_metrics/test_between_reward_distance_truth.py
+++ b/test/paper_metrics/test_between_reward_distance_truth.py
@@ -18,6 +18,9 @@ from src.plotting.btw_rwd_return_leg_dist_totals import (
     ReturnLegDistTotalsConfig,
     ReturnLegDistTotalsPlotter,
 )
+from src.exporting.between_reward_maxdist_sli_bundle import (
+    _extract_between_reward_maxdist_arrays,
+)
 
 
 class _Trajectory:
@@ -70,6 +73,27 @@ class _Video:
 
     def _iter_between_reward_segment_com(self, _trn, fly_idx, **_kwargs):
         yield from self._segments_by_fly.get(fly_idx, [])
+
+
+class _MaxDistVideo:
+    def __init__(self):
+        self.fn = "fake-video"
+        self.trns = [_Training()]
+        self.syncMeanBetweenRewardMaxDist = [
+            {"exp": [1.0, 2.0], "ctrl": [3.0, 4.0]}
+        ]
+        self.syncMeanBetweenRewardMaxDistN = [
+            {"exp": [2, 1], "ctrl": [1, 3]}
+        ]
+
+    def _numRewardsMsg(self, *_args, **_kwargs):
+        return 5
+
+    def _syncBucket(self, _trn, _df):
+        return 0, 2, None
+
+    def bySyncBucketMeanBetweenRewardMaxDist(self, **_kwargs):
+        return None
 
 
 def _segment(*, s, e, b_idx=0, max_i=None, max_d_mm=4.0):
@@ -261,6 +285,19 @@ def test_return_leg_collector_averages_by_sync_bucket_and_honors_nonwalk_option(
     np.testing.assert_allclose(mean_ctrl, [[[2.0, np.nan]]])
     np.testing.assert_array_equal(n_exp, [[[2, 1]]])
     np.testing.assert_array_equal(n_ctrl, [[[1, 0]]])
+
+
+def test_between_reward_maxdist_export_masks_by_min_trajectory_count():
+    va = _MaxDistVideo()
+
+    mean_exp, mean_ctrl, n_exp, n_ctrl = _extract_between_reward_maxdist_arrays(
+        [va], SimpleNamespace(min_between_reward_trajectories=2)
+    )
+
+    np.testing.assert_allclose(mean_exp, [[[1.0, np.nan]]])
+    np.testing.assert_allclose(mean_ctrl, [[[np.nan, 4.0]]])
+    np.testing.assert_array_equal(n_exp, [[[2, 1]]])
+    np.testing.assert_array_equal(n_ctrl, [[[1, 3]]])
 
 
 def test_return_leg_sync_bucket_filter_masks_low_count_buckets():

--- a/test/paper_metrics/test_between_reward_distance_truth.py
+++ b/test/paper_metrics/test_between_reward_distance_truth.py
@@ -14,6 +14,10 @@ from src.plotting.between_reward_segment_metrics import (
 from src.plotting.btw_rwd_return_leg_dist_collectors import (
     ReturnLegDistPerFlyCollector,
 )
+from src.plotting.btw_rwd_return_leg_dist_totals import (
+    ReturnLegDistTotalsConfig,
+    ReturnLegDistTotalsPlotter,
+)
 
 
 class _Trajectory:
@@ -257,3 +261,114 @@ def test_return_leg_collector_averages_by_sync_bucket_and_honors_nonwalk_option(
     np.testing.assert_allclose(mean_ctrl, [[[2.0, np.nan]]])
     np.testing.assert_array_equal(n_exp, [[[2, 1]]])
     np.testing.assert_array_equal(n_ctrl, [[[1, 0]]])
+
+
+def test_return_leg_sync_bucket_filter_masks_low_count_buckets():
+    exp = _Trajectory(x=np.arange(12, dtype=float), d=np.ones(11))
+    va = _Video(
+        trx=[exp],
+        segments_by_fly={
+            0: [
+                _segment(s=0, e=4, b_idx=0, max_i=2),
+                _segment(s=4, e=7, b_idx=0, max_i=5),
+                _segment(s=6, e=10, b_idx=1, max_i=8),
+            ],
+        },
+    )
+
+    collector = ReturnLegDistPerFlyCollector()
+    collector.vas = [va]
+    collector.opts = SimpleNamespace(
+        com_exclude_wall_contact=False,
+        min_between_reward_trajectories=2,
+        btw_rwd_return_leg_dist_exclude_nonwalking_frames=False,
+        btw_rwd_return_leg_dist_min_walk_frames=2,
+    )
+    collector.cfg = SimpleNamespace(
+        skip_first_sync_buckets=0, keep_first_sync_buckets=0
+    )
+
+    mean_exp, _mean_ctrl, n_exp, _n_ctrl = (
+        collector.collect_return_leg_sync_bucket_arrays()
+    )
+
+    np.testing.assert_allclose(mean_exp, [[[0.5, np.nan]]])
+    np.testing.assert_array_equal(n_exp, [[[2, 1]]])
+
+
+def test_return_leg_scalar_bars_filter_after_pooling_selected_episodes():
+    exp = _Trajectory(x=np.arange(12, dtype=float), d=np.ones(11))
+    va = _Video(
+        trx=[exp],
+        segments_by_fly={
+            0: [
+                _segment(s=0, e=4, b_idx=0, max_i=2),
+                _segment(s=4, e=7, b_idx=0, max_i=5),
+                _segment(s=6, e=10, b_idx=1, max_i=8),
+            ],
+        },
+    )
+    va.trns = [_Training(), _Training()]
+
+    opts = SimpleNamespace(
+        com_exclude_wall_contact=False,
+        min_between_reward_trajectories=4,
+        btw_rwd_return_leg_dist_exclude_nonwalking_frames=False,
+        btw_rwd_return_leg_dist_min_walk_frames=2,
+    )
+    cfg = ReturnLegDistTotalsConfig(
+        out_file="unused.png",
+        pool_trainings=True,
+        trainings=[1, 2],
+        skip_first_sync_buckets=0,
+        keep_first_sync_buckets=0,
+    )
+    plotter = ReturnLegDistTotalsPlotter(
+        vas=[va], opts=opts, gls=None, customizer=None, cfg=cfg
+    )
+
+    data = plotter.compute_scalar_panels()
+
+    assert data["panel_labels"] == ["Selected trainings combined"]
+    assert int(data["n_units_panel"][0]) == 1
+    np.testing.assert_allclose(
+        np.asarray(data["per_unit_values_panel"][0], dtype=float), [0.5]
+    )
+    assert data["meta"]["training_selection"]["trainings_effective"] == [1, 2]
+
+
+def test_return_leg_scalar_bars_single_training_filter_uses_selected_episode_count():
+    exp = _Trajectory(x=np.arange(12, dtype=float), d=np.ones(11))
+    va = _Video(
+        trx=[exp],
+        segments_by_fly={
+            0: [
+                _segment(s=0, e=4, b_idx=0, max_i=2),
+                _segment(s=4, e=7, b_idx=0, max_i=5),
+                _segment(s=6, e=10, b_idx=1, max_i=8),
+            ],
+        },
+    )
+
+    opts = SimpleNamespace(
+        com_exclude_wall_contact=False,
+        min_between_reward_trajectories=4,
+        btw_rwd_return_leg_dist_exclude_nonwalking_frames=False,
+        btw_rwd_return_leg_dist_min_walk_frames=2,
+    )
+    cfg = ReturnLegDistTotalsConfig(
+        out_file="unused.png",
+        pool_trainings=False,
+        trainings=[1],
+        skip_first_sync_buckets=0,
+        keep_first_sync_buckets=0,
+    )
+    plotter = ReturnLegDistTotalsPlotter(
+        vas=[va], opts=opts, gls=None, customizer=None, cfg=cfg
+    )
+
+    data = plotter.compute_scalar_panels()
+
+    assert data["panel_labels"] == ["T1"]
+    assert int(data["n_units_panel"][0]) == 0
+    assert data["per_unit_values_panel"][0].size == 0

--- a/test/paper_metrics/test_between_reward_tortuosity_truth.py
+++ b/test/paper_metrics/test_between_reward_tortuosity_truth.py
@@ -1,0 +1,91 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+from src.plotting.between_reward_tortuosity_mean_swarm import (
+    BetweenRewardTortuosityMeanSwarmConfig,
+    BetweenRewardTortuosityMeanSwarmPlotter,
+)
+
+
+class _Trajectory:
+    def __init__(self):
+        self.x = np.arange(12, dtype=float)
+        self.y = np.zeros_like(self.x)
+        self.d = np.ones(11, dtype=float)
+        self.pxPerMmFloor = 1.0
+
+    def bad(self):
+        return False
+
+
+class _Training:
+    def __init__(self, n, label):
+        self.n = int(n)
+        self.start = 0
+        self.stop = 12
+        self._label = str(label)
+
+    def name(self):
+        return self._label
+
+    def circles(self, _fly_idx):
+        return [(0.0, 0.0, 0.0)]
+
+
+class _Video:
+    def __init__(self):
+        self.fn = "fake-tortuosity-video"
+        self.f = 7
+        self.trns = [_Training(1, "T1"), _Training(2, "T2")]
+        self.trx = [_Trajectory()]
+        self.flies = [0]
+        self.noyc = True
+        self._skipped = False
+        self.xf = SimpleNamespace(fctr=1.0)
+        self.sync_bucket_ranges = [
+            [(0, 3), (3, 6), (6, 9), (9, 12)],
+            [(0, 3), (3, 6), (6, 9), (9, 12)],
+        ]
+
+    def _iter_between_reward_segment_com(self, _trn, _fly_idx, **_kwargs):
+        yield SimpleNamespace(s=0, e=3, b_idx=0)
+        yield SimpleNamespace(s=3, e=6, b_idx=1)
+        yield SimpleNamespace(s=6, e=9, b_idx=2)
+
+
+def _plotter(*, pool_trainings):
+    opts = SimpleNamespace(min_between_reward_trajectories=4)
+    cfg = BetweenRewardTortuosityMeanSwarmConfig(
+        out_file="unused.png",
+        pool_trainings=bool(pool_trainings),
+        trainings=[1, 2] if pool_trainings else [1],
+        skip_first_sync_buckets=0,
+        keep_first_sync_buckets=0,
+        metric_mode="path_over_displacement",
+        segment_scope="full",
+        min_segments_per_fly=1,
+    )
+    return BetweenRewardTortuosityMeanSwarmPlotter(
+        vas=[_Video()], opts=opts, gls=None, customizer=None, cfg=cfg
+    )
+
+
+def test_tortuosity_mean_swarm_single_training_filter_uses_segment_count():
+    data = _plotter(pool_trainings=False).compute_scalar_panels()
+
+    assert data["panel_labels"] == ["T1"]
+    assert int(data["n_units_panel"][0]) == 0
+    assert data["per_unit_values_panel"][0].size == 0
+
+
+def test_tortuosity_mean_swarm_filter_after_pooling_selected_segments():
+    data = _plotter(pool_trainings=True).compute_scalar_panels()
+
+    assert data["panel_labels"] == ["Selected trainings combined"]
+    assert int(data["n_units_panel"][0]) == 1
+    np.testing.assert_allclose(
+        np.asarray(data["per_unit_values_panel"][0], dtype=float), [1.0]
+    )
+    assert data["meta"]["training_selection"]["trainings_effective"] == [1, 2]
+    assert data["meta"]["min_segments_per_fly"] == 4

--- a/test/paper_metrics/test_commag_truth.py
+++ b/test/paper_metrics/test_commag_truth.py
@@ -179,3 +179,23 @@ def test_extract_commag_arrays_applies_min_segment_count_masking():
     np.testing.assert_allclose(ctrl, [[[np.nan, 4.0]]])
     np.testing.assert_array_equal(n_exp, [[[2, 1]]])
     np.testing.assert_array_equal(n_ctrl, [[[0, 3]]])
+
+
+def test_extract_commag_arrays_prefers_episode_threshold_option():
+    va = SimpleNamespace(
+        syncCOMMag=[{"exp": [1.0, 2.0], "ctrl": [3.0, 4.0]}],
+        syncCOMMagN=[{"exp": [2, 1], "ctrl": [1, 3]}],
+    )
+
+    exp, ctrl, n_exp, n_ctrl = _extract_commag_arrays(
+        [va],
+        SimpleNamespace(
+            min_between_reward_trajectories=2,
+            btw_rwd_sync_bucket_min_trajectories=99,
+        ),
+    )
+
+    np.testing.assert_allclose(exp, [[[1.0, np.nan]]])
+    np.testing.assert_allclose(ctrl, [[[np.nan, 4.0]]])
+    np.testing.assert_array_equal(n_exp, [[[2, 1]]])
+    np.testing.assert_array_equal(n_ctrl, [[[1, 3]]])

--- a/test/paper_metrics/test_return_prob_excursion_bin_bundle_invariants.py
+++ b/test/paper_metrics/test_return_prob_excursion_bin_bundle_invariants.py
@@ -111,10 +111,33 @@ def test_validate_return_prob_excursion_bin_bundle_rejects_bad_probabilities():
             _bundle(return_prob_excursion_bin_ratio_exp=np.asarray([[1.2, np.nan]]))
         )
 
-    with pytest.raises(ValueError, match="finite .* where total == 0"):
+    with pytest.raises(ValueError, match="finite .* where total is below"):
         validate_return_prob_excursion_bin_bundle(
             _bundle(return_prob_excursion_bin_ratio_exp=np.asarray([[0.5, 0.0]]))
         )
+
+
+def test_validate_return_prob_excursion_bin_bundle_rejects_finite_ratio_below_threshold():
+    with pytest.raises(
+        ValueError,
+        match="finite return_prob_excursion_bin_ratio_exp where total is below reporting threshold 5",
+    ):
+        validate_return_prob_excursion_bin_bundle(
+            _bundle(
+                btw_rwd_sync_bucket_min_trajectories=np.array(5, dtype=int),
+                return_prob_excursion_bin_ratio_exp=np.asarray([[0.5, np.nan]]),
+            )
+        )
+
+
+def test_validate_return_prob_excursion_bin_bundle_allows_nan_below_threshold():
+    validate_return_prob_excursion_bin_bundle(
+        _bundle(
+            btw_rwd_sync_bucket_min_trajectories=np.array(5, dtype=int),
+            return_prob_excursion_bin_ratio_exp=np.asarray([[np.nan, np.nan]]),
+            return_prob_excursion_bin_ratio_ctrl=np.asarray([[0.2, 0.6]]),
+        )
+    )
 
 
 def test_validate_return_prob_excursion_bin_bundle_rejects_inconsistent_ratio():

--- a/test/paper_metrics/test_return_prob_excursion_bin_truth.py
+++ b/test/paper_metrics/test_return_prob_excursion_bin_truth.py
@@ -11,6 +11,9 @@ from src.exporting.return_prob_excursion_bin_sli_bundle import (
     _selected_training_indices,
     _selected_windows_for_va,
 )
+from src.exporting.return_prob_outer_radius_sli_bundle import (
+    _compute_return_prob_curves as _compute_return_prob_outer_radius_curves,
+)
 
 
 class _Training:
@@ -34,6 +37,12 @@ class _Trajectory:
         self.calls = []
 
     def reward_return_excursion_episodes_for_training(self, **kwargs):
+        self.calls.append(kwargs)
+        return list(self._episodes)
+
+
+class _OuterRadiusTrajectory(_Trajectory):
+    def reward_return_probability_episodes_for_training(self, **kwargs):
         self.calls.append(kwargs)
         return list(self._episodes)
 
@@ -203,6 +212,56 @@ def test_return_probability_leaves_bins_nan_when_no_valid_denominator_exists():
     np.testing.assert_array_equal(ret_ctrl, [[0.0, 0.0]])
     np.testing.assert_array_equal(total_exp, [[0, 0]])
     np.testing.assert_array_equal(total_ctrl, [[0, 0]])
+
+
+def test_return_probability_masks_bins_below_min_trajectory_count():
+    exp = _Trajectory(
+        [
+            _episode(10, 1.0, True),
+            _episode(20, 5.0, True),
+            _episode(30, 8.0, True),
+            _episode(40, 20.0, True),
+        ]
+    )
+
+    ratio_exp, _, ret_exp, _, total_exp, _, _ = _curves(
+        [_va(trx=[exp], noyc=True)], min_trajectories=5
+    )
+
+    assert np.isnan(ratio_exp).all()
+    np.testing.assert_allclose(ret_exp, [[1.5, 3.0]])
+    np.testing.assert_array_equal(total_exp, [[4, 4]])
+
+
+def test_return_probability_outer_radius_masks_below_min_trajectory_count():
+    exp = _OuterRadiusTrajectory(
+        [
+            {"stop": 10, "returns": True},
+            {"stop": 20, "returns": False},
+            {"stop": 30, "returns": True},
+        ]
+    )
+
+    ratio_exp, _, ret_exp, _, total_exp, _, _ = (
+        _compute_return_prob_outer_radius_curves(
+            [_va(trx=[exp], noyc=True)],
+            outer_radii_mm=np.asarray([16.0], dtype=float),
+            legacy_outer_radii=False,
+            reward_radius_mm=None,
+            reward_delta_mm=0.0,
+            border_width_mm=0.1,
+            selected_trainings=[0],
+            skip_first=0,
+            keep_first=0,
+            last_sync_buckets=0,
+            debug=False,
+            min_trajectories=4,
+        )
+    )
+
+    np.testing.assert_array_equal(ret_exp, [[2]])
+    np.testing.assert_array_equal(total_exp, [[3]])
+    assert np.isnan(ratio_exp).all()
 
 
 def test_open_ended_bin_resolves_from_nonreturning_censored_excursions_but_does_not_count_them():

--- a/test/paper_metrics/test_turnback_excursion_bin_bundle_invariants.py
+++ b/test/paper_metrics/test_turnback_excursion_bin_bundle_invariants.py
@@ -124,7 +124,7 @@ def test_validate_turnback_excursion_bin_bundle_rejects_bad_probabilities():
             _bundle(turnback_excursion_bin_ratio_exp=np.asarray([[1.2, np.nan]]))
         )
 
-    with pytest.raises(ValueError, match="finite .* where total == 0"):
+    with pytest.raises(ValueError, match="finite .* below reporting threshold"):
         validate_turnback_excursion_bin_bundle(
             _bundle(turnback_excursion_bin_ratio_exp=np.asarray([[0.5, 0.0]]))
         )

--- a/test/paper_metrics/test_turnback_excursion_bin_truth.py
+++ b/test/paper_metrics/test_turnback_excursion_bin_truth.py
@@ -8,6 +8,7 @@ from src.exporting.turnback_excursion_bin_sli_bundle import (
     _compute_pair_curves,
     _compute_turnback_curves,
     _effective_windowing,
+    export_turnback_excursion_bin_sli_bundle,
     _integrated_bin_contribution,
     _pair_deltas_mm,
     _selected_training_indices,
@@ -235,6 +236,26 @@ def test_turnback_binned_average_is_not_bin_membership():
     np.testing.assert_allclose(ratio_exp, [[0.375, 0.75]])
 
 
+def test_turnback_binned_masks_below_min_episode_count():
+    exp = _Trajectory(
+        [
+            _episode(10, 1.0, True),
+            _episode(20, 5.0, True),
+            _episode(30, 8.0, True),
+            _episode(40, 20.0, True),
+        ]
+    )
+
+    ratio_exp, _, turn_exp, _, total_exp, _, _ = _curves(
+        [_va(trx=[exp], noyc=True)],
+        min_episodes=5,
+    )
+
+    assert np.isnan(ratio_exp).all()
+    np.testing.assert_allclose(turn_exp, [[1.5, 3.0]])
+    np.testing.assert_array_equal(total_exp, [[4, 4]])
+
+
 def test_open_ended_bin_resolves_from_nonturning_excursions_but_does_not_count_them():
     exp = _Trajectory([_episode(10, 20.0, False)])
 
@@ -285,3 +306,68 @@ def test_independent_pair_curves_call_dual_circle_metric_per_pair():
         (call["inner_delta_mm"], call["outer_delta_mm"])
         for call in exp.calls
     ] == [(2.0, 4.0), (6.0, 8.0), (14.0, 16.0)]
+
+
+def test_independent_pair_curves_mask_below_min_episode_count():
+    exp = _Trajectory([_episode(10, 0.0, True), _episode(20, 0.0, False)])
+
+    ratio_exp, _, turn_exp, _, total_exp, _, _ = _pair_curves(
+        [_va(trx=[exp], noyc=True)],
+        pairs=((2.0, 4.0),),
+        min_episodes=3,
+    )
+
+    assert np.isnan(ratio_exp).all()
+    np.testing.assert_allclose(turn_exp, [[1.0]])
+    np.testing.assert_array_equal(total_exp, [[2]])
+
+
+def test_turnback_excursion_bin_export_records_min_episode_filter(tmp_path, monkeypatch):
+    exp = _Trajectory(
+        [
+            _episode(10, 1.0, True),
+            _episode(20, 5.0, True),
+            _episode(30, 8.0, True),
+            _episode(40, 20.0, True),
+        ]
+    )
+    va = _va(trx=[exp], noyc=True, sync_bucket_ranges=[[(0, 50)]])
+    opts = SimpleNamespace(
+        export_group_label="group",
+        turnback_excursion_bin_edges_mm="2,8,16",
+        turnback_excursion_bin_radii_mm=None,
+        turnback_excursion_bin_radius_pairs_mm=None,
+        turnback_excursion_bin_pairs_mm=None,
+        turnback_excursion_bin_trainings=None,
+        turnback_excursion_bin_skip_first_sync_buckets=0,
+        turnback_excursion_bin_keep_first_sync_buckets=0,
+        turnback_excursion_bin_last_sync_buckets=0,
+        turnback_inner_delta_mm=2.0,
+        turnback_inner_radius_mm=None,
+        turnback_border_width_mm=0.1,
+        turnback_inner_radius_offset_px=0.0,
+        turnback_excursion_bin_debug=False,
+        best_worst_trn=1,
+        sli_use_training_mean=True,
+        sli_select_skip_first_sync_buckets=0,
+        sli_select_keep_first_sync_buckets=0,
+        min_turnback_episodes=5,
+        turnback_excursion_bin_debug_episodes_csv=None,
+    )
+    monkeypatch.setattr(
+        "src.exporting.turnback_excursion_bin_sli_bundle._compute_sli_scalar_and_timeseries_from_rpid",
+        lambda _vas, _opts: (
+            np.asarray([0.1], dtype=float),
+            np.asarray([[[0.1]]], dtype=float),
+        ),
+    )
+    out = tmp_path / "turnback_excursion_bin.npz"
+
+    export_turnback_excursion_bin_sli_bundle([va], opts, gls=None, out_fn=str(out))
+
+    with np.load(out, allow_pickle=True) as bundle:
+        assert int(bundle["min_turnback_episodes"]) == 5
+        assert np.isnan(bundle["turnback_excursion_bin_ratio_exp"]).all()
+        np.testing.assert_array_equal(
+            bundle["turnback_excursion_bin_total_exp"], [[4, 4]]
+        )

--- a/test/paper_metrics/test_turnback_excursion_bin_truth.py
+++ b/test/paper_metrics/test_turnback_excursion_bin_truth.py
@@ -371,3 +371,11 @@ def test_turnback_excursion_bin_export_records_min_episode_filter(tmp_path, monk
         np.testing.assert_array_equal(
             bundle["turnback_excursion_bin_total_exp"], [[4, 4]]
         )
+        assert int(bundle["episode_filter_turnback_excursion_bin_exp_min_episodes"]) == 5
+        assert int(bundle["episode_filter_turnback_excursion_bin_exp_unit_count"]) == 2
+        assert int(bundle["episode_filter_turnback_excursion_bin_exp_included_count"]) == 0
+        assert int(bundle["episode_filter_turnback_excursion_bin_exp_excluded_count"]) == 2
+        np.testing.assert_array_equal(
+            bundle["episode_filter_turnback_excursion_bin_exp_excluded_episode_counts"],
+            [4, 4],
+        )

--- a/test/paper_metrics/test_turnback_outer_radius_truth.py
+++ b/test/paper_metrics/test_turnback_outer_radius_truth.py
@@ -1,0 +1,75 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+from src.exporting.turnback_outer_radius_sli_bundle import (
+    _compute_outer_radius_curves,
+)
+
+
+class _Training:
+    def __init__(self, start=0, stop=100, *, circle=True, name="training"):
+        self.start = start
+        self.stop = stop
+        self._circle = circle
+        self._name = name
+
+    def isCircle(self):
+        return self._circle
+
+    def name(self):
+        return self._name
+
+
+class _Trajectory:
+    def __init__(self, episodes, *, bad=False):
+        self._episodes = list(episodes)
+        self._bad = bad
+
+    def reward_turnback_dual_circle_episodes_for_training(self, **_kwargs):
+        return list(self._episodes)
+
+
+def _episode(stop, turns_back):
+    return {"stop": int(stop), "turns_back": bool(turns_back)}
+
+
+def _va(*, trx, noyc=True):
+    return SimpleNamespace(
+        fn="fake-video",
+        trns=[_Training()],
+        trx=list(trx),
+        sync_bucket_ranges=[[(0, 50)]],
+        noyc=bool(noyc),
+        _skipped=False,
+    )
+
+
+def test_turnback_outer_radius_masks_below_min_episode_count():
+    exp = _Trajectory(
+        [
+            _episode(10, True),
+            _episode(20, False),
+            _episode(30, True),
+        ]
+    )
+
+    ratio_exp, _, turn_exp, _, total_exp, _, _ = _compute_outer_radius_curves(
+        [_va(trx=[exp])],
+        outer_radii_mm=np.asarray([16.0], dtype=float),
+        legacy_outer_radii=False,
+        inner_radius_mm=None,
+        inner_delta_mm=0.0,
+        border_width_mm=0.1,
+        radius_offset_px=0.0,
+        selected_trainings=[0],
+        skip_first=0,
+        keep_first=0,
+        last_sync_buckets=0,
+        debug=False,
+        min_episodes=4,
+    )
+
+    assert np.isnan(ratio_exp).all()
+    np.testing.assert_array_equal(turn_exp, [[2]])
+    np.testing.assert_array_equal(total_exp, [[3]])

--- a/test/paper_metrics/test_turnback_ratio_bundle_invariants.py
+++ b/test/paper_metrics/test_turnback_ratio_bundle_invariants.py
@@ -110,7 +110,9 @@ def test_validate_turnback_ratio_bundle_rejects_bad_probabilities():
             )
         )
 
-    with pytest.raises(ValueError, match="finite turnback_ratio_exp where total == 0"):
+    with pytest.raises(
+        ValueError, match="finite turnback_ratio_exp.*below reporting threshold"
+    ):
         validate_turnback_ratio_bundle(
             _bundle(
                 turnback_ratio_exp=np.asarray(

--- a/test/paper_metrics/test_turnback_ratio_truth.py
+++ b/test/paper_metrics/test_turnback_ratio_truth.py
@@ -233,6 +233,7 @@ def test_turnback_bundle_export_records_inner_and_outer_radius_metadata(
         turnback_inner_delta_mm=4.0,
         turnback_outer_delta_mm=8.0,
         turnback_inner_radius_offset_px=0.25,
+        min_turnback_episodes=1,
     )
     out = tmp_path / "turnback_bundle.npz"
 

--- a/test/paper_metrics/test_turnback_ratio_truth.py
+++ b/test/paper_metrics/test_turnback_ratio_truth.py
@@ -79,7 +79,15 @@ def test_turnback_dual_circle_detects_success_failure_and_excludes_censored_epis
         trn=trn, inner_delta_mm=4.0, outer_delta_mm=8.0, border_width_mm=0.0
     )
 
-    assert episodes == [
+    assert [
+        {
+            "start": ep["start"],
+            "stop": ep["stop"],
+            "turns_back": ep["turns_back"],
+            "end_reason": ep["end_reason"],
+        }
+        for ep in episodes
+    ] == [
         {"start": 1, "stop": 3, "turns_back": True, "end_reason": "reenter_inner"},
         {
             "start": 5,
@@ -127,6 +135,7 @@ def test_turnback_ratio_bins_by_outcome_frame_and_leaves_empty_buckets_nan():
             turnback_border_width_mm=0.0,
             turnback_inner_radius_offset_px=0.0,
             turnback_dual_circle_debug=False,
+            min_turnback_episodes=1,
         ),
         sync_bucket_ranges=[[(0, 5), (5, 10), (10, 15)]],
         trns=[_CircleTraining(start=0, stop=15)],
@@ -144,6 +153,36 @@ def test_turnback_ratio_bins_by_outcome_frame_and_leaves_empty_buckets_nan():
 
     assert exp.calls[0]["inner_delta_mm"] == 4.0
     assert exp.calls[0]["outer_delta_mm"] == 8.0
+
+
+def test_turnback_ratio_min_episode_filter_masks_low_total_buckets():
+    exp = _TrajectoryEpisodes(
+        [
+            {"start": 1, "stop": 4, "turns_back": True},
+            {"start": 1, "stop": 6, "turns_back": False},
+            {"start": 8, "stop": 10, "turns_back": True},
+        ]
+    )
+    va = SimpleNamespace(
+        circle=True,
+        opts=SimpleNamespace(
+            turnback_inner_delta_mm=4.0,
+            turnback_outer_delta_mm=8.0,
+            turnback_border_width_mm=0.0,
+            turnback_inner_radius_offset_px=0.0,
+            turnback_dual_circle_debug=False,
+            min_turnback_episodes=2,
+        ),
+        sync_bucket_ranges=[[(0, 5), (5, 10), (10, 15)]],
+        trns=[_CircleTraining(start=0, stop=15)],
+        trx=[exp],
+    )
+
+    VideoAnalysis.analyzeRewardTurnbackDualCircle(va)
+
+    counts = va.reward_turnback_dual_circle_counts
+    np.testing.assert_array_equal(counts["total"], [[[1, 2, 0]]])
+    np.testing.assert_allclose(counts["ratio"], [[[np.nan, 0.5, np.nan]]])
 
 
 def test_turnback_bundle_extraction_keeps_exp_ctrl_axes_and_pads_missing_buckets():

--- a/test/paper_metrics/test_turnback_ratio_truth.py
+++ b/test/paper_metrics/test_turnback_ratio_truth.py
@@ -243,3 +243,15 @@ def test_turnback_bundle_export_records_inner_and_outer_radius_metadata(
         assert float(bundle["turnback_inner_delta_mm"]) == 4.0
         assert float(bundle["turnback_outer_delta_mm"]) == 8.0
         assert float(bundle["turnback_inner_radius_offset_px"]) == 0.25
+        assert int(bundle["episode_filter_turnback_sync_exp_min_episodes"]) == 1
+        assert int(bundle["episode_filter_turnback_sync_exp_unit_count"]) == 2
+        assert int(bundle["episode_filter_turnback_sync_exp_included_count"]) == 2
+        assert int(bundle["episode_filter_turnback_sync_exp_excluded_count"]) == 0
+        np.testing.assert_array_equal(
+            bundle["episode_filter_turnback_sync_exp_episode_counts"], [3, 2]
+        )
+        assert int(bundle["episode_filter_turnback_sync_ctrl_included_count"]) == 1
+        assert int(bundle["episode_filter_turnback_sync_ctrl_excluded_count"]) == 1
+        np.testing.assert_array_equal(
+            bundle["episode_filter_turnback_sync_ctrl_excluded_episode_counts"], [0]
+        )

--- a/test/paper_metrics/test_wall_contacts_per_reward_interval_truth.py
+++ b/test/paper_metrics/test_wall_contacts_per_reward_interval_truth.py
@@ -1,0 +1,103 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+from src.plotting.wall_contacts_per_reward_interval_totals import (
+    WallContactsPerRewardIntervalTotalsConfig,
+    WallContactsPerRewardIntervalTotalsPlotter,
+)
+
+
+class _Region:
+    def __init__(self, start):
+        self.start = int(start)
+
+
+class _Trajectory:
+    def __init__(self, starts, *, f=0, bad=False):
+        self.f = f
+        self._bad = bad
+        self.boundary_event_stats = {
+            "wall": {
+                "all": {
+                    "edge": {
+                        "boundary_contact_regions": [_Region(s) for s in starts]
+                    }
+                }
+            }
+        }
+
+    def bad(self):
+        return self._bad
+
+
+class _Training:
+    def __init__(self, n, label):
+        self.n = int(n)
+        self.start = 0
+        self.stop = 8
+        self._label = str(label)
+
+    def name(self):
+        return self._label
+
+
+class _Video:
+    def __init__(self):
+        self.fn = "fake-wall-contact-video"
+        self.f = 7
+        self.trns = [_Training(1, "T1"), _Training(2, "T2")]
+        self.trx = [_Trajectory([1, 3, 5])]
+        self.flies = [0]
+        self.noyc = True
+        self._skipped = False
+        self.sync_bucket_ranges = [
+            [(0, 2), (2, 4), (4, 6), (6, 8)],
+            [(0, 2), (2, 4), (4, 6), (6, 8)],
+        ]
+
+    def _getOn(self, _trn, *, calc=False, f=0):
+        return np.asarray([0, 2, 4, 6], dtype=int)
+
+
+def test_wall_contact_scalar_bars_single_training_filter_uses_interval_count():
+    opts = SimpleNamespace(min_between_reward_trajectories=4)
+    cfg = WallContactsPerRewardIntervalTotalsConfig(
+        out_file="unused.png",
+        pool_trainings=False,
+        trainings=[1],
+        skip_first_sync_buckets=0,
+        keep_first_sync_buckets=0,
+    )
+    plotter = WallContactsPerRewardIntervalTotalsPlotter(
+        vas=[_Video()], opts=opts, gls=None, customizer=None, cfg=cfg
+    )
+
+    data = plotter.compute_scalar_panels()
+
+    assert data["panel_labels"] == ["T1"]
+    assert int(data["n_units_panel"][0]) == 0
+    assert data["per_unit_values_panel"][0].size == 0
+
+
+def test_wall_contact_scalar_bars_filter_after_pooling_selected_intervals():
+    opts = SimpleNamespace(min_between_reward_trajectories=4)
+    cfg = WallContactsPerRewardIntervalTotalsConfig(
+        out_file="unused.png",
+        pool_trainings=True,
+        trainings=[1, 2],
+        skip_first_sync_buckets=0,
+        keep_first_sync_buckets=0,
+    )
+    plotter = WallContactsPerRewardIntervalTotalsPlotter(
+        vas=[_Video()], opts=opts, gls=None, customizer=None, cfg=cfg
+    )
+
+    data = plotter.compute_scalar_panels()
+
+    assert data["panel_labels"] == ["Selected trainings combined"]
+    assert int(data["n_units_panel"][0]) == 1
+    np.testing.assert_allclose(
+        np.asarray(data["per_unit_values_panel"][0], dtype=float), [1.0]
+    )
+    assert data["meta"]["training_selection"]["trainings_effective"] == [1, 2]

--- a/test/test_between_reward_filters.py
+++ b/test/test_between_reward_filters.py
@@ -21,6 +21,15 @@ def test_between_reward_min_trajectory_threshold_can_be_disabled():
     assert min_between_reward_sync_bucket_trajectories(opts) == 0
 
 
+def test_between_reward_new_episode_threshold_option_takes_precedence():
+    opts = SimpleNamespace(
+        min_between_reward_trajectories=3,
+        btw_rwd_sync_bucket_min_trajectories=9,
+    )
+
+    assert min_between_reward_sync_bucket_trajectories(opts) == 3
+
+
 def test_between_reward_metric_mask_is_per_bucket_and_keeps_counts_external():
     values = np.array([[1.0, 2.0, 3.0]])
     counts = np.array([[9, 10, 11]])

--- a/test/test_episode_filters.py
+++ b/test/test_episode_filters.py
@@ -9,6 +9,8 @@ from src.analysis.episode_filters import (
     EPISODE_TYPE_INNER_EXIT_REENTRY,
     EPISODE_TYPE_OUTER_ENTRY_REEXIT,
     eligible_by_min_episode_count,
+    episode_filter_accounting,
+    episode_filter_accounting_payload,
     mask_metric_by_min_episode_count,
     min_episode_count_for_type,
 )
@@ -86,3 +88,26 @@ def test_mask_metric_by_min_episode_count_keeps_counts_external():
 
     np.testing.assert_allclose(masked, [[np.nan, 2.0, 3.0]])
     np.testing.assert_array_equal(counts, [[4, 5, 6]])
+
+
+def test_episode_filter_accounting_reports_included_and_excluded_units():
+    counts = np.array([[0, 4, 5], [6, 2, 8]])
+    observed = np.array([[False, True, True], [True, False, True]])
+
+    summary = episode_filter_accounting(counts, 5, observed=observed)
+
+    assert int(summary["min_episodes"]) == 5
+    assert int(summary["unit_count"]) == 4
+    assert int(summary["included_count"]) == 3
+    assert int(summary["excluded_count"]) == 1
+    np.testing.assert_array_equal(summary["episode_counts"], [4, 5, 6, 8])
+    np.testing.assert_array_equal(summary["excluded_episode_counts"], [4])
+
+
+def test_episode_filter_accounting_payload_prefixes_summary_keys():
+    payload = episode_filter_accounting_payload("episode_filter_demo", [1, 2], 2)
+
+    assert int(payload["episode_filter_demo_included_count"]) == 1
+    np.testing.assert_array_equal(
+        payload["episode_filter_demo_excluded_episode_counts"], [1]
+    )

--- a/test/test_episode_filters.py
+++ b/test/test_episode_filters.py
@@ -1,0 +1,88 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from src.analysis.episode_filters import (
+    DEFAULT_MIN_EPISODES,
+    EPISODE_TYPE_BETWEEN_REWARD_TRAJECTORY,
+    EPISODE_TYPE_INNER_EXIT_REENTRY,
+    EPISODE_TYPE_OUTER_ENTRY_REEXIT,
+    eligible_by_min_episode_count,
+    mask_metric_by_min_episode_count,
+    min_episode_count_for_type,
+)
+
+
+def test_episode_filter_defaults_are_episode_type_level():
+    opts = SimpleNamespace()
+
+    assert (
+        min_episode_count_for_type(opts, EPISODE_TYPE_BETWEEN_REWARD_TRAJECTORY)
+        == DEFAULT_MIN_EPISODES
+    )
+    assert min_episode_count_for_type(opts, EPISODE_TYPE_INNER_EXIT_REENTRY) == 5
+    assert min_episode_count_for_type(opts, EPISODE_TYPE_OUTER_ENTRY_REEXIT) == 5
+
+
+def test_between_reward_episode_filter_accepts_legacy_option():
+    opts = SimpleNamespace(btw_rwd_sync_bucket_min_trajectories=7)
+
+    assert (
+        min_episode_count_for_type(opts, EPISODE_TYPE_BETWEEN_REWARD_TRAJECTORY)
+        == 7
+    )
+
+
+def test_primary_episode_filter_option_wins_over_legacy_option():
+    opts = SimpleNamespace(
+        min_between_reward_trajectories=3,
+        btw_rwd_sync_bucket_min_trajectories=7,
+    )
+
+    assert (
+        min_episode_count_for_type(opts, EPISODE_TYPE_BETWEEN_REWARD_TRAJECTORY)
+        == 3
+    )
+
+
+def test_episode_filter_thresholds_can_be_disabled():
+    opts = SimpleNamespace(min_turnback_episodes=0)
+
+    assert min_episode_count_for_type(opts, EPISODE_TYPE_INNER_EXIT_REENTRY) == 0
+
+
+def test_invalid_episode_filter_values_fall_back_to_default():
+    opts = SimpleNamespace(min_agarose_episodes="not-an-int")
+
+    assert min_episode_count_for_type(opts, EPISODE_TYPE_OUTER_ENTRY_REEXIT) == 5
+
+
+def test_agarose_episode_filter_accepts_legacy_option():
+    opts = SimpleNamespace(agarose_dual_circle_min_total=8)
+
+    assert min_episode_count_for_type(opts, EPISODE_TYPE_OUTER_ENTRY_REEXIT) == 8
+
+
+def test_unknown_episode_filter_type_raises():
+    with pytest.raises(ValueError, match="unknown episode filter type"):
+        min_episode_count_for_type(SimpleNamespace(), "mystery")
+
+
+def test_eligible_by_min_episode_count_uses_inclusive_threshold():
+    counts = np.array([4, 5, 6])
+
+    np.testing.assert_array_equal(
+        eligible_by_min_episode_count(counts, 5),
+        np.array([False, True, True]),
+    )
+
+
+def test_mask_metric_by_min_episode_count_keeps_counts_external():
+    values = np.array([[1.0, 2.0, 3.0]])
+    counts = np.array([[4, 5, 6]])
+
+    masked = mask_metric_by_min_episode_count(values, counts, 5)
+
+    np.testing.assert_allclose(masked, [[np.nan, 2.0, 3.0]])
+    np.testing.assert_array_equal(counts, [[4, 5, 6]])


### PR DESCRIPTION
## Summary

This PR introduces a shared episode-count filtering system for paper-facing metrics and applies it across agarose avoidance, turnback, return probability, between-reward distance, tortuosity, COM magnitude, and wall-contact metric paths.

The main goal is to make low-count metric values consistently report as `NaN` when the relevant fly/window/bin does not have enough contributing episodes, while preserving raw episode counts for diagnostics, validation, and downstream accounting.

## What changed

- Added a shared `episode_filters` module for resolving and applying minimum episode-count thresholds.
- Introduced metric-level episode types:
  - `outer_entry_reexit` for agarose avoidance
  - `inner_exit_reentry` for turnback metrics
  - `between_reward_trajectory` for between-reward trajectory metrics
- Added clearer primary CLI options:
  - `--min-agarose-episodes`
  - `--min-turnback-episodes`
  - `--min-between-reward-trajectories`
- Kept legacy CLI options as aliases where applicable:
  - `--agarose-dual-circle-min-total`
  - `--btw-rwd-sync-bucket-min-trajectories`
- Standardized the default minimum episode threshold to 5.
- Applied low-count masking to exported bundle ratios and scalar metric paths.
- Added episode-filter accounting payloads to relevant NPZ bundles so reviewers can inspect:
  - configured minimum episode threshold
  - number of metric units considered
  - number included
  - number excluded
  - observed and excluded episode counts
- Updated bundle validators so finite metric values are only allowed when their corresponding episode counts pass the reporting threshold.
- Updated pooled scalar plotting so selected trainings can be pooled at the episode/count level before filtering, rather than only summing already-filtered scalar values.
- Added and updated tests covering:
  - option precedence between primary and legacy flags
  - low-count masking behavior
  - bundle invariants
  - episode-filter accounting payloads
  - pooled-training filtering semantics

## Motivation

Several paper-facing metrics depend on ratios or averages computed from discrete behavioral episodes. When a fly/window/bin has only a very small number of contributing episodes, the resulting value can be mathematically defined but scientifically fragile.

Before this change, related filters existed in more local or metric-specific forms, which made it easier for filtering behavior to diverge across exports, plots, and validators. This PR centralizes the common filtering mechanics while preserving metric-specific episode definitions.

In practice, this means that each metric still uses the episode type appropriate to its biology and denominator, but the code now resolves thresholds, masks low-count values, records accounting metadata, and validates bundle consistency through a shared system.

## Notes for reviewers

The key conceptual distinction is:

- **Counts remain raw.**
- **Metric values are masked to `NaN` when counts are below the configured threshold.**
- **Filtering thresholds are resolved by episode type, with primary options taking precedence over legacy aliases.**
- **Pooled scalar plots can now apply the filter after pooling selected trainings at the episode level.**

This should make low-count exclusions more consistent and more auditable across the paper-metric pipeline.

## Testing

Added and updated tests for the shared episode-filter helpers, paper-metric truth cases, scalar plotting behavior, and bundle validators.