### PR TITLE
Add return-leg tortuosity analyses, wall-contact variants, and diagnostics

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -14922,6 +14922,14 @@ if __name__ == "__main__":
             )
             opts.wall = WALL_CONTACT_DEFAULT_THRESH_STR
 
+    if getattr(opts, "return_leg_tortuosity_excursion_bin_exclude_wall_contact", False):
+        if getattr(opts, "wall", None) is None:
+            print(
+                f"[return-leg-tortuosity-excursion-bin] enabling --wall={WALL_CONTACT_DEFAULT_THRESH_STR} "
+                "because --return-leg-tortuosity-excursion-bin-exclude-wall-contact was set"
+            )
+            opts.wall = WALL_CONTACT_DEFAULT_THRESH_STR
+
     if getattr(opts, "turnback_excursion_bin_exclude_wall_contact", False):
         if getattr(opts, "wall", None) is None:
             print(

--- a/analyze.py
+++ b/analyze.py
@@ -5696,6 +5696,16 @@ g.add_argument(
     help="Return-leg tortuosity definition. Default: %(default)s.",
 )
 g.add_argument(
+    "--return-leg-tortuosity-excursion-bin-top-fraction",
+    type=float,
+    default=1.0,
+    help=(
+        "Within each fly and distance bin, average only the highest-tortuosity "
+        "fraction of valid trajectories. Uses rank-based selection with "
+        "ceil(fraction * n); 1.0 preserves the ordinary mean. Default: %(default)s."
+    ),
+)
+g.add_argument(
     "--turnback-excursion-bin-exclude-wall-contact",
     action="store_true",
     help=(

--- a/analyze.py
+++ b/analyze.py
@@ -109,6 +109,9 @@ from src.exporting.return_prob_excursion_bin_sli_bundle import (
 from src.exporting.return_leg_tortuosity_excursion_bin_sli_bundle import (
     export_return_leg_tortuosity_excursion_bin_sli_bundle,
 )
+from src.exporting.return_leg_tortuosity_excursion_bin_examples import (
+    export_return_leg_tortuosity_excursion_bin_examples,
+)
 from src.exporting.turnback_excursion_bin_sli_bundle import (
     export_turnback_excursion_bin_sli_bundle,
 )
@@ -5314,6 +5317,16 @@ g.add_argument(
     ),
 )
 g.add_argument(
+    "--export-return-leg-tortuosity-excursion-bin-examples",
+    type=str,
+    default=None,
+    metavar="DIR",
+    help=(
+        "Export the highest-tortuosity contributing return-leg trajectories in "
+        "each maximum-distance bin, plus a CSV manifest, under DIR."
+    ),
+)
+g.add_argument(
     "--export-turnback-excursion-bin-sli-bundle",
     type=str,
     default=None,
@@ -5714,6 +5727,36 @@ g.add_argument(
         "Within each fly and distance bin, average only the highest-tortuosity "
         "fraction of valid trajectories. Uses rank-based selection with "
         "ceil(fraction * n); 1.0 preserves the ordinary mean. Default: %(default)s."
+    ),
+)
+g.add_argument(
+    "--return-leg-tortuosity-excursion-bin-examples-per-bin",
+    type=int,
+    default=6,
+    help="Number of ranked trajectory images to export per group and bin.",
+)
+g.add_argument(
+    "--return-leg-tortuosity-excursion-bin-examples-max-per-fly",
+    type=int,
+    default=0,
+    help=(
+        "Optional maximum examples from one fly in each group/bin; 0 disables "
+        "the cap. Default: %(default)s."
+    ),
+)
+g.add_argument(
+    "--return-leg-tortuosity-excursion-bin-examples-role",
+    choices=["exp", "ctrl", "both"],
+    default="exp",
+    help="Trajectory role to include in the diagnostic gallery. Default: %(default)s.",
+)
+g.add_argument(
+    "--return-leg-tortuosity-excursion-bin-examples-zoom-radius-mm",
+    type=float,
+    default=None,
+    help=(
+        "Reward-centered zoom radius for diagnostic images. By default each bin "
+        "uses its upper edge plus 1 mm; use 0 for the full arena."
     ),
 )
 g.add_argument(
@@ -10846,6 +10889,15 @@ def _export_post_analyze_bundles(vas, gls) -> int:
             opts,
             gls,
             opts.export_return_leg_tortuosity_excursion_bin_sli_bundle,
+        )
+        num_exports += 1
+
+    if getattr(opts, "export_return_leg_tortuosity_excursion_bin_examples", None):
+        export_return_leg_tortuosity_excursion_bin_examples(
+            vas,
+            opts,
+            gls,
+            opts.export_return_leg_tortuosity_excursion_bin_examples,
         )
         num_exports += 1
 

--- a/analyze.py
+++ b/analyze.py
@@ -5740,6 +5740,15 @@ g.add_argument(
     ),
 )
 g.add_argument(
+    "--return-leg-tortuosity-excursion-bin-exclude-wall-contact-frames",
+    action="store_true",
+    help=(
+        "Keep trajectories containing wall contact, but omit traveled-distance "
+        "steps whose endpoint frames include wall contact. The original global "
+        "maximum-distance denominator is retained."
+    ),
+)
+g.add_argument(
     "--return-leg-tortuosity-excursion-bin-exclude-nonwalking-frames",
     action="store_true",
     help="Compute return-leg tortuosity after dropping nonwalking frames.",
@@ -15136,6 +15145,19 @@ if __name__ == "__main__":
             )
             opts.wall = WALL_CONTACT_DEFAULT_THRESH_STR
 
+    if getattr(
+        opts,
+        "return_leg_tortuosity_excursion_bin_exclude_wall_contact_frames",
+        False,
+    ):
+        if getattr(opts, "wall", None) is None:
+            print(
+                f"[return-leg-tortuosity-excursion-bin] enabling "
+                f"--wall={WALL_CONTACT_DEFAULT_THRESH_STR} because frame-level "
+                "wall-contact exclusion was requested"
+            )
+            opts.wall = WALL_CONTACT_DEFAULT_THRESH_STR
+
     if (
         getattr(opts, "export_post_wall_departure_tortuosity_sli_bundle", None)
         or getattr(opts, "export_post_wall_departure_tortuosity_examples", None)
@@ -15169,6 +15191,53 @@ if __name__ == "__main__":
                 "because post_last_wall_max return-leg starts were requested"
             )
             opts.wall = WALL_CONTACT_DEFAULT_THRESH_STR
+
+    wall_treatment_count = sum(
+        (
+            bool(
+                getattr(
+                    opts,
+                    "return_leg_tortuosity_excursion_bin_exclude_wall_contact",
+                    False,
+                )
+            ),
+            bool(
+                getattr(
+                    opts,
+                    "return_leg_tortuosity_excursion_bin_exclude_wall_contact_frames",
+                    False,
+                )
+            ),
+            getattr(
+                opts,
+                "return_leg_tortuosity_excursion_bin_return_start_mode",
+                "global_max",
+            )
+            == "post_last_wall_max",
+        )
+    )
+    if wall_treatment_count > 1:
+        raise ValueError(
+            "Return-leg tortuosity whole-episode wall exclusion, frame-level "
+            "wall exclusion, and post-last-wall starts are mutually exclusive."
+        )
+    if (
+        getattr(
+            opts,
+            "return_leg_tortuosity_excursion_bin_exclude_wall_contact_frames",
+            False,
+        )
+        and getattr(
+            opts,
+            "return_leg_tortuosity_excursion_bin_metric_mode",
+            "path_over_max_radius",
+        )
+        != "path_over_max_radius"
+    ):
+        raise ValueError(
+            "--return-leg-tortuosity-excursion-bin-exclude-wall-contact-frames "
+            "requires metric mode path_over_max_radius."
+        )
 
     if (
         getattr(

--- a/analyze.py
+++ b/analyze.py
@@ -5696,6 +5696,17 @@ g.add_argument(
     help="Return-leg tortuosity definition. Default: %(default)s.",
 )
 g.add_argument(
+    "--return-leg-tortuosity-excursion-bin-return-start-mode",
+    choices=["global_max", "post_last_wall_max"],
+    default="global_max",
+    help=(
+        "How to define the return-leg start. 'global_max' uses the full-episode "
+        "maximum distance. 'post_last_wall_max' keeps the episode but starts at "
+        "the maximum distance after its final wall-contact frame. Default: "
+        "%(default)s."
+    ),
+)
+g.add_argument(
     "--return-leg-tortuosity-excursion-bin-top-fraction",
     type=float,
     default=1.0,
@@ -14937,6 +14948,29 @@ if __name__ == "__main__":
             print(
                 f"[return-leg-tortuosity-excursion-bin] enabling --wall={WALL_CONTACT_DEFAULT_THRESH_STR} "
                 "because --return-leg-tortuosity-excursion-bin-exclude-wall-contact was set"
+            )
+            opts.wall = WALL_CONTACT_DEFAULT_THRESH_STR
+
+    if (
+        getattr(
+            opts,
+            "return_leg_tortuosity_excursion_bin_return_start_mode",
+            "global_max",
+        )
+        == "post_last_wall_max"
+    ):
+        if getattr(
+            opts, "return_leg_tortuosity_excursion_bin_exclude_wall_contact", False
+        ):
+            raise ValueError(
+                "--return-leg-tortuosity-excursion-bin-return-start-mode "
+                "post_last_wall_max cannot be combined with "
+                "--return-leg-tortuosity-excursion-bin-exclude-wall-contact"
+            )
+        if getattr(opts, "wall", None) is None:
+            print(
+                f"[return-leg-tortuosity-excursion-bin] enabling --wall={WALL_CONTACT_DEFAULT_THRESH_STR} "
+                "because post_last_wall_max return-leg starts were requested"
             )
             opts.wall = WALL_CONTACT_DEFAULT_THRESH_STR
 

--- a/analyze.py
+++ b/analyze.py
@@ -112,6 +112,12 @@ from src.exporting.return_leg_tortuosity_excursion_bin_sli_bundle import (
 from src.exporting.return_leg_tortuosity_excursion_bin_examples import (
     export_return_leg_tortuosity_excursion_bin_examples,
 )
+from src.exporting.post_wall_departure_tortuosity_sli_bundle import (
+    export_post_wall_departure_tortuosity_sli_bundle,
+)
+from src.exporting.post_wall_departure_tortuosity_examples import (
+    export_post_wall_departure_tortuosity_examples,
+)
 from src.exporting.turnback_excursion_bin_sli_bundle import (
     export_turnback_excursion_bin_sli_bundle,
 )
@@ -5327,6 +5333,26 @@ g.add_argument(
     ),
 )
 g.add_argument(
+    "--export-post-wall-departure-tortuosity-sli-bundle",
+    type=str,
+    default=None,
+    help=(
+        "Write a .npz bundle containing, for wall-contact between-reward "
+        "trajectories, the per-fly mean path distance after final wall "
+        "departure divided by direct distance to the reward-circle perimeter."
+    ),
+)
+g.add_argument(
+    "--export-post-wall-departure-tortuosity-examples",
+    type=str,
+    default=None,
+    metavar="DIR",
+    help=(
+        "Export ranked trajectory images for the post-wall departure "
+        "tortuosity metric, plus a CSV manifest, under DIR."
+    ),
+)
+g.add_argument(
     "--export-turnback-excursion-bin-sli-bundle",
     type=str,
     default=None,
@@ -5369,6 +5395,15 @@ g.add_argument(
     help=(
         "Trainings to include in return-leg-tortuosity excursion-bin exports, "
         "e.g. '2' or '2-3'. Default: all trainings."
+    ),
+)
+g.add_argument(
+    "--post-wall-departure-tortuosity-trainings",
+    type=str,
+    default=None,
+    help=(
+        "Trainings to include in post-wall departure tortuosity exports, e.g. "
+        "'2' or '2-3'. Default: all trainings."
     ),
 )
 g.add_argument(
@@ -5569,6 +5604,15 @@ g.add_argument(
     ),
 )
 g.add_argument(
+    "--post-wall-departure-tortuosity-skip-first-sync-buckets",
+    type=int,
+    default=None,
+    help=(
+        "Optional export-specific sync-bucket skip for post-wall departure "
+        "tortuosity. Defaults to --skip-first-sync-buckets."
+    ),
+)
+g.add_argument(
     "--turnback-excursion-bin-skip-first-sync-buckets",
     type=int,
     default=None,
@@ -5611,6 +5655,15 @@ g.add_argument(
     help=(
         "Optional export-specific sync-bucket cap for return-leg-tortuosity "
         "excursion-bin bundles. Defaults to --keep-first-sync-buckets."
+    ),
+)
+g.add_argument(
+    "--post-wall-departure-tortuosity-keep-first-sync-buckets",
+    type=int,
+    default=None,
+    help=(
+        "Optional export-specific sync-bucket cap for post-wall departure "
+        "tortuosity. Defaults to --keep-first-sync-buckets."
     ),
 )
 g.add_argument(
@@ -5698,6 +5751,26 @@ g.add_argument(
     help="Minimum kept frames required for return-leg tortuosity.",
 )
 g.add_argument(
+    "--post-wall-departure-tortuosity-exclude-nonwalking-frames",
+    action="store_true",
+    help="Drop nonwalking frames from post-wall departure path distance.",
+)
+g.add_argument(
+    "--post-wall-departure-tortuosity-min-walk-frames",
+    type=int,
+    default=2,
+    help="Minimum kept frames required after final wall departure.",
+)
+g.add_argument(
+    "--post-wall-departure-tortuosity-min-direct-distance-mm",
+    type=float,
+    default=0.0,
+    help=(
+        "Exclude departures whose direct distance to the reward-circle "
+        "perimeter is at or below this value. Default: %(default)s."
+    ),
+)
+g.add_argument(
     "--return-leg-tortuosity-excursion-bin-min-radius-mm",
     type=float,
     default=0.0,
@@ -5769,6 +5842,36 @@ g.add_argument(
     help=(
         "Reward-centered zoom radius for diagnostic images. By default each bin "
         "uses its upper edge plus 1 mm; use 0 for the full arena."
+    ),
+)
+g.add_argument(
+    "--post-wall-departure-tortuosity-examples-num",
+    type=int,
+    default=12,
+    help="Total ranked trajectory images to export. Default: %(default)s.",
+)
+g.add_argument(
+    "--post-wall-departure-tortuosity-examples-max-per-fly",
+    type=int,
+    default=1,
+    help=(
+        "Maximum ranked images from one fly; 0 disables the cap. "
+        "Default: %(default)s."
+    ),
+)
+g.add_argument(
+    "--post-wall-departure-tortuosity-examples-role",
+    choices=["exp", "ctrl", "both"],
+    default="exp",
+    help="Trajectory role to include in the diagnostic gallery. Default: %(default)s.",
+)
+g.add_argument(
+    "--post-wall-departure-tortuosity-examples-zoom-radius-mm",
+    type=float,
+    default=None,
+    help=(
+        "Reward-centered zoom radius for diagnostic images; unset or 0 uses "
+        "the full arena."
     ),
 )
 g.add_argument(
@@ -10913,6 +11016,24 @@ def _export_post_analyze_bundles(vas, gls) -> int:
         )
         num_exports += 1
 
+    if getattr(opts, "export_post_wall_departure_tortuosity_sli_bundle", None):
+        export_post_wall_departure_tortuosity_sli_bundle(
+            vas,
+            opts,
+            gls,
+            opts.export_post_wall_departure_tortuosity_sli_bundle,
+        )
+        num_exports += 1
+
+    if getattr(opts, "export_post_wall_departure_tortuosity_examples", None):
+        export_post_wall_departure_tortuosity_examples(
+            vas,
+            opts,
+            gls,
+            opts.export_post_wall_departure_tortuosity_examples,
+        )
+        num_exports += 1
+
     if getattr(opts, "export_turnback_excursion_bin_sli_bundle", None):
         export_turnback_excursion_bin_sli_bundle(
             vas, opts, gls, opts.export_turnback_excursion_bin_sli_bundle
@@ -15014,6 +15135,17 @@ if __name__ == "__main__":
                 "because --return-leg-tortuosity-excursion-bin-exclude-wall-contact was set"
             )
             opts.wall = WALL_CONTACT_DEFAULT_THRESH_STR
+
+    if (
+        getattr(opts, "export_post_wall_departure_tortuosity_sli_bundle", None)
+        or getattr(opts, "export_post_wall_departure_tortuosity_examples", None)
+    ) and getattr(opts, "wall", None) is None:
+        print(
+            f"[post-wall-departure-tortuosity] enabling "
+            f"--wall={WALL_CONTACT_DEFAULT_THRESH_STR} because wall-contact "
+            "trajectory analysis was requested"
+        )
+        opts.wall = WALL_CONTACT_DEFAULT_THRESH_STR
 
     if (
         getattr(

--- a/analyze.py
+++ b/analyze.py
@@ -106,6 +106,9 @@ from src.exporting.return_prob_outer_radius_sli_bundle import (
 from src.exporting.return_prob_excursion_bin_sli_bundle import (
     export_return_prob_excursion_bin_sli_bundle,
 )
+from src.exporting.return_leg_tortuosity_excursion_bin_sli_bundle import (
+    export_return_leg_tortuosity_excursion_bin_sli_bundle,
+)
 from src.exporting.turnback_excursion_bin_sli_bundle import (
     export_turnback_excursion_bin_sli_bundle,
 )
@@ -5301,6 +5304,16 @@ g.add_argument(
     ),
 )
 g.add_argument(
+    "--export-return-leg-tortuosity-excursion-bin-sli-bundle",
+    type=str,
+    default=None,
+    help=(
+        "Write an .npz bundle with mean return-leg tortuosity of between-reward "
+        "trajectories as a function of maximum-distance bins for multi-group "
+        "overlays/stats."
+    ),
+)
+g.add_argument(
     "--export-turnback-excursion-bin-sli-bundle",
     type=str,
     default=None,
@@ -5334,6 +5347,15 @@ g.add_argument(
     help=(
         "Trainings to include in return-prob-excursion-bin exports, e.g. '2' or "
         "'2-3'. Default: all trainings."
+    ),
+)
+g.add_argument(
+    "--return-leg-tortuosity-excursion-bin-trainings",
+    type=str,
+    default=None,
+    help=(
+        "Trainings to include in return-leg-tortuosity excursion-bin exports, "
+        "e.g. '2' or '2-3'. Default: all trainings."
     ),
 )
 g.add_argument(
@@ -5401,6 +5423,42 @@ g.add_argument(
         "return-prob-excursion-bin export. Use 'inf' as the final edge for an "
         "open-ended upper bin resolved to the maximum observed excursion, "
         "e.g. '2,8,16,inf'."
+    ),
+)
+g.add_argument(
+    "--return-leg-tortuosity-excursion-bin-radii-mm",
+    type=str,
+    default=None,
+    help=(
+        "Comma-separated radial distance bin edges from reward-circle center (mm) "
+        "for the return-leg-tortuosity excursion-bin export."
+    ),
+)
+g.add_argument(
+    "--return-leg-tortuosity-excursion-bin-edges-mm",
+    type=str,
+    default=None,
+    help=(
+        "Deprecated: comma-separated bin edges in mm beyond reward-circle radius "
+        "for the return-leg-tortuosity excursion-bin export."
+    ),
+)
+g.add_argument(
+    "--return-leg-tortuosity-excursion-bin-radius-pairs-mm",
+    type=str,
+    default=None,
+    help=(
+        "Optional independent radial distance ranges from reward-circle center, "
+        "e.g. '17:19,22:24,27:29'."
+    ),
+)
+g.add_argument(
+    "--return-leg-tortuosity-excursion-bin-pairs-mm",
+    type=str,
+    default=None,
+    help=(
+        "Deprecated: independent ranges in mm beyond reward-circle radius, "
+        "e.g. '3:5,8:10,13:15'."
     ),
 )
 g.add_argument(
@@ -5477,6 +5535,15 @@ g.add_argument(
     ),
 )
 g.add_argument(
+    "--return-leg-tortuosity-excursion-bin-skip-first-sync-buckets",
+    type=int,
+    default=None,
+    help=(
+        "Optional export-specific sync-bucket skip for return-leg-tortuosity "
+        "excursion-bin bundles. Defaults to --skip-first-sync-buckets."
+    ),
+)
+g.add_argument(
     "--turnback-excursion-bin-skip-first-sync-buckets",
     type=int,
     default=None,
@@ -5510,6 +5577,15 @@ g.add_argument(
     help=(
         "Optional export-specific sync-bucket cap for return-prob-excursion-bin "
         "bundles. Defaults to --keep-first-sync-buckets."
+    ),
+)
+g.add_argument(
+    "--return-leg-tortuosity-excursion-bin-keep-first-sync-buckets",
+    type=int,
+    default=None,
+    help=(
+        "Optional export-specific sync-bucket cap for return-leg-tortuosity "
+        "excursion-bin bundles. Defaults to --keep-first-sync-buckets."
     ),
 )
 g.add_argument(
@@ -5578,6 +5654,48 @@ g.add_argument(
     ),
 )
 g.add_argument(
+    "--return-leg-tortuosity-excursion-bin-exclude-wall-contact",
+    action="store_true",
+    help=(
+        "Discard between-reward trajectories whose frame span overlaps wall "
+        "contact."
+    ),
+)
+g.add_argument(
+    "--return-leg-tortuosity-excursion-bin-exclude-nonwalking-frames",
+    action="store_true",
+    help="Compute return-leg tortuosity after dropping nonwalking frames.",
+)
+g.add_argument(
+    "--return-leg-tortuosity-excursion-bin-min-walk-frames",
+    type=int,
+    default=2,
+    help="Minimum kept frames required for return-leg tortuosity.",
+)
+g.add_argument(
+    "--return-leg-tortuosity-excursion-bin-min-radius-mm",
+    type=float,
+    default=0.0,
+    help="Minimum radius for path_over_max_radius return-leg tortuosity.",
+)
+g.add_argument(
+    "--return-leg-tortuosity-excursion-bin-min-displacement-mm",
+    type=float,
+    default=0.0,
+    help="Minimum displacement for displacement-based tortuosity modes.",
+)
+g.add_argument(
+    "--return-leg-tortuosity-excursion-bin-metric-mode",
+    choices=[
+        "path_over_max_radius",
+        "path_over_displacement",
+        "straightness",
+        "excess_path",
+    ],
+    default="path_over_max_radius",
+    help="Return-leg tortuosity definition. Default: %(default)s.",
+)
+g.add_argument(
     "--turnback-excursion-bin-exclude-wall-contact",
     action="store_true",
     help=(
@@ -5627,6 +5745,11 @@ g.add_argument(
         "Debug export of return-prob-excursion-bin+SLI bundle: print selected "
         "windows, bins, and per-video count summaries."
     ),
+)
+g.add_argument(
+    "--return-leg-tortuosity-excursion-bin-debug",
+    action="store_true",
+    help="Print per-video segment counts for the new excursion-bin export.",
 )
 g.add_argument(
     "--return-prob-reward-radius-mm",
@@ -10693,6 +10816,15 @@ def _export_post_analyze_bundles(vas, gls) -> int:
     if getattr(opts, "export_return_prob_excursion_bin_sli_bundle", None):
         export_return_prob_excursion_bin_sli_bundle(
             vas, opts, gls, opts.export_return_prob_excursion_bin_sli_bundle
+        )
+        num_exports += 1
+
+    if getattr(opts, "export_return_leg_tortuosity_excursion_bin_sli_bundle", None):
+        export_return_leg_tortuosity_excursion_bin_sli_bundle(
+            vas,
+            opts,
+            gls,
+            opts.export_return_leg_tortuosity_excursion_bin_sli_bundle,
         )
         num_exports += 1
 

--- a/analyze.py
+++ b/analyze.py
@@ -5466,6 +5466,18 @@ g.add_argument(
     ),
 )
 g.add_argument(
+    "--return-leg-tortuosity-excursion-bin-binning-mode",
+    choices=["absolute_distance", "per_fly_quartile"],
+    default="absolute_distance",
+    help=(
+        "Bin trajectories by fixed absolute maximum-distance ranges or by four "
+        "equal-count maximum-distance quartiles calculated independently for "
+        "each fly. Quartile mode does not use radius-edge options and requires "
+        "--return-leg-tortuosity-excursion-bin-top-fraction 1.0. Default: "
+        "%(default)s."
+    ),
+)
+g.add_argument(
     "--return-leg-tortuosity-excursion-bin-pairs-mm",
     type=str,
     default=None,
@@ -15025,6 +15037,28 @@ if __name__ == "__main__":
                 "because post_last_wall_max return-leg starts were requested"
             )
             opts.wall = WALL_CONTACT_DEFAULT_THRESH_STR
+
+    if (
+        getattr(
+            opts,
+            "return_leg_tortuosity_excursion_bin_binning_mode",
+            "absolute_distance",
+        )
+        == "per_fly_quartile"
+        and float(
+            getattr(
+                opts,
+                "return_leg_tortuosity_excursion_bin_top_fraction",
+                1.0,
+            )
+            or 1.0
+        )
+        != 1.0
+    ):
+        raise ValueError(
+            "--return-leg-tortuosity-excursion-bin-top-fraction must be 1.0 "
+            "with per_fly_quartile binning"
+        )
 
     if getattr(opts, "turnback_excursion_bin_exclude_wall_contact", False):
         if getattr(opts, "wall", None) is None:

--- a/scripts/plot_post_wall_departure_tortuosity_sli_bundles.py
+++ b/scripts/plot_post_wall_departure_tortuosity_sli_bundles.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+import argparse
+from types import SimpleNamespace
+
+from src.plotting.post_wall_departure_tortuosity_sli_bundle_plotter import (
+    plot_post_wall_departure_tortuosity_sli_bundles,
+)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--bundles", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--labels", default=None)
+    parser.add_argument(
+        "--mode", default="exp", choices=["exp", "ctrl", "exp_minus_ctrl"]
+    )
+    parser.add_argument(
+        "--sli-extremes", default=None, choices=["top", "bottom", "both"]
+    )
+    parser.add_argument(
+        "--best-worst-fraction", type=float, default=argparse.SUPPRESS
+    )
+    parser.add_argument("--top-sli-fraction", type=float, default=argparse.SUPPRESS)
+    parser.add_argument(
+        "--bottom-sli-fraction", type=float, default=argparse.SUPPRESS
+    )
+    parser.add_argument("--standalone-extreme-labels", action="store_true")
+    parser.add_argument("--title", default=None)
+    parser.add_argument("--xlabel", default=None)
+    parser.add_argument("--ylabel", default=None)
+    parser.add_argument("--ymax", type=float, default=None)
+    parser.add_argument("--stats", action="store_true")
+    parser.add_argument("--stats-alpha", type=float, default=0.05)
+    parser.add_argument("--stats-paired", action="store_true")
+    parser.add_argument("--debug", action="store_true")
+    parser.add_argument("--bar-alpha", type=float, default=0.90)
+    parser.add_argument(
+        "--image-format", "--imgFormat", dest="image_format", default="png"
+    )
+    parser.add_argument("--fs", dest="font_size", type=float, default=None)
+    parser.add_argument("--fontFamily", dest="font_family", default=None)
+    args = parser.parse_args()
+
+    shared = getattr(args, "best_worst_fraction", None)
+    top = getattr(args, "top_sli_fraction", None)
+    bottom = getattr(args, "bottom_sli_fraction", None)
+    top = shared if top is None else top
+    bottom = shared if bottom is None else bottom
+    for name, value in (
+        ("--best-worst-fraction", shared),
+        ("--top-sli-fraction", top),
+        ("--bottom-sli-fraction", bottom),
+    ):
+        if value is not None and not (0 < float(value) <= 1):
+            raise SystemExit(f"{name} must be in the interval (0, 1].")
+
+    plot_post_wall_departure_tortuosity_sli_bundles(
+        [item for item in args.bundles.split(",") if item],
+        args.out,
+        labels=(
+            [item.strip() for item in args.labels.split(",")]
+            if args.labels
+            else None
+        ),
+        mode=args.mode,
+        sli_extremes=args.sli_extremes,
+        sli_fraction=shared,
+        sli_top_fraction=top,
+        sli_bottom_fraction=bottom,
+        standalone_extreme_labels=args.standalone_extreme_labels,
+        title=args.title,
+        xlabel=args.xlabel,
+        ylabel=args.ylabel,
+        ymax=args.ymax,
+        stats=args.stats,
+        stats_alpha=args.stats_alpha,
+        stats_paired=args.stats_paired,
+        debug=args.debug,
+        bar_alpha=args.bar_alpha,
+        opts=SimpleNamespace(
+            imageFormat=args.image_format,
+            fontSize=args.font_size,
+            fontFamily=args.font_family,
+        ),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/plot_return_leg_tortuosity_excursion_bin_sli_bundles.py
+++ b/scripts/plot_return_leg_tortuosity_excursion_bin_sli_bundles.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+import argparse
+from types import SimpleNamespace
+
+from src.plotting.return_leg_tortuosity_excursion_bin_sli_bundle_plotter import (
+    plot_return_leg_tortuosity_excursion_bin_sli_bundles,
+)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--bundles", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--labels", default=None)
+    parser.add_argument(
+        "--mode", default="exp", choices=["exp", "ctrl", "exp_minus_ctrl"]
+    )
+    parser.add_argument(
+        "--sli-extremes", default=None, choices=["top", "bottom", "both"]
+    )
+    parser.add_argument(
+        "--best-worst-fraction", type=float, default=argparse.SUPPRESS
+    )
+    parser.add_argument("--top-sli-fraction", type=float, default=argparse.SUPPRESS)
+    parser.add_argument(
+        "--bottom-sli-fraction", type=float, default=argparse.SUPPRESS
+    )
+    parser.add_argument("--standalone-extreme-labels", action="store_true")
+    parser.add_argument("--title", default=None)
+    parser.add_argument("--xlabel", default=None)
+    parser.add_argument("--ylabel", default=None)
+    parser.add_argument("--ymax", type=float, default=None)
+    parser.add_argument("--stats", action="store_true")
+    parser.add_argument("--stats-alpha", type=float, default=0.05)
+    parser.add_argument("--stats-paired", action="store_true")
+    parser.add_argument("--debug", action="store_true")
+    parser.add_argument("--bar-alpha", type=float, default=0.90)
+    parser.add_argument(
+        "--image-format", "--imgFormat", dest="image_format", default="png"
+    )
+    parser.add_argument("--fs", dest="font_size", type=float, default=None)
+    parser.add_argument("--fontFamily", dest="font_family", default=None)
+    args = parser.parse_args()
+
+    shared = getattr(args, "best_worst_fraction", None)
+    top = getattr(args, "top_sli_fraction", None)
+    bottom = getattr(args, "bottom_sli_fraction", None)
+    top = shared if top is None else top
+    bottom = shared if bottom is None else bottom
+    for name, value in (
+        ("--best-worst-fraction", shared),
+        ("--top-sli-fraction", top),
+        ("--bottom-sli-fraction", bottom),
+    ):
+        if value is not None and not (0 < float(value) <= 1):
+            raise SystemExit(f"{name} must be in the interval (0, 1].")
+
+    plot_return_leg_tortuosity_excursion_bin_sli_bundles(
+        [item for item in args.bundles.split(",") if item],
+        args.out,
+        labels=(
+            [item.strip() for item in args.labels.split(",")]
+            if args.labels
+            else None
+        ),
+        mode=args.mode,
+        sli_extremes=args.sli_extremes,
+        sli_fraction=shared,
+        sli_top_fraction=top,
+        sli_bottom_fraction=bottom,
+        standalone_extreme_labels=args.standalone_extreme_labels,
+        title=args.title,
+        xlabel=args.xlabel,
+        ylabel=args.ylabel,
+        ymax=args.ymax,
+        stats=args.stats,
+        stats_alpha=args.stats_alpha,
+        stats_paired=args.stats_paired,
+        debug=args.debug,
+        bar_alpha=args.bar_alpha,
+        opts=SimpleNamespace(
+            imageFormat=args.image_format,
+            fontSize=args.font_size,
+            fontFamily=args.font_family,
+        ),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_analysis_matrix.sh
+++ b/scripts/run_analysis_matrix.sh
@@ -245,7 +245,7 @@ run_return_leg_tortuosity_bins() {
       -f 0-1 \
       --rCC 15 \
       --export-return-leg-tortuosity-excursion-bin-sli-bundle "$bundle" \
-      --return-leg-tortuosity-excursion-bin-pairs-mm "$bins_arg" \
+      --return-leg-tortuosity-excursion-bin-radius-pairs-mm "$bins_arg" \
       --return-leg-tortuosity-excursion-bin-trainings 2 \
       --return-leg-tortuosity-excursion-bin-skip-first-sync-buckets 1 \
       --best-worst-trn 2 \
@@ -322,7 +322,7 @@ run_return_leg_tortuosity_bins() {
 
 # ---------------------------------------------------------------------
 # Return-leg tortuosity by max-distance bin
-# radial config: 3-5, 8-10, 13-15 mm beyond reward-circle radius
+# radial config: 3-5, 8-10, 13-15 mm from reward-circle center
 # only 5-episode minimum + T2 SB5 presence filter
 # ---------------------------------------------------------------------
 

--- a/scripts/run_analysis_matrix.sh
+++ b/scripts/run_analysis_matrix.sh
@@ -200,6 +200,7 @@ run_return_leg_tortuosity_bins() {
   local wall_tag="$4"
   local summary_tag="$5"
   local top_fraction="$6"
+  local binning_mode="${7:-absolute_distance}"
 
   local filter_flags=()
   case "$filter_tag" in
@@ -248,8 +249,27 @@ run_return_leg_tortuosity_bins() {
     local group_slug="${GROUP_SLUGS[$i]}"
     local group_label="${GROUP_LABELS[$i]}"
     local bundle="exports/returnLegTortuosityBins_${summary_tag}_${filter_tag}_${wall_tag}_${group_slug}_flatLgc_T2_b${bins_label}_${DATE_TAG}.npz"
+    local binning_flags=()
+    case "$binning_mode" in
+      absolute_distance)
+        binning_flags=(
+          --return-leg-tortuosity-excursion-bin-radius-pairs-mm "$bins_arg"
+          --return-leg-tortuosity-excursion-bin-top-fraction "$top_fraction"
+        )
+        ;;
+      per_fly_quartile)
+        binning_flags=(
+          --return-leg-tortuosity-excursion-bin-binning-mode per_fly_quartile
+          --return-leg-tortuosity-excursion-bin-top-fraction 1.0
+        )
+        ;;
+      *)
+        echo "Unknown return-leg tortuosity binning mode: $binning_mode" >&2
+        exit 1
+        ;;
+    esac
     local example_flags=()
-    if [[ "$RETURN_LEG_TORTUOSITY_EXAMPLES" == "1" ]]; then
+    if [[ "$RETURN_LEG_TORTUOSITY_EXAMPLES" == "1" && "$binning_mode" == "absolute_distance" ]]; then
       local example_dir="exports/returnLegTortuosityExamples_${summary_tag}_${filter_tag}_${wall_tag}_${group_slug}_flatLgc_T2_b${bins_label}_${DATE_TAG}"
       example_flags=(
         --export-return-leg-tortuosity-excursion-bin-examples "$example_dir"
@@ -265,14 +285,13 @@ run_return_leg_tortuosity_bins() {
       -f 0-1 \
       --rCC 15 \
       --export-return-leg-tortuosity-excursion-bin-sli-bundle "$bundle" \
-      --return-leg-tortuosity-excursion-bin-radius-pairs-mm "$bins_arg" \
-      --return-leg-tortuosity-excursion-bin-top-fraction "$top_fraction" \
       --return-leg-tortuosity-excursion-bin-trainings 2 \
       --return-leg-tortuosity-excursion-bin-skip-first-sync-buckets 1 \
       --best-worst-trn 2 \
       --sli-use-training-mean \
       --sli-select-skip-first-sync-buckets 1 \
       --export-group-label "$group_label" \
+      "${binning_flags[@]}" \
       "${filter_flags[@]}" \
       "${wall_flags[@]}" \
       "${example_flags[@]}"
@@ -360,4 +379,21 @@ for wall_tag in wall noWall postWall; do
     "$wall_tag" \
     top25 \
     0.25
+done
+
+# ---------------------------------------------------------------------
+# Mean return-leg tortuosity by per-fly maximum-distance quartile
+# Q1-Q4 are four equal-count bins formed independently for each fly.
+# Top-fraction tortuosity aggregation is intentionally disabled.
+# ---------------------------------------------------------------------
+
+for wall_tag in wall noWall postWall; do
+  run_return_leg_tortuosity_bins \
+    "quartiles" \
+    "" \
+    minEpSb5Filt \
+    "$wall_tag" \
+    mean \
+    1.0 \
+    per_fly_quartile
 done

--- a/scripts/run_analysis_matrix.sh
+++ b/scripts/run_analysis_matrix.sh
@@ -239,6 +239,11 @@ run_return_leg_tortuosity_bins() {
         post_last_wall_max
       )
       ;;
+    offWallFrames)
+      wall_flags=(
+        --return-leg-tortuosity-excursion-bin-exclude-wall-contact-frames
+      )
+      ;;
     *)
       echo "Unknown wall tag: $wall_tag" >&2
       exit 1
@@ -435,19 +440,18 @@ run_post_wall_departure_tortuosity() {
 # wall: standard full-episode maximum return-leg start
 # noWall: discard episodes containing wall contact
 # postWall: keep episodes and use the maximum after final wall contact
+# offWallFrames: keep episodes but omit wall-contact steps from path distance
 # only 5-episode minimum + T2 SB5 presence filter
 # Set RETURN_LEG_TORTUOSITY_EXAMPLES=1 to export ranked trajectory galleries.
 # ---------------------------------------------------------------------
 
-# for wall_tag in wall noWall postWall; do
-#   run_return_leg_tortuosity_bins \
-#     "3-5_8-10_13-15" \
-#     "3:5,8:10,13:15" \
-#     minEpSb5Filt \
-#     "$wall_tag" \
-#     top25 \
-#     0.25
-# done
+run_return_leg_tortuosity_bins \
+  "3-5_8-10_13-15_15-20_20-25_25-30" \
+  "3:5,8:10,13:15,15:20,20:25,25:30" \
+  noFilt \
+  offWallFrames \
+  all \
+  1.0
 
 # ---------------------------------------------------------------------
 # Mean tortuosity after the final wall departure.

--- a/scripts/run_analysis_matrix.sh
+++ b/scripts/run_analysis_matrix.sh
@@ -195,6 +195,8 @@ run_return_leg_tortuosity_bins() {
   local bins_arg="$2"
   local filter_tag="$3"
   local wall_tag="$4"
+  local summary_tag="$5"
+  local top_fraction="$6"
 
   local filter_flags=()
   case "$filter_tag" in
@@ -236,7 +238,7 @@ run_return_leg_tortuosity_bins() {
     local dataset="${!var_name}"
     local group_slug="${GROUP_SLUGS[$i]}"
     local group_label="${GROUP_LABELS[$i]}"
-    local bundle="exports/returnLegTortuosityBins_${filter_tag}_${wall_tag}_${group_slug}_flatLgc_T2_b${bins_label}_${DATE_TAG}.npz"
+    local bundle="exports/returnLegTortuosityBins_${summary_tag}_${filter_tag}_${wall_tag}_${group_slug}_flatLgc_T2_b${bins_label}_${DATE_TAG}.npz"
 
     bundles+=("$bundle")
     run_cmd \
@@ -246,6 +248,7 @@ run_return_leg_tortuosity_bins() {
       --rCC 15 \
       --export-return-leg-tortuosity-excursion-bin-sli-bundle "$bundle" \
       --return-leg-tortuosity-excursion-bin-radius-pairs-mm "$bins_arg" \
+      --return-leg-tortuosity-excursion-bin-top-fraction "$top_fraction" \
       --return-leg-tortuosity-excursion-bin-trainings 2 \
       --return-leg-tortuosity-excursion-bin-skip-first-sync-buckets 1 \
       --best-worst-trn 2 \
@@ -261,7 +264,7 @@ run_return_leg_tortuosity_bins() {
   run_cmd \
     python -m scripts.plot_return_leg_tortuosity_excursion_bin_sli_bundles \
     --bundles "$bundle_csv" \
-    --out "exports/returnLegTortuosityBins_${filter_tag}_${wall_tag}_flatLgc_T2_b${bins_label}_${DATE_TAG}.png" \
+    --out "exports/returnLegTortuosityBins_${summary_tag}_${filter_tag}_${wall_tag}_flatLgc_T2_b${bins_label}_${DATE_TAG}.png" \
     --stats
 }
 
@@ -321,7 +324,7 @@ run_return_leg_tortuosity_bins() {
 # done
 
 # ---------------------------------------------------------------------
-# Return-leg tortuosity by max-distance bin
+# Top-25% mean return-leg tortuosity by max-distance bin
 # radial config: 3-5, 8-10, 13-15 mm from reward-circle center
 # only 5-episode minimum + T2 SB5 presence filter
 # ---------------------------------------------------------------------
@@ -331,5 +334,7 @@ for wall_tag in wall noWall; do
     "3-5_8-10_13-15" \
     "3:5,8:10,13:15" \
     minEpSb5Filt \
-    "$wall_tag"
+    "$wall_tag" \
+    top25 \
+    0.25
 done

--- a/scripts/run_analysis_matrix.sh
+++ b/scripts/run_analysis_matrix.sh
@@ -6,6 +6,9 @@ PRINT_ONLY="${PRINT_ONLY:-0}"
 RETURN_LEG_TORTUOSITY_EXAMPLES="${RETURN_LEG_TORTUOSITY_EXAMPLES:-0}"
 RETURN_LEG_TORTUOSITY_EXAMPLES_PER_BIN="${RETURN_LEG_TORTUOSITY_EXAMPLES_PER_BIN:-6}"
 RETURN_LEG_TORTUOSITY_EXAMPLES_MAX_PER_FLY="${RETURN_LEG_TORTUOSITY_EXAMPLES_MAX_PER_FLY:-0}"
+POST_WALL_DEPARTURE_TORTUOSITY_EXAMPLES="${POST_WALL_DEPARTURE_TORTUOSITY_EXAMPLES:-0}"
+POST_WALL_DEPARTURE_TORTUOSITY_EXAMPLES_NUM="${POST_WALL_DEPARTURE_TORTUOSITY_EXAMPLES_NUM:-12}"
+POST_WALL_DEPARTURE_TORTUOSITY_EXAMPLES_MAX_PER_FLY="${POST_WALL_DEPARTURE_TORTUOSITY_EXAMPLES_MAX_PER_FLY:-1}"
 
 GROUP_VARS=(INTACT_CTRL INTACT_PFND AR_CTRL)
 GROUP_SLUGS=(intact_ctrlKir intact_pfnKir ar_ctrlKir)
@@ -306,6 +309,71 @@ run_return_leg_tortuosity_bins() {
     --stats
 }
 
+run_post_wall_departure_tortuosity() {
+  local filter_tag="$1"
+  local filter_flags=()
+  case "$filter_tag" in
+    noFilt)
+      filter_flags=(--min-between-reward-trajectories 0)
+      ;;
+    minEpFilt)
+      filter_flags=()
+      ;;
+    minEpSb5Filt)
+      filter_flags=(--require-exp-target-sync-bucket)
+      ;;
+    minEpPiFilt)
+      filter_flags=(--require-exp-pi-threshold-bucket)
+      ;;
+    *)
+      echo "Unknown post-wall departure tortuosity filter tag: $filter_tag" >&2
+      exit 1
+      ;;
+  esac
+
+  local bundles=()
+  for i in "${!GROUP_VARS[@]}"; do
+    local var_name="${GROUP_VARS[$i]}"
+    local dataset="${!var_name}"
+    local group_slug="${GROUP_SLUGS[$i]}"
+    local group_label="${GROUP_LABELS[$i]}"
+    local bundle="exports/postWallDepartureTortuosity_${filter_tag}_${group_slug}_flatLgc_T2_${DATE_TAG}.npz"
+    local example_flags=()
+    if [[ "$POST_WALL_DEPARTURE_TORTUOSITY_EXAMPLES" == "1" ]]; then
+      local example_dir="exports/postWallDepartureTortuosityExamples_${filter_tag}_${group_slug}_flatLgc_T2_${DATE_TAG}"
+      example_flags=(
+        --export-post-wall-departure-tortuosity-examples "$example_dir"
+        --post-wall-departure-tortuosity-examples-num "$POST_WALL_DEPARTURE_TORTUOSITY_EXAMPLES_NUM"
+        --post-wall-departure-tortuosity-examples-max-per-fly "$POST_WALL_DEPARTURE_TORTUOSITY_EXAMPLES_MAX_PER_FLY"
+      )
+    fi
+
+    bundles+=("$bundle")
+    run_cmd \
+      python analyze.py \
+      -v "$dataset" \
+      -f 0-1 \
+      --rCC 15 \
+      --export-post-wall-departure-tortuosity-sli-bundle "$bundle" \
+      --post-wall-departure-tortuosity-trainings 2 \
+      --post-wall-departure-tortuosity-skip-first-sync-buckets 1 \
+      --best-worst-trn 2 \
+      --sli-use-training-mean \
+      --sli-select-skip-first-sync-buckets 1 \
+      --export-group-label "$group_label" \
+      "${filter_flags[@]}" \
+      "${example_flags[@]}"
+  done
+
+  local bundle_csv
+  bundle_csv="$(join_by_comma "${bundles[@]}")"
+  run_cmd \
+    python -m scripts.plot_post_wall_departure_tortuosity_sli_bundles \
+    --bundles "$bundle_csv" \
+    --out "exports/postWallDepartureTortuosity_${filter_tag}_flatLgc_T2_${DATE_TAG}.png" \
+    --stats
+}
+
 # ---------------------------------------------------------------------
 # Fraction of trajectories within radius, historical return-prob name
 # radial config: 6 / 11 / 16 mm
@@ -371,15 +439,23 @@ run_return_leg_tortuosity_bins() {
 # Set RETURN_LEG_TORTUOSITY_EXAMPLES=1 to export ranked trajectory galleries.
 # ---------------------------------------------------------------------
 
-for wall_tag in wall noWall postWall; do
-  run_return_leg_tortuosity_bins \
-    "3-5_8-10_13-15" \
-    "3:5,8:10,13:15" \
-    minEpSb5Filt \
-    "$wall_tag" \
-    top25 \
-    0.25
-done
+# for wall_tag in wall noWall postWall; do
+#   run_return_leg_tortuosity_bins \
+#     "3-5_8-10_13-15" \
+#     "3:5,8:10,13:15" \
+#     minEpSb5Filt \
+#     "$wall_tag" \
+#     top25 \
+#     0.25
+# done
+
+# ---------------------------------------------------------------------
+# Mean tortuosity after the final wall departure.
+# Only between-reward trajectories containing wall contact contribute.
+# Set POST_WALL_DEPARTURE_TORTUOSITY_EXAMPLES=1 for ranked path galleries.
+# ---------------------------------------------------------------------
+
+run_post_wall_departure_tortuosity minEpSb5Filt
 
 # ---------------------------------------------------------------------
 # Mean return-leg tortuosity by per-fly maximum-distance quartile
@@ -387,13 +463,13 @@ done
 # Top-fraction tortuosity aggregation is intentionally disabled.
 # ---------------------------------------------------------------------
 
-for wall_tag in wall noWall postWall; do
-  run_return_leg_tortuosity_bins \
-    "quartiles" \
-    "" \
-    minEpSb5Filt \
-    "$wall_tag" \
-    mean \
-    1.0 \
-    per_fly_quartile
-done
+# for wall_tag in wall noWall postWall; do
+#   run_return_leg_tortuosity_bins \
+#     "quartiles" \
+#     "" \
+#     minEpSb5Filt \
+#     "$wall_tag" \
+#     mean \
+#     1.0 \
+#     per_fly_quartile
+# done

--- a/scripts/run_analysis_matrix.sh
+++ b/scripts/run_analysis_matrix.sh
@@ -226,6 +226,12 @@ run_return_leg_tortuosity_bins() {
     noWall)
       wall_flags=(--return-leg-tortuosity-excursion-bin-exclude-wall-contact)
       ;;
+    postWall)
+      wall_flags=(
+        --return-leg-tortuosity-excursion-bin-return-start-mode
+        post_last_wall_max
+      )
+      ;;
     *)
       echo "Unknown wall tag: $wall_tag" >&2
       exit 1
@@ -326,10 +332,13 @@ run_return_leg_tortuosity_bins() {
 # ---------------------------------------------------------------------
 # Top-25% mean return-leg tortuosity by max-distance bin
 # radial config: 3-5, 8-10, 13-15 mm from reward-circle center
+# wall: standard full-episode maximum return-leg start
+# noWall: discard episodes containing wall contact
+# postWall: keep episodes and use the maximum after final wall contact
 # only 5-episode minimum + T2 SB5 presence filter
 # ---------------------------------------------------------------------
 
-for wall_tag in wall noWall; do
+for wall_tag in wall noWall postWall; do
   run_return_leg_tortuosity_bins \
     "3-5_8-10_13-15" \
     "3:5,8:10,13:15" \

--- a/scripts/run_analysis_matrix.sh
+++ b/scripts/run_analysis_matrix.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 DATE_TAG="2026-06-12"
 PRINT_ONLY="${PRINT_ONLY:-0}"
+RETURN_LEG_TORTUOSITY_EXAMPLES="${RETURN_LEG_TORTUOSITY_EXAMPLES:-0}"
+RETURN_LEG_TORTUOSITY_EXAMPLES_PER_BIN="${RETURN_LEG_TORTUOSITY_EXAMPLES_PER_BIN:-6}"
+RETURN_LEG_TORTUOSITY_EXAMPLES_MAX_PER_FLY="${RETURN_LEG_TORTUOSITY_EXAMPLES_MAX_PER_FLY:-0}"
 
 GROUP_VARS=(INTACT_CTRL INTACT_PFND AR_CTRL)
 GROUP_SLUGS=(intact_ctrlKir intact_pfnKir ar_ctrlKir)
@@ -245,6 +248,15 @@ run_return_leg_tortuosity_bins() {
     local group_slug="${GROUP_SLUGS[$i]}"
     local group_label="${GROUP_LABELS[$i]}"
     local bundle="exports/returnLegTortuosityBins_${summary_tag}_${filter_tag}_${wall_tag}_${group_slug}_flatLgc_T2_b${bins_label}_${DATE_TAG}.npz"
+    local example_flags=()
+    if [[ "$RETURN_LEG_TORTUOSITY_EXAMPLES" == "1" ]]; then
+      local example_dir="exports/returnLegTortuosityExamples_${summary_tag}_${filter_tag}_${wall_tag}_${group_slug}_flatLgc_T2_b${bins_label}_${DATE_TAG}"
+      example_flags=(
+        --export-return-leg-tortuosity-excursion-bin-examples "$example_dir"
+        --return-leg-tortuosity-excursion-bin-examples-per-bin "$RETURN_LEG_TORTUOSITY_EXAMPLES_PER_BIN"
+        --return-leg-tortuosity-excursion-bin-examples-max-per-fly "$RETURN_LEG_TORTUOSITY_EXAMPLES_MAX_PER_FLY"
+      )
+    fi
 
     bundles+=("$bundle")
     run_cmd \
@@ -262,7 +274,8 @@ run_return_leg_tortuosity_bins() {
       --sli-select-skip-first-sync-buckets 1 \
       --export-group-label "$group_label" \
       "${filter_flags[@]}" \
-      "${wall_flags[@]}"
+      "${wall_flags[@]}" \
+      "${example_flags[@]}"
   done
 
   local bundle_csv
@@ -336,6 +349,7 @@ run_return_leg_tortuosity_bins() {
 # noWall: discard episodes containing wall contact
 # postWall: keep episodes and use the maximum after final wall contact
 # only 5-episode minimum + T2 SB5 presence filter
+# Set RETURN_LEG_TORTUOSITY_EXAMPLES=1 to export ranked trajectory galleries.
 # ---------------------------------------------------------------------
 
 for wall_tag in wall noWall postWall; do

--- a/scripts/run_analysis_matrix.sh
+++ b/scripts/run_analysis_matrix.sh
@@ -190,16 +190,91 @@ run_turnback_pairs() {
     --stats
 }
 
+run_return_leg_tortuosity_bins() {
+  local bins_label="$1"
+  local bins_arg="$2"
+  local filter_tag="$3"
+  local wall_tag="$4"
+
+  local filter_flags=()
+  case "$filter_tag" in
+    noFilt)
+      filter_flags=(--min-between-reward-trajectories 0)
+      ;;
+    minEpFilt)
+      filter_flags=()
+      ;;
+    minEpSb5Filt)
+      filter_flags=(--require-exp-target-sync-bucket)
+      ;;
+    minEpPiFilt)
+      filter_flags=(--require-exp-pi-threshold-bucket)
+      ;;
+    *)
+      echo "Unknown return-leg tortuosity filter tag: $filter_tag" >&2
+      exit 1
+      ;;
+  esac
+
+  local wall_flags=()
+  case "$wall_tag" in
+    wall)
+      wall_flags=()
+      ;;
+    noWall)
+      wall_flags=(--return-leg-tortuosity-excursion-bin-exclude-wall-contact)
+      ;;
+    *)
+      echo "Unknown wall tag: $wall_tag" >&2
+      exit 1
+      ;;
+  esac
+
+  local bundles=()
+  for i in "${!GROUP_VARS[@]}"; do
+    local var_name="${GROUP_VARS[$i]}"
+    local dataset="${!var_name}"
+    local group_slug="${GROUP_SLUGS[$i]}"
+    local group_label="${GROUP_LABELS[$i]}"
+    local bundle="exports/returnLegTortuosityBins_${filter_tag}_${wall_tag}_${group_slug}_flatLgc_T2_b${bins_label}_${DATE_TAG}.npz"
+
+    bundles+=("$bundle")
+    run_cmd \
+      python analyze.py \
+      -v "$dataset" \
+      -f 0-1 \
+      --rCC 15 \
+      --export-return-leg-tortuosity-excursion-bin-sli-bundle "$bundle" \
+      --return-leg-tortuosity-excursion-bin-pairs-mm "$bins_arg" \
+      --return-leg-tortuosity-excursion-bin-trainings 2 \
+      --return-leg-tortuosity-excursion-bin-skip-first-sync-buckets 1 \
+      --best-worst-trn 2 \
+      --sli-use-training-mean \
+      --sli-select-skip-first-sync-buckets 1 \
+      --export-group-label "$group_label" \
+      "${filter_flags[@]}" \
+      "${wall_flags[@]}"
+  done
+
+  local bundle_csv
+  bundle_csv="$(join_by_comma "${bundles[@]}")"
+  run_cmd \
+    python -m scripts.plot_return_leg_tortuosity_excursion_bin_sli_bundles \
+    --bundles "$bundle_csv" \
+    --out "exports/returnLegTortuosityBins_${filter_tag}_${wall_tag}_flatLgc_T2_b${bins_label}_${DATE_TAG}.png" \
+    --stats
+}
+
 # ---------------------------------------------------------------------
 # Fraction of trajectories within radius, historical return-prob name
 # radial config: 6 / 11 / 16 mm
 # ---------------------------------------------------------------------
 
-for filter_tag in noFilt minEpFilt minEpSb5Filt minEpPiFilt; do
-  for wall_tag in wall noWall; do
-    run_return_prob "$filter_tag" "$wall_tag"
-  done
-done
+# for filter_tag in noFilt minEpFilt minEpSb5Filt minEpPiFilt; do
+#   for wall_tag in wall noWall; do
+#     run_return_prob "$filter_tag" "$wall_tag"
+#   done
+# done
 
 # ---------------------------------------------------------------------
 # Turnback ratio
@@ -207,15 +282,15 @@ done
 # full filter x wall-contact matrix
 # ---------------------------------------------------------------------
 
-for filter_tag in noFilt minEpFilt minEpSb5Filt minEpPiFilt; do
-  for wall_tag in wall noWall; do
-    run_turnback_pairs \
-      "3-5_8-10_13-15" \
-      "3:5,8:10,13:15" \
-      "$filter_tag" \
-      "$wall_tag"
-  done
-done
+# for filter_tag in noFilt minEpFilt minEpSb5Filt minEpPiFilt; do
+#   for wall_tag in wall noWall; do
+#     run_turnback_pairs \
+#       "3-5_8-10_13-15" \
+#       "3:5,8:10,13:15" \
+#       "$filter_tag" \
+#       "$wall_tag"
+#   done
+# done
 
 # ---------------------------------------------------------------------
 # Turnback ratio
@@ -223,13 +298,13 @@ done
 # only 5-episode minimum + T2 SB5 presence filter
 # ---------------------------------------------------------------------
 
-for wall_tag in wall noWall; do
-  run_turnback_pairs \
-    "4-6_9-11_14-16" \
-    "4:6,9:11,14:16" \
-    minEpSb5Filt \
-    "$wall_tag"
-done
+# for wall_tag in wall noWall; do
+#   run_turnback_pairs \
+#     "4-6_9-11_14-16" \
+#     "4:6,9:11,14:16" \
+#     minEpSb5Filt \
+#     "$wall_tag"
+# done
 
 # ---------------------------------------------------------------------
 # Turnback ratio
@@ -237,10 +312,24 @@ done
 # only 5-episode minimum + T2 SB5 presence filter
 # ---------------------------------------------------------------------
 
+# for wall_tag in wall noWall; do
+#   run_turnback_pairs \
+#     "2-5_8-11_14-17" \
+#     "2:5,8:11,14:17" \
+#     minEpSb5Filt \
+#     "$wall_tag"
+# done
+
+# ---------------------------------------------------------------------
+# Return-leg tortuosity by max-distance bin
+# radial config: 3-5, 8-10, 13-15 mm beyond reward-circle radius
+# only 5-episode minimum + T2 SB5 presence filter
+# ---------------------------------------------------------------------
+
 for wall_tag in wall noWall; do
-  run_turnback_pairs \
-    "2-5_8-11_14-17" \
-    "2:5,8:11,14:17" \
+  run_return_leg_tortuosity_bins \
+    "3-5_8-10_13-15" \
+    "3:5,8:10,13:15" \
     minEpSb5Filt \
     "$wall_tag"
 done

--- a/src/analysis/sli_bundle_utils.py
+++ b/src/analysis/sli_bundle_utils.py
@@ -1197,10 +1197,37 @@ def validate_return_leg_tortuosity_excursion_bin_bundle(
             )
         )
     )
-    if exclude_wall and return_start_mode == "post_last_wall_max":
+    exclude_wall_frames = bool(
+        as_scalar(
+            bundle.get(
+                "return_leg_tortuosity_excursion_bin_exclude_wall_contact_frames",
+                False,
+            )
+        )
+    )
+    if sum(
+        (
+            exclude_wall,
+            exclude_wall_frames,
+            return_start_mode == "post_last_wall_max",
+        )
+    ) > 1:
         raise ValueError(
-            f"Bundle {where} combines whole-episode wall exclusion with "
-            "post-last-wall return-leg starts"
+            f"Bundle {where} combines mutually exclusive return-leg wall "
+            "treatments"
+        )
+    metric_mode = str(
+        as_scalar(
+            bundle.get(
+                "return_leg_tortuosity_excursion_bin_metric_mode",
+                "path_over_max_radius",
+            )
+        )
+    )
+    if exclude_wall_frames and metric_mode != "path_over_max_radius":
+        raise ValueError(
+            f"Bundle {where} combines frame-level wall exclusion with "
+            f"unsupported metric mode {metric_mode!r}"
         )
 
     selected_keys = (

--- a/src/analysis/sli_bundle_utils.py
+++ b/src/analysis/sli_bundle_utils.py
@@ -1120,6 +1120,54 @@ def validate_return_leg_tortuosity_excursion_bin_bundle(
         n_videos=n_videos,
         n_bins=n_bins,
     )
+    top_fraction = float(
+        as_scalar(bundle.get("return_leg_tortuosity_excursion_bin_top_fraction", 1.0))
+    )
+    if not np.isfinite(top_fraction) or not (0.0 < top_fraction <= 1.0):
+        raise ValueError(
+            f"Bundle {where} has invalid return-leg tortuosity top fraction "
+            f"{top_fraction}"
+        )
+
+    selected_keys = (
+        "return_leg_tortuosity_excursion_bin_selectedN_exp",
+        "return_leg_tortuosity_excursion_bin_selectedN_ctrl",
+    )
+    if any(key in bundle for key in selected_keys):
+        missing_selected = [key for key in selected_keys if key not in bundle]
+        if missing_selected:
+            raise ValueError(
+                f"Bundle {where} has incomplete selected-count keys: "
+                f"{missing_selected}"
+            )
+        selected_exp = _validate_return_prob_count_array(
+            bundle,
+            selected_keys[0],
+            where=where,
+            n_videos=n_videos,
+            n_bins=n_bins,
+        )
+        selected_ctrl = _validate_return_prob_count_array(
+            bundle,
+            selected_keys[1],
+            where=where,
+            n_videos=n_videos,
+            n_bins=n_bins,
+        )
+        for key, selected, raw in (
+            (selected_keys[0], selected_exp, counts_exp),
+            (selected_keys[1], selected_ctrl, counts_ctrl),
+        ):
+            expected = np.zeros_like(raw)
+            has_values = raw > 0
+            expected[has_values] = np.ceil(
+                top_fraction * raw[has_values]
+            ).astype(int)
+            if np.any(selected != expected):
+                raise ValueError(
+                    f"Bundle {where} has {key} inconsistent with raw counts and "
+                    f"top fraction {top_fraction:g}"
+                )
 
     min_segments = int(
         as_scalar(bundle.get("btw_rwd_sync_bucket_min_trajectories", 1))

--- a/src/analysis/sli_bundle_utils.py
+++ b/src/analysis/sli_bundle_utils.py
@@ -1039,6 +1039,20 @@ def validate_return_leg_tortuosity_excursion_bin_bundle(
     if edges.ndim != 1 or edges.size < 2 or np.any(~np.isfinite(edges)):
         raise ValueError(f"Bundle {where} has invalid resolved bin edges")
 
+    binning_mode = str(
+        as_scalar(
+            bundle.get(
+                "return_leg_tortuosity_excursion_bin_binning_mode",
+                "absolute_distance",
+            )
+        )
+    )
+    if binning_mode not in {"absolute_distance", "per_fly_quartile"}:
+        raise ValueError(
+            f"Bundle {where} has invalid return-leg tortuosity binning mode "
+            f"{binning_mode!r}"
+        )
+
     pair_mode = bool(
         as_scalar(bundle.get("return_leg_tortuosity_excursion_bin_pair_mode", False))
     )
@@ -1050,7 +1064,29 @@ def validate_return_leg_tortuosity_excursion_bin_bundle(
         bundle.get("return_leg_tortuosity_excursion_bin_pair_upper_mm", []),
         dtype=float,
     ).reshape(-1)
-    if pair_mode:
+    if binning_mode == "per_fly_quartile":
+        if pair_mode:
+            raise ValueError(
+                f"Bundle {where} combines per-fly quartiles with pair bins"
+            )
+        percentile_edges = np.asarray(
+            bundle.get(
+                "return_leg_tortuosity_excursion_bin_percentile_edges", []
+            ),
+            dtype=float,
+        ).reshape(-1)
+        expected_percentiles = np.asarray([0.0, 25.0, 50.0, 75.0, 100.0])
+        if (
+            percentile_edges.shape != expected_percentiles.shape
+            or not np.allclose(percentile_edges, expected_percentiles)
+            or edges.shape != expected_percentiles.shape
+            or not np.allclose(edges, expected_percentiles)
+        ):
+            raise ValueError(
+                f"Bundle {where} has invalid per-fly quartile percentile edges"
+            )
+        n_bins = 4
+    elif pair_mode:
         if pair_lo.size == 0 or pair_lo.shape != pair_hi.shape:
             raise ValueError(f"Bundle {where} has invalid pair-bin metadata")
         if np.any(~np.isfinite(pair_lo)) or np.any(~np.isfinite(pair_hi)):
@@ -1128,6 +1164,10 @@ def validate_return_leg_tortuosity_excursion_bin_bundle(
             f"Bundle {where} has invalid return-leg tortuosity top fraction "
             f"{top_fraction}"
         )
+    if binning_mode == "per_fly_quartile" and top_fraction != 1.0:
+        raise ValueError(
+            f"Bundle {where} applies top-fraction aggregation to per-fly quartiles"
+        )
     return_start_mode = str(
         as_scalar(
             bundle.get(
@@ -1193,6 +1233,75 @@ def validate_return_leg_tortuosity_excursion_bin_bundle(
                 raise ValueError(
                     f"Bundle {where} has {key} inconsistent with raw counts and "
                     f"top fraction {top_fraction:g}"
+                )
+
+    if binning_mode == "per_fly_quartile":
+        for stat in ("min", "max", "mean", "median"):
+            for role, counts in (("exp", counts_exp), ("ctrl", counts_ctrl)):
+                key = (
+                    "return_leg_tortuosity_excursion_bin_distance_"
+                    f"{stat}_mm_{role}"
+                )
+                if key not in bundle:
+                    raise ValueError(
+                        f"Bundle {where} is missing quartile distance metadata {key}"
+                    )
+                values = np.asarray(bundle[key], dtype=float)
+                if values.shape != (n_videos, n_bins):
+                    raise ValueError(
+                        f"Bundle {where} has {key} shape {values.shape}; "
+                        f"expected {(n_videos, n_bins)}"
+                    )
+                if np.any((counts > 0) & ~np.isfinite(values)):
+                    raise ValueError(
+                        f"Bundle {where} has non-finite {key} for non-empty quartiles"
+                    )
+                if np.any((counts == 0) & np.isfinite(values)):
+                    raise ValueError(
+                        f"Bundle {where} has finite {key} for empty quartiles"
+                    )
+        for role in ("exp", "ctrl"):
+            minimum = np.asarray(
+                bundle[
+                    "return_leg_tortuosity_excursion_bin_distance_min_mm_"
+                    f"{role}"
+                ],
+                dtype=float,
+            )
+            maximum = np.asarray(
+                bundle[
+                    "return_leg_tortuosity_excursion_bin_distance_max_mm_"
+                    f"{role}"
+                ],
+                dtype=float,
+            )
+            mean = np.asarray(
+                bundle[
+                    "return_leg_tortuosity_excursion_bin_distance_mean_mm_"
+                    f"{role}"
+                ],
+                dtype=float,
+            )
+            median = np.asarray(
+                bundle[
+                    "return_leg_tortuosity_excursion_bin_distance_median_mm_"
+                    f"{role}"
+                ],
+                dtype=float,
+            )
+            finite = np.isfinite(minimum)
+            if np.any(
+                finite
+                & (
+                    (minimum > mean)
+                    | (mean > maximum)
+                    | (minimum > median)
+                    | (median > maximum)
+                )
+            ):
+                raise ValueError(
+                    f"Bundle {where} has inconsistent quartile distance "
+                    f"summaries for {role}"
                 )
 
     min_segments = int(

--- a/src/analysis/sli_bundle_utils.py
+++ b/src/analysis/sli_bundle_utils.py
@@ -31,6 +31,7 @@ BUNDLE_ARRAY_PREFIXES = (
     "fraction_within_radius_",
     "return_prob_",
     "return_leg_",
+    "post_wall_",
     "sli_",
 )
 
@@ -130,6 +131,13 @@ RETURN_LEG_TORTUOSITY_EXCURSION_BIN_KEYS = (
     "return_leg_tortuosity_excursion_binN_exp",
     "return_leg_tortuosity_excursion_binN_ctrl",
     "return_leg_tortuosity_excursion_bin_edges_mm",
+)
+
+POST_WALL_DEPARTURE_TORTUOSITY_KEYS = (
+    "post_wall_departure_tortuosity_exp",
+    "post_wall_departure_tortuosity_ctrl",
+    "post_wall_departure_tortuosityN_exp",
+    "post_wall_departure_tortuosityN_ctrl",
 )
 
 COMMAG_KEYS = (
@@ -1334,6 +1342,92 @@ def validate_return_leg_tortuosity_excursion_bin_bundle(
             raise ValueError(f"Bundle {where} has negative {key}")
 
 
+def validate_post_wall_departure_tortuosity_bundle(
+    bundle: dict, *, path: str | None = None
+) -> None:
+    where = _bundle_label(bundle, path)
+    missing = [k for k in POST_WALL_DEPARTURE_TORTUOSITY_KEYS if k not in bundle]
+    if missing:
+        raise ValueError(
+            f"Bundle {where} is missing post-wall departure tortuosity keys: "
+            f"{missing}"
+        )
+
+    sli = np.asarray(bundle["sli"], dtype=float)
+    if sli.ndim != 1:
+        raise ValueError(f"Bundle {where} has non-1D sli shape {sli.shape}")
+    n_videos = int(sli.shape[0])
+    values_exp = _validate_return_prob_metric_array(
+        bundle,
+        "post_wall_departure_tortuosity_exp",
+        where=where,
+        n_videos=n_videos,
+        n_bins=1,
+    )
+    values_ctrl = _validate_return_prob_metric_array(
+        bundle,
+        "post_wall_departure_tortuosity_ctrl",
+        where=where,
+        n_videos=n_videos,
+        n_bins=1,
+    )
+    counts_exp = _validate_return_prob_count_array(
+        bundle,
+        "post_wall_departure_tortuosityN_exp",
+        where=where,
+        n_videos=n_videos,
+        n_bins=1,
+    )
+    counts_ctrl = _validate_return_prob_count_array(
+        bundle,
+        "post_wall_departure_tortuosityN_ctrl",
+        where=where,
+        n_videos=n_videos,
+        n_bins=1,
+    )
+    min_segments = int(
+        as_scalar(bundle.get("btw_rwd_sync_bucket_min_trajectories", 1))
+    )
+    if min_segments < 0:
+        raise ValueError(
+            f"Bundle {where} has negative btw_rwd_sync_bucket_min_trajectories"
+        )
+    threshold = max(1, min_segments)
+    for key, values, counts in (
+        ("post_wall_departure_tortuosity_exp", values_exp, counts_exp),
+        ("post_wall_departure_tortuosity_ctrl", values_ctrl, counts_ctrl),
+    ):
+        finite = np.isfinite(values)
+        if np.any(values[finite] < 0):
+            raise ValueError(f"Bundle {where} has negative values in {key}")
+        if np.any(finite & (counts < threshold)):
+            raise ValueError(
+                f"Bundle {where} has finite {key} where count is below "
+                f"{threshold}"
+            )
+
+    for key in (
+        "post_wall_departure_tortuosity_skip_first_sync_buckets",
+        "post_wall_departure_tortuosity_keep_first_sync_buckets",
+        "post_wall_departure_tortuosity_min_walk_frames",
+    ):
+        if key in bundle and int(as_scalar(bundle[key])) < 0:
+            raise ValueError(f"Bundle {where} has negative {key}")
+    min_direct_key = "post_wall_departure_tortuosity_min_direct_distance_mm"
+    if min_direct_key in bundle:
+        min_direct = float(as_scalar(bundle[min_direct_key]))
+        if not np.isfinite(min_direct) or min_direct < 0:
+            raise ValueError(f"Bundle {where} has invalid {min_direct_key}")
+    summary_key = "post_wall_departure_tortuosity_window_summary"
+    if summary_key in bundle:
+        summary = as_str_array(bundle[summary_key])
+        if summary.shape[0] != n_videos:
+            raise ValueError(
+                f"Bundle {where} has {summary.shape[0]} window summaries for "
+                f"{n_videos} videos"
+            )
+
+
 def validate_turnback_excursion_bin_bundle(
     bundle: dict, *, path: str | None = None
 ) -> None:
@@ -1610,6 +1704,8 @@ def normalize_sli_bundle(bundle: dict, *, path: str | None = None) -> dict:
         validate_between_reward_return_leg_dist_bundle(out, path=path)
     if any(k in out for k in RETURN_LEG_TORTUOSITY_EXCURSION_BIN_KEYS):
         validate_return_leg_tortuosity_excursion_bin_bundle(out, path=path)
+    if any(k in out for k in POST_WALL_DEPARTURE_TORTUOSITY_KEYS):
+        validate_post_wall_departure_tortuosity_bundle(out, path=path)
     if any(k in out for k in COMMAG_KEYS):
         validate_commag_bundle(out, path=path)
     if any(k in out for k in TURNBACK_RATIO_PRIMARY_KEYS):

--- a/src/analysis/sli_bundle_utils.py
+++ b/src/analysis/sli_bundle_utils.py
@@ -30,6 +30,7 @@ BUNDLE_ARRAY_PREFIXES = (
     "speed_",
     "fraction_within_radius_",
     "return_prob_",
+    "return_leg_",
     "sli_",
 )
 
@@ -121,6 +122,14 @@ BETWEEN_REWARD_RETURN_LEG_DIST_KEYS = (
     "between_reward_return_leg_dist_ctrl",
     "between_reward_return_leg_distN_exp",
     "between_reward_return_leg_distN_ctrl",
+)
+
+RETURN_LEG_TORTUOSITY_EXCURSION_BIN_KEYS = (
+    "return_leg_tortuosity_excursion_bin_exp",
+    "return_leg_tortuosity_excursion_bin_ctrl",
+    "return_leg_tortuosity_excursion_binN_exp",
+    "return_leg_tortuosity_excursion_binN_ctrl",
+    "return_leg_tortuosity_excursion_bin_edges_mm",
 )
 
 COMMAG_KEYS = (
@@ -1008,6 +1017,140 @@ def validate_return_prob_excursion_bin_bundle(
     validate_fraction_within_radius_excursion_bin_bundle(bundle, path=path)
 
 
+def validate_return_leg_tortuosity_excursion_bin_bundle(
+    bundle: dict, *, path: str | None = None
+) -> None:
+    where = _bundle_label(bundle, path)
+    missing = [k for k in RETURN_LEG_TORTUOSITY_EXCURSION_BIN_KEYS if k not in bundle]
+    if missing:
+        raise ValueError(
+            f"Bundle {where} is missing return-leg tortuosity excursion-bin keys: "
+            f"{missing}"
+        )
+
+    sli = np.asarray(bundle["sli"], dtype=float)
+    if sli.ndim != 1:
+        raise ValueError(f"Bundle {where} has non-1D sli shape {sli.shape}")
+    n_videos = int(sli.shape[0])
+
+    edges = np.asarray(
+        bundle["return_leg_tortuosity_excursion_bin_edges_mm"], dtype=float
+    )
+    if edges.ndim != 1 or edges.size < 2 or np.any(~np.isfinite(edges)):
+        raise ValueError(f"Bundle {where} has invalid resolved bin edges")
+
+    pair_mode = bool(
+        as_scalar(bundle.get("return_leg_tortuosity_excursion_bin_pair_mode", False))
+    )
+    pair_lo = np.asarray(
+        bundle.get("return_leg_tortuosity_excursion_bin_pair_lower_mm", []),
+        dtype=float,
+    ).reshape(-1)
+    pair_hi = np.asarray(
+        bundle.get("return_leg_tortuosity_excursion_bin_pair_upper_mm", []),
+        dtype=float,
+    ).reshape(-1)
+    if pair_mode:
+        if pair_lo.size == 0 or pair_lo.shape != pair_hi.shape:
+            raise ValueError(f"Bundle {where} has invalid pair-bin metadata")
+        if np.any(~np.isfinite(pair_lo)) or np.any(~np.isfinite(pair_hi)):
+            raise ValueError(f"Bundle {where} has non-finite pair-bin metadata")
+        if np.any(pair_lo < 0) or np.any(pair_hi <= pair_lo):
+            raise ValueError(f"Bundle {where} has invalid pair-bin bounds")
+        n_bins = int(pair_lo.size)
+    else:
+        if np.any(np.diff(edges) <= 0):
+            raise ValueError(f"Bundle {where} has non-increasing bin edges")
+        n_bins = int(edges.size - 1)
+
+    requested = np.asarray(
+        bundle.get(
+            "return_leg_tortuosity_excursion_bin_requested_edges_mm", edges
+        ),
+        dtype=float,
+    )
+    expected_requested = 2 * n_bins if pair_mode else edges.size
+    if requested.ndim != 1 or requested.size != expected_requested:
+        raise ValueError(
+            f"Bundle {where} has requested-edge shape {requested.shape}; "
+            f"expected {(expected_requested,)}"
+        )
+    if pair_mode:
+        if np.any(~np.isfinite(requested)):
+            raise ValueError(f"Bundle {where} has non-finite requested pair bounds")
+    else:
+        if np.any(~np.isfinite(requested[:-1])) or np.any(np.diff(requested) <= 0):
+            raise ValueError(f"Bundle {where} has invalid requested bin edges")
+
+    if "return_leg_tortuosity_excursion_bin_window_summary" in bundle:
+        summary = as_str_array(
+            bundle["return_leg_tortuosity_excursion_bin_window_summary"]
+        )
+        if summary.shape[0] != n_videos:
+            raise ValueError(
+                f"Bundle {where} has {summary.shape[0]} window summaries for "
+                f"{n_videos} videos"
+            )
+
+    values_exp = _validate_return_prob_metric_array(
+        bundle,
+        "return_leg_tortuosity_excursion_bin_exp",
+        where=where,
+        n_videos=n_videos,
+        n_bins=n_bins,
+    )
+    values_ctrl = _validate_return_prob_metric_array(
+        bundle,
+        "return_leg_tortuosity_excursion_bin_ctrl",
+        where=where,
+        n_videos=n_videos,
+        n_bins=n_bins,
+    )
+    counts_exp = _validate_return_prob_count_array(
+        bundle,
+        "return_leg_tortuosity_excursion_binN_exp",
+        where=where,
+        n_videos=n_videos,
+        n_bins=n_bins,
+    )
+    counts_ctrl = _validate_return_prob_count_array(
+        bundle,
+        "return_leg_tortuosity_excursion_binN_ctrl",
+        where=where,
+        n_videos=n_videos,
+        n_bins=n_bins,
+    )
+
+    min_segments = int(
+        as_scalar(bundle.get("btw_rwd_sync_bucket_min_trajectories", 1))
+    )
+    if min_segments < 0:
+        raise ValueError(
+            f"Bundle {where} has negative btw_rwd_sync_bucket_min_trajectories"
+        )
+    sufficient_count = max(1, min_segments)
+    for key, values, counts in (
+        ("return_leg_tortuosity_excursion_bin_exp", values_exp, counts_exp),
+        ("return_leg_tortuosity_excursion_bin_ctrl", values_ctrl, counts_ctrl),
+    ):
+        finite = np.isfinite(values)
+        if np.any(values[finite] < 0):
+            raise ValueError(f"Bundle {where} has negative values in {key}")
+        if np.any(finite & (counts < sufficient_count)):
+            raise ValueError(
+                f"Bundle {where} has finite {key} where count is below "
+                f"{sufficient_count}"
+            )
+
+    for key in (
+        "return_leg_tortuosity_excursion_bin_skip_first_sync_buckets",
+        "return_leg_tortuosity_excursion_bin_keep_first_sync_buckets",
+        "return_leg_tortuosity_excursion_bin_min_walk_frames",
+    ):
+        if key in bundle and int(as_scalar(bundle[key])) < 0:
+            raise ValueError(f"Bundle {where} has negative {key}")
+
+
 def validate_turnback_excursion_bin_bundle(
     bundle: dict, *, path: str | None = None
 ) -> None:
@@ -1282,6 +1425,8 @@ def normalize_sli_bundle(bundle: dict, *, path: str | None = None) -> dict:
         validate_between_reward_maxdist_bundle(out, path=path)
     if any(k in out for k in BETWEEN_REWARD_RETURN_LEG_DIST_KEYS):
         validate_between_reward_return_leg_dist_bundle(out, path=path)
+    if any(k in out for k in RETURN_LEG_TORTUOSITY_EXCURSION_BIN_KEYS):
+        validate_return_leg_tortuosity_excursion_bin_bundle(out, path=path)
     if any(k in out for k in COMMAG_KEYS):
         validate_commag_bundle(out, path=path)
     if any(k in out for k in TURNBACK_RATIO_PRIMARY_KEYS):

--- a/src/analysis/sli_bundle_utils.py
+++ b/src/analysis/sli_bundle_utils.py
@@ -1128,6 +1128,32 @@ def validate_return_leg_tortuosity_excursion_bin_bundle(
             f"Bundle {where} has invalid return-leg tortuosity top fraction "
             f"{top_fraction}"
         )
+    return_start_mode = str(
+        as_scalar(
+            bundle.get(
+                "return_leg_tortuosity_excursion_bin_return_start_mode",
+                "global_max",
+            )
+        )
+    )
+    if return_start_mode not in {"global_max", "post_last_wall_max"}:
+        raise ValueError(
+            f"Bundle {where} has invalid return-leg start mode "
+            f"{return_start_mode!r}"
+        )
+    exclude_wall = bool(
+        as_scalar(
+            bundle.get(
+                "return_leg_tortuosity_excursion_bin_exclude_wall_contact",
+                False,
+            )
+        )
+    )
+    if exclude_wall and return_start_mode == "post_last_wall_max":
+        raise ValueError(
+            f"Bundle {where} combines whole-episode wall exclusion with "
+            "post-last-wall return-leg starts"
+        )
 
     selected_keys = (
         "return_leg_tortuosity_excursion_bin_selectedN_exp",

--- a/src/analysis/video_analysis.py
+++ b/src/analysis/video_analysis.py
@@ -641,10 +641,17 @@ class VideoAnalysis:
                 )
             )
             or (
-                getattr(
-                    self.opts,
-                    "export_return_leg_tortuosity_excursion_bin_sli_bundle",
-                    None,
+                (
+                    getattr(
+                        self.opts,
+                        "export_return_leg_tortuosity_excursion_bin_sli_bundle",
+                        None,
+                    )
+                    or getattr(
+                        self.opts,
+                        "export_return_leg_tortuosity_excursion_bin_examples",
+                        None,
+                    )
                 )
                 and (
                     getattr(

--- a/src/analysis/video_analysis.py
+++ b/src/analysis/video_analysis.py
@@ -641,6 +641,18 @@ class VideoAnalysis:
                 )
             )
             or (
+                getattr(
+                    self.opts,
+                    "export_return_leg_tortuosity_excursion_bin_sli_bundle",
+                    None,
+                )
+                and getattr(
+                    self.opts,
+                    "return_leg_tortuosity_excursion_bin_exclude_wall_contact",
+                    False,
+                )
+            )
+            or (
                 getattr(self.opts, "export_turnback_excursion_bin_sli_bundle", None)
                 and getattr(
                     self.opts,

--- a/src/analysis/video_analysis.py
+++ b/src/analysis/video_analysis.py
@@ -661,6 +661,11 @@ class VideoAnalysis:
                     )
                     or getattr(
                         self.opts,
+                        "return_leg_tortuosity_excursion_bin_exclude_wall_contact_frames",
+                        False,
+                    )
+                    or getattr(
+                        self.opts,
                         "return_leg_tortuosity_excursion_bin_return_start_mode",
                         "global_max",
                     )

--- a/src/analysis/video_analysis.py
+++ b/src/analysis/video_analysis.py
@@ -646,10 +646,18 @@ class VideoAnalysis:
                     "export_return_leg_tortuosity_excursion_bin_sli_bundle",
                     None,
                 )
-                and getattr(
-                    self.opts,
-                    "return_leg_tortuosity_excursion_bin_exclude_wall_contact",
-                    False,
+                and (
+                    getattr(
+                        self.opts,
+                        "return_leg_tortuosity_excursion_bin_exclude_wall_contact",
+                        False,
+                    )
+                    or getattr(
+                        self.opts,
+                        "return_leg_tortuosity_excursion_bin_return_start_mode",
+                        "global_max",
+                    )
+                    == "post_last_wall_max"
                 )
             )
             or (

--- a/src/analysis/video_analysis.py
+++ b/src/analysis/video_analysis.py
@@ -677,6 +677,19 @@ class VideoAnalysis:
             )
         )
 
+        keep_wall_regions_for_post_wall_departure_tortuosity = bool(
+            getattr(
+                self.opts,
+                "export_post_wall_departure_tortuosity_sli_bundle",
+                None,
+            )
+            or getattr(
+                self.opts,
+                "export_post_wall_departure_tortuosity_examples",
+                None,
+            )
+        )
+
         keep_wall_regions_for_return_prob_outer_radius = bool(
             getattr(self.opts, "export_return_prob_outer_radius_sli_bundle", None)
             and getattr(
@@ -705,6 +718,7 @@ class VideoAnalysis:
             or keep_wall_regions_for_rrd
             or keep_wall_regions_for_between_reward_maxdist
             or keep_wall_regions_for_excursion_bin_exports
+            or keep_wall_regions_for_post_wall_departure_tortuosity
             or keep_wall_regions_for_return_prob_outer_radius
             or keep_wall_regions_for_wall_contacts_per_reward_interval_total
         )

--- a/src/exporting/post_wall_departure_tortuosity_examples.py
+++ b/src/exporting/post_wall_departure_tortuosity_examples.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import csv
+import os
+
+import numpy as np
+
+from src.analysis.between_reward_filters import (
+    min_between_reward_sync_bucket_trajectories,
+)
+from src.analysis.sync_bucket_presence_filters import (
+    exp_target_sync_bucket_eligibility_mask,
+)
+from src.exporting.com_sli_bundle import _safe_group_label
+from src.exporting.post_wall_departure_tortuosity_sli_bundle import (
+    collect_post_wall_departure_tortuosity,
+)
+from src.plotting.event_chain_plotter import EventChainPlotter
+
+
+MANIFEST_FIELDS = [
+    "group",
+    "role",
+    "rank",
+    "eligible_episodes",
+    "video",
+    "trajectory_index",
+    "training",
+    "segment_start",
+    "segment_stop",
+    "last_wall_contact_frame",
+    "departure_frame",
+    "path_mm",
+    "direct_distance_to_reward_circle_mm",
+    "tortuosity",
+    "image",
+]
+
+
+def export_post_wall_departure_tortuosity_examples(vas, opts, gls, out_dir):
+    vas_ok = [va for va in vas if not getattr(va, "_skipped", False)]
+    if not vas_ok:
+        print("[post-wall-departure-tortuosity-examples] no non-skipped videos")
+        return
+    records, details, _windows = collect_post_wall_departure_tortuosity(
+        vas_ok, opts
+    )
+    threshold = max(1, min_between_reward_sync_bucket_trajectories(opts))
+    target_eligible = exp_target_sync_bucket_eligibility_mask(vas_ok, opts)
+    role_mode = str(
+        getattr(opts, "post_wall_departure_tortuosity_examples_role", "exp")
+        or "exp"
+    ).lower()
+    allowed_roles = {0} if role_mode == "exp" else {1}
+    if role_mode == "both":
+        allowed_roles = {0, 1}
+    eligible_units = {
+        (vi, role_idx)
+        for vi, video_roles in enumerate(records)
+        for role_idx, values in enumerate(video_roles)
+        if len(values) >= threshold
+        and role_idx in allowed_roles
+        and (role_idx != 0 or bool(target_eligible[vi]))
+    }
+    candidates = [
+        detail
+        for detail in details
+        if (int(detail["video_index"]), int(detail["role_idx"])) in eligible_units
+    ]
+    candidates.sort(key=lambda row: float(row["tortuosity"]), reverse=True)
+
+    limit = max(
+        1,
+        int(
+            getattr(opts, "post_wall_departure_tortuosity_examples_num", 12)
+            or 12
+        ),
+    )
+    max_per_fly = max(
+        0,
+        int(
+            getattr(
+                opts,
+                "post_wall_departure_tortuosity_examples_max_per_fly",
+                1,
+            )
+            or 0
+        ),
+    )
+    selected = []
+    fly_counts: dict[tuple[int, int], int] = {}
+    for detail in candidates:
+        unit = (int(detail["video_index"]), int(detail["role_idx"]))
+        if max_per_fly and fly_counts.get(unit, 0) >= max_per_fly:
+            continue
+        selected.append(detail)
+        fly_counts[unit] = fly_counts.get(unit, 0) + 1
+        if len(selected) >= limit:
+            break
+
+    os.makedirs(out_dir, exist_ok=True)
+    group_label = _safe_group_label(opts, gls)
+    image_format = str(getattr(opts, "imageFormat", "png") or "png").lower()
+    zoom_radius_mm = getattr(
+        opts,
+        "post_wall_departure_tortuosity_examples_zoom_radius_mm",
+        None,
+    )
+    manifest_rows = []
+    for rank, detail in enumerate(selected, start=1):
+        va = detail["va"]
+        role_idx = int(detail["role_idx"])
+        role_label = "exp" if role_idx == 0 else "ctrl"
+        video_base = os.path.splitext(os.path.basename(str(va.fn)))[0]
+        filename = (
+            f"rank{rank:02d}__{video_base}"
+            f"__fly{int(detail['trajectory_index'])}"
+            f"__T{int(detail['training_idx']) + 1}"
+            f"__frames{int(detail['segment_start'])}-{int(detail['segment_stop'])}"
+            f".{image_format}"
+        )
+        out_path = os.path.join(out_dir, role_label, filename)
+        annotation = (
+            f"rank: {rank}/{len(candidates)}\n"
+            f"tortuosity: {float(detail['tortuosity']):.3f}\n"
+            f"post-wall path: {float(detail['path_mm']):.3f} mm\n"
+            f"direct distance: {float(detail['direct_mm']):.3f} mm\n"
+            f"last wall frame: {int(detail['last_wall_contact_frame'])}\n"
+            f"departure frame: {int(detail['departure_frame'])}"
+        )
+        zoom = zoom_radius_mm is not None and float(zoom_radius_mm) > 0
+        EventChainPlotter(
+            trj=detail["traj"],
+            va=va,
+            image_format=image_format,
+        ).plot_between_reward_interval(
+            trn_index=int(detail["training_idx"]),
+            start_reward=int(detail["segment_start"]),
+            end_reward=int(detail["segment_stop"]),
+            role_idx=role_idx,
+            pad=0,
+            zoom=zoom,
+            zoom_radius_mm=float(zoom_radius_mm) if zoom else None,
+            out_path=out_path,
+            title_suffix=f"| {group_label} | {role_label}",
+            annotation_text=annotation,
+            annotation_location="figure-right",
+            annotation_wrap_width=30,
+            title_wrap_width=90,
+            highlight_start_frame=int(detail["departure_frame"]),
+            highlight_stop_frame=int(detail["metric_stop"]),
+            highlight_exclude_nonwalking=bool(detail["exclude_nonwalk"]),
+            highlight_label="Path after final wall departure",
+            comparison_line_start_xy=detail["departure_xy"],
+            comparison_line_stop_xy=detail["reward_edge_xy"],
+            comparison_line_label="Direct distance to reward circle",
+        )
+        manifest_rows.append(
+            {
+                "group": group_label,
+                "role": role_label,
+                "rank": rank,
+                "eligible_episodes": len(candidates),
+                "video": str(va.fn),
+                "trajectory_index": int(detail["trajectory_index"]),
+                "training": int(detail["training_idx"]) + 1,
+                "segment_start": int(detail["segment_start"]),
+                "segment_stop": int(detail["segment_stop"]),
+                "last_wall_contact_frame": int(
+                    detail["last_wall_contact_frame"]
+                ),
+                "departure_frame": int(detail["departure_frame"]),
+                "path_mm": float(detail["path_mm"]),
+                "direct_distance_to_reward_circle_mm": float(
+                    detail["direct_mm"]
+                ),
+                "tortuosity": float(detail["tortuosity"]),
+                "image": out_path,
+            }
+        )
+
+    manifest_path = os.path.join(out_dir, "manifest.csv")
+    with open(manifest_path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=MANIFEST_FIELDS)
+        writer.writeheader()
+        writer.writerows(manifest_rows)
+    print(
+        "[post-wall-departure-tortuosity-examples] wrote "
+        f"{len(manifest_rows)} images and {manifest_path}"
+    )

--- a/src/exporting/post_wall_departure_tortuosity_sli_bundle.py
+++ b/src/exporting/post_wall_departure_tortuosity_sli_bundle.py
@@ -1,0 +1,531 @@
+from __future__ import annotations
+
+import os
+
+import numpy as np
+
+from src.analysis.between_reward_filters import (
+    min_between_reward_sync_bucket_trajectories,
+)
+from src.analysis.sli_bundle_utils import (
+    validate_post_wall_departure_tortuosity_bundle,
+    validate_sli_bundle,
+)
+from src.analysis.sync_bucket_presence_filters import (
+    exp_target_sync_bucket_eligibility_mask,
+    exp_target_sync_bucket_filter_payload,
+    mask_by_exp_target_sync_bucket_filter,
+)
+from src.exporting.com_sli_bundle import (
+    _compute_sli_scalar_and_timeseries_from_rpid,
+    _safe_group_label,
+)
+from src.plotting.between_reward_segment_binning import (
+    sync_bucket_window,
+    wall_contact_mask,
+)
+from src.plotting.between_reward_segment_metrics import dist_traveled_mm_masked
+from src.utils.parsers import parse_training_selector
+
+
+def selected_training_indices(vas, opts) -> list[int]:
+    n_trn = len(getattr(vas[0], "trns", []) or []) if vas else 0
+    raw = getattr(opts, "post_wall_departure_tortuosity_trainings", None)
+    if not raw:
+        return list(range(n_trn))
+    selected = sorted(
+        {
+            int(idx1) - 1
+            for idx1 in parse_training_selector(raw)
+            if 0 <= int(idx1) - 1 < n_trn
+        }
+    )
+    if selected:
+        return selected
+    print(
+        "[post-wall-departure-tortuosity] warning: training selector matched "
+        "no trainings; using all trainings."
+    )
+    return list(range(n_trn))
+
+
+def effective_windowing(opts) -> tuple[int, int]:
+    skip = getattr(opts, "post_wall_departure_tortuosity_skip_first_sync_buckets", None)
+    keep = getattr(opts, "post_wall_departure_tortuosity_keep_first_sync_buckets", None)
+    if skip is None:
+        skip = getattr(opts, "skip_first_sync_buckets", 0)
+    if keep is None:
+        keep = getattr(opts, "keep_first_sync_buckets", 0)
+    return max(0, int(skip or 0)), max(0, int(keep or 0))
+
+
+def _px_per_mm(va, traj) -> float | None:
+    for get_value in (
+        lambda: float(traj.pxPerMmFloor * va.xf.fctr),
+        lambda: float(va.xf.fctr * va.ct.pxPerMmFloor()),
+    ):
+        try:
+            value = get_value()
+        except Exception:
+            continue
+        if np.isfinite(value) and value > 0:
+            return value
+    return None
+
+
+def _nonwalk_mask(opts, traj, *, fi: int, n_frames: int):
+    if not bool(
+        getattr(
+            opts,
+            "post_wall_departure_tortuosity_exclude_nonwalking_frames",
+            False,
+        )
+    ):
+        return None
+    walking = getattr(traj, "walking", None)
+    if walking is None:
+        return None
+    start = max(0, min(int(fi), len(walking)))
+    stop = max(0, min(int(fi + n_frames), len(walking)))
+    window = np.zeros((int(max(1, n_frames)),), dtype=bool)
+    if stop > start:
+        values = np.asarray(walking[start:stop], dtype=float)
+        values = np.where(np.isfinite(values), values, 0.0)
+        window[: len(values)] = values > 0
+    return ~window
+
+
+def last_wall_departure_frame(
+    wc,
+    *,
+    segment_start: int,
+    segment_stop: int,
+    window_start: int,
+) -> tuple[int, int] | None:
+    """Return (last wall-contact frame, first subsequent non-contact frame)."""
+    if wc is None:
+        return None
+    s = int(segment_start)
+    e = int(segment_stop)
+    fi = int(window_start)
+    start = max(0, min(s - fi, len(wc)))
+    stop = max(0, min(e - fi, len(wc)))
+    if stop <= start:
+        return None
+    contacts = np.flatnonzero(np.asarray(wc[start:stop], dtype=bool))
+    if contacts.size == 0:
+        return None
+    last_contact = fi + start + int(contacts[-1])
+    departure = last_contact + 1
+    if departure >= e:
+        return None
+    return int(last_contact), int(departure)
+
+
+def departure_distance_to_reward_circle_mm(
+    traj,
+    *,
+    departure_frame: int,
+    reward_circle,
+    px_per_mm: float,
+) -> tuple[float, tuple[float, float]] | None:
+    """Shortest distance from departure position to the reward-circle perimeter."""
+    frame = int(departure_frame)
+    if frame < 0 or frame >= min(len(traj.x), len(traj.y)):
+        return None
+    x = float(traj.x[frame])
+    y = float(traj.y[frame])
+    cx, cy, radius_px = (float(value) for value in reward_circle)
+    if not np.all(np.isfinite([x, y, cx, cy, radius_px, px_per_mm])):
+        return None
+    dx = x - cx
+    dy = y - cy
+    radial_px = float(np.hypot(dx, dy))
+    if radial_px <= radius_px or radial_px <= 0 or px_per_mm <= 0:
+        return None
+    direct_mm = float((radial_px - radius_px) / px_per_mm)
+    reward_edge_xy = (
+        float(cx + radius_px * dx / radial_px),
+        float(cy + radius_px * dy / radial_px),
+    )
+    return direct_mm, reward_edge_xy
+
+
+def collect_post_wall_departure_tortuosity(vas, opts):
+    selected_trainings = selected_training_indices(vas, opts)
+    skip_first, keep_first = effective_windowing(opts)
+    exclude_nonwalk = bool(
+        getattr(
+            opts,
+            "post_wall_departure_tortuosity_exclude_nonwalking_frames",
+            False,
+        )
+    )
+    min_walk_frames = max(
+        2,
+        int(
+            getattr(opts, "post_wall_departure_tortuosity_min_walk_frames", 2) or 2
+        ),
+    )
+    min_direct_mm = max(
+        0.0,
+        float(
+            getattr(
+                opts,
+                "post_wall_departure_tortuosity_min_direct_distance_mm",
+                0.0,
+            )
+            or 0.0
+        ),
+    )
+
+    records = [[[] for _ in range(2)] for _ in vas]
+    details: list[dict] = []
+    windows_meta = [[] for _ in vas]
+    warned_missing_wc = [False]
+
+    for vi, va in enumerate(vas):
+        for role_idx, f in enumerate((0, 1)):
+            if f >= len(getattr(va, "trx", [])):
+                continue
+            if role_idx == 1 and getattr(va, "noyc", False):
+                continue
+            traj = va.trx[f]
+            if traj is None or traj.bad():
+                continue
+            px_per_mm = _px_per_mm(va, traj)
+            if px_per_mm is None:
+                continue
+
+            for training_idx in selected_trainings:
+                if training_idx >= len(getattr(va, "trns", [])):
+                    continue
+                trn = va.trns[training_idx]
+                if trn is None or not trn.isCircle():
+                    continue
+                fi, df, n_buckets, complete = sync_bucket_window(
+                    va,
+                    trn,
+                    t_idx=training_idx,
+                    f=f,
+                    skip_first=skip_first,
+                    keep_first=keep_first,
+                    use_exclusion_mask=False,
+                )
+                if n_buckets <= 0:
+                    continue
+                metric_n_frames = int(max(1, n_buckets * df))
+                wall_stop = min(
+                    min(len(traj.x), len(traj.y)),
+                    max(int(fi + metric_n_frames), int(trn.stop)),
+                )
+                wall_n_frames = int(max(1, wall_stop - fi))
+                wc = wall_contact_mask(
+                    opts,
+                    va,
+                    f,
+                    fi=fi,
+                    n_frames=wall_n_frames,
+                    log_tag="post_wall_departure_tortuosity",
+                    warned_missing_wc=warned_missing_wc,
+                    enabled=True,
+                )
+                if wc is None:
+                    continue
+                nonwalk = _nonwalk_mask(
+                    opts,
+                    traj,
+                    fi=fi,
+                    n_frames=wall_n_frames,
+                )
+                try:
+                    reward_circle = trn.circles(f)[0]
+                except Exception:
+                    continue
+
+                windows_meta[vi].append(
+                    {
+                        "role": "exp" if role_idx == 0 else "ctrl",
+                        "training_idx": int(training_idx),
+                        "training_name": trn.name(),
+                        "start": int(fi),
+                        "stop": int(fi + metric_n_frames),
+                    }
+                )
+
+                for seg in va._iter_between_reward_segment_com(
+                    trn,
+                    f,
+                    fi=fi,
+                    df=df,
+                    n_buckets=n_buckets,
+                    complete=complete,
+                    relative_to_reward=True,
+                    per_segment_min_meddist_mm=0.0,
+                    exclude_wall=False,
+                    wc=None,
+                    exclude_nonwalk=False,
+                    nonwalk_mask=None,
+                    min_walk_frames=2,
+                    dist_stats=(),
+                    debug=False,
+                    yield_skips=False,
+                ):
+                    s = int(seg.s)
+                    e = int(seg.e)
+                    departure_info = last_wall_departure_frame(
+                        wc,
+                        segment_start=s,
+                        segment_stop=e,
+                        window_start=fi,
+                    )
+                    if departure_info is None:
+                        continue
+                    last_contact, departure = departure_info
+                    direct_info = departure_distance_to_reward_circle_mm(
+                        traj,
+                        departure_frame=departure,
+                        reward_circle=reward_circle,
+                        px_per_mm=px_per_mm,
+                    )
+                    if direct_info is None:
+                        continue
+                    direct_mm, reward_edge_xy = direct_info
+                    if direct_mm <= min_direct_mm:
+                        continue
+
+                    metric_stop = min(e + 1, len(traj.x), len(traj.y))
+                    path_mm = dist_traveled_mm_masked(
+                        traj=traj,
+                        s=departure,
+                        e=metric_stop,
+                        fi=fi,
+                        nonwalk_mask=nonwalk,
+                        exclude_nonwalk=exclude_nonwalk,
+                        px_per_mm=px_per_mm,
+                        min_keep_frames=min_walk_frames,
+                    )
+                    if not np.isfinite(path_mm) or path_mm <= 0:
+                        continue
+                    ratio = float(path_mm / direct_mm)
+                    if not np.isfinite(ratio):
+                        continue
+
+                    records[vi][role_idx].append(ratio)
+                    details.append(
+                        {
+                            "va": va,
+                            "video_index": int(vi),
+                            "role_idx": int(role_idx),
+                            "trajectory_index": int(f),
+                            "traj": traj,
+                            "training_idx": int(training_idx),
+                            "segment_start": s,
+                            "segment_stop": e,
+                            "last_wall_contact_frame": int(last_contact),
+                            "departure_frame": int(departure),
+                            "metric_stop": int(metric_stop),
+                            "path_mm": float(path_mm),
+                            "direct_mm": float(direct_mm),
+                            "tortuosity": ratio,
+                            "reward_edge_xy": reward_edge_xy,
+                            "departure_xy": (
+                                float(traj.x[departure]),
+                                float(traj.y[departure]),
+                            ),
+                            "exclude_nonwalk": exclude_nonwalk,
+                        }
+                    )
+    return records, details, windows_meta
+
+
+def aggregate_post_wall_departure_tortuosity(records, *, min_episodes: int):
+    n_videos = len(records)
+    means = [
+        np.full((n_videos, 1), np.nan, dtype=float),
+        np.full((n_videos, 1), np.nan, dtype=float),
+    ]
+    counts = [
+        np.zeros((n_videos, 1), dtype=int),
+        np.zeros((n_videos, 1), dtype=int),
+    ]
+    threshold = max(1, int(min_episodes))
+    for vi, video_roles in enumerate(records):
+        for role_idx, values in enumerate(video_roles):
+            finite = np.asarray(values, dtype=float)
+            finite = finite[np.isfinite(finite)]
+            counts[role_idx][vi, 0] = int(finite.size)
+            if finite.size >= threshold:
+                means[role_idx][vi, 0] = float(np.mean(finite))
+    return means[0], means[1], counts[0], counts[1]
+
+
+def build_post_wall_departure_tortuosity_sli_bundle(vas, opts, gls):
+    vas_ok = [va for va in vas if not getattr(va, "_skipped", False)]
+    if not vas_ok:
+        raise ValueError(
+            "No non-skipped videos for post-wall departure tortuosity bundle."
+        )
+    records, details, windows_meta = collect_post_wall_departure_tortuosity(
+        vas_ok, opts
+    )
+    min_episodes = min_between_reward_sync_bucket_trajectories(opts)
+    mean_exp, mean_ctrl, n_exp, n_ctrl = (
+        aggregate_post_wall_departure_tortuosity(
+            records,
+            min_episodes=min_episodes,
+        )
+    )
+    n_videos = len(vas_ok)
+    try:
+        sli, sli_ts = _compute_sli_scalar_and_timeseries_from_rpid(vas_ok, opts)
+    except Exception as exc:
+        print(
+            "[post-wall-departure-tortuosity] warning: failed to compute SLI: "
+            f"{exc}"
+        )
+        sli = np.full((n_videos,), np.nan, dtype=float)
+        sli_ts = np.full(
+            (n_videos, len(getattr(vas_ok[0], "trns", []) or []), 0),
+            np.nan,
+        )
+    target_eligible = exp_target_sync_bucket_eligibility_mask(vas_ok, opts)
+    mean_exp = mask_by_exp_target_sync_bucket_filter(mean_exp, target_eligible)
+    sli = mask_by_exp_target_sync_bucket_filter(sli, target_eligible)
+    sli_ts = mask_by_exp_target_sync_bucket_filter(sli_ts, target_eligible)
+
+    selected_trainings = selected_training_indices(vas_ok, opts)
+    skip_first, keep_first = effective_windowing(opts)
+    video_fns = np.asarray([getattr(va, "fn", "") for va in vas_ok], dtype=str)
+    fly_ids = np.asarray([int(getattr(va, "f", -1)) for va in vas_ok], dtype=int)
+    payload = dict(
+        sli=np.asarray(sli, dtype=float),
+        sli_ts=np.asarray(sli_ts, dtype=float),
+        group_label=np.asarray(_safe_group_label(opts, gls)),
+        bucket_len_min=np.asarray(np.nan),
+        training_names=np.asarray(
+            [trn.name() for trn in getattr(vas_ok[0], "trns", [])],
+            dtype=str,
+        ),
+        video_ids=np.asarray(
+            [f"{fn}::f{fly_id}" for fn, fly_id in zip(video_fns, fly_ids)],
+            dtype=str,
+        ),
+        video_fns=video_fns,
+        fly_ids=fly_ids,
+        sli_training_idx=np.asarray(
+            getattr(opts, "best_worst_trn", 1) - 1,
+            dtype=int,
+        ),
+        sli_use_training_mean=np.asarray(
+            bool(getattr(opts, "sli_use_training_mean", False))
+        ),
+        sli_select_skip_first_sync_buckets=np.asarray(
+            max(
+                0,
+                int(
+                    getattr(opts, "sli_select_skip_first_sync_buckets", 0)
+                    or 0
+                ),
+            ),
+            dtype=int,
+        ),
+        sli_select_keep_first_sync_buckets=np.asarray(
+            max(
+                0,
+                int(
+                    getattr(opts, "sli_select_keep_first_sync_buckets", 0)
+                    or 0
+                ),
+            ),
+            dtype=int,
+        ),
+        post_wall_departure_tortuosity_exp=mean_exp,
+        post_wall_departure_tortuosity_ctrl=mean_ctrl,
+        post_wall_departure_tortuosityN_exp=n_exp,
+        post_wall_departure_tortuosityN_ctrl=n_ctrl,
+        post_wall_departure_tortuosity_trainings=np.asarray(
+            selected_trainings, dtype=int
+        ),
+        post_wall_departure_tortuosity_skip_first_sync_buckets=np.asarray(
+            skip_first, dtype=int
+        ),
+        post_wall_departure_tortuosity_keep_first_sync_buckets=np.asarray(
+            keep_first, dtype=int
+        ),
+        post_wall_departure_tortuosity_exclude_nonwalking_frames=np.asarray(
+            bool(
+                getattr(
+                    opts,
+                    "post_wall_departure_tortuosity_exclude_nonwalking_frames",
+                    False,
+                )
+            )
+        ),
+        post_wall_departure_tortuosity_min_walk_frames=np.asarray(
+            max(
+                2,
+                int(
+                    getattr(
+                        opts,
+                        "post_wall_departure_tortuosity_min_walk_frames",
+                        2,
+                    )
+                    or 2
+                ),
+            ),
+            dtype=int,
+        ),
+        post_wall_departure_tortuosity_min_direct_distance_mm=np.asarray(
+            max(
+                0.0,
+                float(
+                    getattr(
+                        opts,
+                        "post_wall_departure_tortuosity_min_direct_distance_mm",
+                        0.0,
+                    )
+                    or 0.0
+                ),
+            )
+        ),
+        post_wall_departure_tortuosity_denominator=np.asarray(
+            "shortest distance from wall-departure point to reward-circle perimeter"
+        ),
+        post_wall_departure_tortuosity_window_summary=np.asarray(
+            [
+                "; ".join(
+                    f"{window['role']} T{window['training_idx'] + 1} "
+                    f"{window['training_name']}[{window['start']},{window['stop']})"
+                    for window in video_windows
+                )
+                for video_windows in windows_meta
+            ],
+            dtype=str,
+        ),
+        btw_rwd_sync_bucket_min_trajectories=np.asarray(
+            min_episodes, dtype=int
+        ),
+        **exp_target_sync_bucket_filter_payload(
+            vas_ok,
+            opts,
+            prefix="exp_target_sync_bucket_filter",
+        ),
+    )
+    validate_sli_bundle(payload)
+    validate_post_wall_departure_tortuosity_bundle(payload)
+    return payload, details
+
+
+def export_post_wall_departure_tortuosity_sli_bundle(vas, opts, gls, out_fn):
+    payload, _details = build_post_wall_departure_tortuosity_sli_bundle(
+        vas, opts, gls
+    )
+    if not str(out_fn).lower().endswith(".npz"):
+        out_fn = f"{out_fn}.npz"
+    os.makedirs(os.path.dirname(out_fn) or ".", exist_ok=True)
+    np.savez_compressed(out_fn, **payload)
+    print(
+        "[export] Wrote post-wall-departure-tortuosity+SLI bundle: "
+        f"{out_fn} (n={len(payload['sli'])})"
+    )

--- a/src/exporting/return_leg_tortuosity_excursion_bin_examples.py
+++ b/src/exporting/return_leg_tortuosity_excursion_bin_examples.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+
+import csv
+import os
+
+import numpy as np
+
+from src.analysis.between_reward_filters import (
+    min_between_reward_sync_bucket_trajectories,
+)
+from src.analysis.sync_bucket_presence_filters import (
+    exp_target_sync_bucket_eligibility_mask,
+)
+from src.exporting.com_sli_bundle import _safe_group_label
+from src.exporting.return_leg_tortuosity_excursion_bin_sli_bundle import (
+    _collect_records,
+    _effective_windowing,
+    _parse_edges,
+    _parse_pairs,
+    _resolved_bins,
+    _selected_training_indices,
+    _top_fraction,
+)
+from src.plotting.between_reward_segment_metrics import (
+    dist_traveled_mm_masked,
+    max_radial_distance_mm_masked,
+    net_displacement_mm_masked,
+)
+from src.plotting.event_chain_plotter import EventChainPlotter
+from src.utils import util
+
+
+def _group_label(record, opts, gls) -> str:
+    explicit = getattr(opts, "export_group_label", None)
+    if explicit:
+        return str(explicit)
+    try:
+        group_idx = int(record["va"].gidx)
+    except Exception:
+        group_idx = 0
+    if gls and 0 <= group_idx < len(gls) and gls[group_idx]:
+        return str(gls[group_idx])
+    return _safe_group_label(opts, gls)
+
+
+def _bin_index(value: float, lower: np.ndarray, upper: np.ndarray) -> int | None:
+    matches = np.flatnonzero((lower <= float(value)) & (float(value) < upper))
+    return int(matches[0]) if matches.size else None
+
+
+def _last_wall_frame(record) -> int | None:
+    wc = record.get("wall_mask")
+    if wc is None:
+        return None
+    fi = int(record["window_start"])
+    s = int(record["segment_start"])
+    e = int(record["segment_stop"])
+    start = max(0, min(s - fi, len(wc)))
+    stop = max(0, min(e - fi, len(wc)))
+    idx = np.flatnonzero(np.asarray(wc[start:stop], dtype=bool))
+    if not idx.size:
+        return None
+    return int(fi + start + idx[-1])
+
+
+def _metric_components(record) -> tuple[float, float, float]:
+    common = dict(
+        traj=record["traj"],
+        s=int(record["metric_start"]),
+        e=int(record["segment_stop"]),
+        fi=int(record["window_start"]),
+        nonwalk_mask=record["nonwalk_mask"],
+        exclude_nonwalk=bool(record["exclude_nonwalk"]),
+        px_per_mm=float(record["px_per_mm"]),
+        min_keep_frames=int(record["min_walk_frames"]),
+    )
+    path_mm = dist_traveled_mm_masked(**common)
+    displacement_mm = net_displacement_mm_masked(**common)
+    max_radius_mm = max_radial_distance_mm_masked(
+        **common,
+        center_xy=record["reward_center_xy"],
+    )
+    return float(path_mm), float(displacement_mm), float(max_radius_mm)
+
+
+def _format_bin(lo: float, hi: float) -> str:
+    return f"{lo:g}-{hi:g} mm"
+
+
+MANIFEST_FIELDS = [
+    "group",
+    "role",
+    "bin_index",
+    "bin_lower_mm",
+    "bin_upper_mm",
+    "rank",
+    "eligible_episodes_in_group_bin",
+    "video",
+    "trajectory_index",
+    "training",
+    "segment_start",
+    "segment_stop",
+    "global_max_frame",
+    "return_start_frame",
+    "last_wall_frame",
+    "episode_bin_distance_mm",
+    "episode_bin_distance_semantics",
+    "return_path_mm",
+    "return_displacement_mm",
+    "return_max_radius_mm",
+    "tortuosity",
+    "metric_mode",
+    "return_start_mode",
+    "image",
+]
+
+
+def export_return_leg_tortuosity_excursion_bin_examples(
+    vas,
+    opts,
+    gls,
+    out_dir: str,
+) -> None:
+    vas_ok = [va for va in vas if not getattr(va, "_skipped", False)]
+    if not vas_ok:
+        print("[return-leg-tortuosity-examples] no non-skipped videos")
+        return
+
+    pair_spec = _parse_pairs(opts)
+    legacy_distances = pair_spec[2] if pair_spec is not None else _parse_edges(opts)[1]
+    selected_trainings = _selected_training_indices(vas_ok, opts)
+    skip_first, keep_first = _effective_windowing(opts)
+    details: list[dict] = []
+    records, _windows = _collect_records(
+        vas_ok,
+        opts,
+        selected_trainings=selected_trainings,
+        skip_first=skip_first,
+        keep_first=keep_first,
+        legacy_distances=legacy_distances,
+        episode_callback=details.append,
+    )
+    lower, upper, _edges, _pair_mode, _legacy = _resolved_bins(opts, records)
+
+    role_mode = str(
+        getattr(
+            opts,
+            "return_leg_tortuosity_excursion_bin_examples_role",
+            "exp",
+        )
+        or "exp"
+    ).lower()
+    allowed_roles = {0} if role_mode == "exp" else {1}
+    if role_mode == "both":
+        allowed_roles = {0, 1}
+
+    target_eligible = exp_target_sync_bucket_eligibility_mask(vas_ok, opts)
+    min_segments = min_between_reward_sync_bucket_trajectories(opts)
+    top_fraction = _top_fraction(opts)
+    per_bin = max(
+        1,
+        int(
+            getattr(
+                opts,
+                "return_leg_tortuosity_excursion_bin_examples_per_bin",
+                6,
+            )
+            or 6
+        ),
+    )
+    max_per_fly = max(
+        0,
+        int(
+            getattr(
+                opts,
+                "return_leg_tortuosity_excursion_bin_examples_max_per_fly",
+                0,
+            )
+            or 0
+        ),
+    )
+
+    indexed: dict[tuple[int, int, int], list[dict]] = {}
+    for record in details:
+        role_idx = int(record["role_idx"])
+        if role_idx not in allowed_roles:
+            continue
+        vi = int(record["video_index"])
+        if role_idx == 0 and not bool(target_eligible[vi]):
+            continue
+        bin_idx = _bin_index(record["radial_mm"], lower, upper)
+        if bin_idx is None:
+            continue
+        record["bin_idx"] = bin_idx
+        indexed.setdefault((vi, role_idx, bin_idx), []).append(record)
+
+    eligible: list[dict] = []
+    for unit_records in indexed.values():
+        if len(unit_records) < min_segments:
+            continue
+        n_selected = max(1, int(np.ceil(top_fraction * len(unit_records))))
+        ranked = sorted(
+            unit_records,
+            key=lambda item: float(item["tortuosity"]),
+            reverse=True,
+        )
+        eligible.extend(ranked[:n_selected])
+
+    grouped: dict[tuple[str, int, int], list[dict]] = {}
+    for record in eligible:
+        key = (
+            _group_label(record, opts, gls),
+            int(record["role_idx"]),
+            int(record["bin_idx"]),
+        )
+        grouped.setdefault(key, []).append(record)
+
+    os.makedirs(out_dir, exist_ok=True)
+    manifest_rows: list[dict] = []
+    image_format = str(getattr(opts, "imageFormat", "png") or "png").lower()
+    zoom_override = getattr(
+        opts,
+        "return_leg_tortuosity_excursion_bin_examples_zoom_radius_mm",
+        None,
+    )
+
+    for (group_label, role_idx, bin_idx), candidates in sorted(grouped.items()):
+        ranked = sorted(
+            candidates,
+            key=lambda item: float(item["tortuosity"]),
+            reverse=True,
+        )
+        selected = []
+        fly_counts: dict[int, int] = {}
+        for record in ranked:
+            vi = int(record["video_index"])
+            if max_per_fly and fly_counts.get(vi, 0) >= max_per_fly:
+                continue
+            selected.append(record)
+            fly_counts[vi] = fly_counts.get(vi, 0) + 1
+            if len(selected) >= per_bin:
+                break
+
+        lo = float(lower[bin_idx])
+        hi = float(upper[bin_idx])
+        group_slug = util.slugify(group_label) or "group"
+        role_label = "exp" if role_idx == 0 else "ctrl"
+        bin_slug = f"bin{bin_idx + 1}_{lo:g}-{hi:g}mm"
+        bin_dir = os.path.join(out_dir, group_slug, role_label, bin_slug)
+        os.makedirs(bin_dir, exist_ok=True)
+
+        for rank, record in enumerate(selected, start=1):
+            va = record["va"]
+            traj = record["traj"]
+            video_base = os.path.splitext(os.path.basename(str(va.fn)))[0]
+            path_mm, displacement_mm, max_radius_mm = _metric_components(record)
+            last_wall_frame = _last_wall_frame(record)
+            mode = str(record["metric_mode"])
+            distance_semantics = (
+                "distance past reward-circle perimeter"
+                if record["legacy_distances"]
+                else "distance from reward-circle center"
+            )
+            denominator = (
+                max_radius_mm
+                if mode == "path_over_max_radius"
+                else displacement_mm
+            )
+            annotation = (
+                f"rank: {rank}/{len(candidates)}\n"
+                f"tortuosity: {float(record['tortuosity']):.3f}\n"
+                f"max-distance bin: {_format_bin(lo, hi)}\n"
+                f"episode bin distance: {float(record['radial_mm']):.3f} mm\n"
+                f"return path: {path_mm:.3f} mm\n"
+                f"net displacement: {displacement_mm:.3f} mm\n"
+                f"return max radius: {max_radius_mm:.3f} mm\n"
+                f"metric denominator: {denominator:.3f} mm\n"
+                f"return start: {int(record['metric_start'])}\n"
+                f"last wall frame: "
+                f"{'none' if last_wall_frame is None else last_wall_frame}"
+            )
+            filename = (
+                f"rank{rank:02d}__{video_base}__fly{int(record['trajectory_index'])}"
+                f"__T{int(record['training_idx']) + 1}"
+                f"__frames{int(record['segment_start'])}-{int(record['segment_stop'])}"
+                f".{image_format}"
+            )
+            out_path = os.path.join(bin_dir, filename)
+            if zoom_override is None:
+                zoom_radius_mm = hi + 1.0 if np.isfinite(hi) else None
+                zoom = zoom_radius_mm is not None
+            else:
+                zoom_radius_mm = float(zoom_override)
+                zoom = zoom_radius_mm > 0
+                if not zoom:
+                    zoom_radius_mm = None
+
+            EventChainPlotter(
+                trj=traj,
+                va=va,
+                image_format=image_format,
+            ).plot_between_reward_interval(
+                trn_index=int(record["training_idx"]),
+                start_reward=int(record["segment_start"]),
+                end_reward=int(record["segment_stop"]),
+                role_idx=role_idx,
+                pad=0,
+                zoom=zoom,
+                zoom_radius_mm=zoom_radius_mm,
+                out_path=out_path,
+                title_suffix=(
+                    f"| {group_label} | {role_label} | "
+                    f"{record['return_start_mode']}"
+                ),
+                annotation_text=annotation,
+                annotation_location="figure-right",
+                annotation_wrap_width=30,
+                title_wrap_width=90,
+                highlight_start_frame=int(record["metric_start"]),
+                highlight_stop_frame=int(record["segment_stop"]),
+                highlight_exclude_nonwalking=bool(record["exclude_nonwalk"]),
+                highlight_label="Measured return leg",
+            )
+
+            manifest_rows.append(
+                {
+                    "group": group_label,
+                    "role": role_label,
+                    "bin_index": bin_idx,
+                    "bin_lower_mm": lo,
+                    "bin_upper_mm": hi,
+                    "rank": rank,
+                    "eligible_episodes_in_group_bin": len(candidates),
+                    "video": str(va.fn),
+                    "trajectory_index": int(record["trajectory_index"]),
+                    "training": int(record["training_idx"]) + 1,
+                    "segment_start": int(record["segment_start"]),
+                    "segment_stop": int(record["segment_stop"]),
+                    "global_max_frame": int(record["global_max_frame"]),
+                    "return_start_frame": int(record["metric_start"]),
+                    "last_wall_frame": (
+                        "" if last_wall_frame is None else int(last_wall_frame)
+                    ),
+                    "episode_bin_distance_mm": float(record["radial_mm"]),
+                    "episode_bin_distance_semantics": distance_semantics,
+                    "return_path_mm": path_mm,
+                    "return_displacement_mm": displacement_mm,
+                    "return_max_radius_mm": max_radius_mm,
+                    "tortuosity": float(record["tortuosity"]),
+                    "metric_mode": mode,
+                    "return_start_mode": str(record["return_start_mode"]),
+                    "image": out_path,
+                }
+            )
+
+    manifest_path = os.path.join(out_dir, "manifest.csv")
+    with open(manifest_path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=MANIFEST_FIELDS)
+        writer.writeheader()
+        if manifest_rows:
+            writer.writerows(manifest_rows)
+    print(
+        "[return-leg-tortuosity-examples] wrote "
+        f"{len(manifest_rows)} images and {manifest_path}"
+    )

--- a/src/exporting/return_leg_tortuosity_excursion_bin_examples.py
+++ b/src/exporting/return_leg_tortuosity_excursion_bin_examples.py
@@ -14,6 +14,7 @@ from src.analysis.sync_bucket_presence_filters import (
 from src.exporting.com_sli_bundle import _safe_group_label
 from src.exporting.return_leg_tortuosity_excursion_bin_sli_bundle import (
     _collect_records,
+    _binning_mode,
     _effective_windowing,
     _parse_edges,
     _parse_pairs,
@@ -125,6 +126,12 @@ def export_return_leg_tortuosity_excursion_bin_examples(
     if not vas_ok:
         print("[return-leg-tortuosity-examples] no non-skipped videos")
         return
+
+    if _binning_mode(opts) != "absolute_distance":
+        raise ValueError(
+            "Ranked return-leg tortuosity trajectory examples currently require "
+            "absolute-distance binning."
+        )
 
     pair_spec = _parse_pairs(opts)
     legacy_distances = pair_spec[2] if pair_spec is not None else _parse_edges(opts)[1]

--- a/src/exporting/return_leg_tortuosity_excursion_bin_examples.py
+++ b/src/exporting/return_leg_tortuosity_excursion_bin_examples.py
@@ -15,6 +15,7 @@ from src.exporting.com_sli_bundle import _safe_group_label
 from src.exporting.return_leg_tortuosity_excursion_bin_sli_bundle import (
     _collect_records,
     _binning_mode,
+    _combined_exclusion_mask,
     _effective_windowing,
     _parse_edges,
     _parse_pairs,
@@ -65,20 +66,35 @@ def _last_wall_frame(record) -> int | None:
 
 
 def _metric_components(record) -> tuple[float, float, float]:
+    exclude_wall_frames = bool(record.get("exclude_wall_frames", False))
+    path_mask = _combined_exclusion_mask(
+        record["nonwalk_mask"],
+        record["wall_mask"],
+        exclude_nonwalk=bool(record["exclude_nonwalk"]),
+        exclude_wall_frames=exclude_wall_frames,
+    )
     common = dict(
         traj=record["traj"],
         s=int(record["metric_start"]),
         e=int(record["segment_stop"]),
         fi=int(record["window_start"]),
-        nonwalk_mask=record["nonwalk_mask"],
-        exclude_nonwalk=bool(record["exclude_nonwalk"]),
         px_per_mm=float(record["px_per_mm"]),
         min_keep_frames=int(record["min_walk_frames"]),
     )
-    path_mm = dist_traveled_mm_masked(**common)
-    displacement_mm = net_displacement_mm_masked(**common)
+    path_mm = dist_traveled_mm_masked(
+        **common,
+        nonwalk_mask=path_mask,
+        exclude_nonwalk=path_mask is not None,
+    )
+    displacement_mm = net_displacement_mm_masked(
+        **common,
+        nonwalk_mask=path_mask,
+        exclude_nonwalk=path_mask is not None,
+    )
     max_radius_mm = max_radial_distance_mm_masked(
         **common,
+        nonwalk_mask=record["nonwalk_mask"],
+        exclude_nonwalk=bool(record["exclude_nonwalk"]),
         center_xy=record["reward_center_xy"],
     )
     return float(path_mm), float(displacement_mm), float(max_radius_mm)
@@ -112,6 +128,7 @@ MANIFEST_FIELDS = [
     "tortuosity",
     "metric_mode",
     "return_start_mode",
+    "exclude_wall_contact_frames",
     "image",
 ]
 
@@ -283,6 +300,8 @@ def export_return_leg_tortuosity_excursion_bin_examples(
                 f"return max radius: {max_radius_mm:.3f} mm\n"
                 f"metric denominator: {denominator:.3f} mm\n"
                 f"return start: {int(record['metric_start'])}\n"
+                f"wall-contact path frames excluded: "
+                f"{bool(record.get('exclude_wall_frames', False))}\n"
                 f"last wall frame: "
                 f"{'none' if last_wall_frame is None else last_wall_frame}"
             )
@@ -326,6 +345,12 @@ def export_return_leg_tortuosity_excursion_bin_examples(
                 highlight_start_frame=int(record["metric_start"]),
                 highlight_stop_frame=int(record["segment_stop"]),
                 highlight_exclude_nonwalking=bool(record["exclude_nonwalk"]),
+                highlight_excluded_frame_mask=(
+                    record["wall_mask"]
+                    if record.get("exclude_wall_frames", False)
+                    else None
+                ),
+                highlight_excluded_frame_mask_start=int(record["window_start"]),
                 highlight_label="Measured return leg",
             )
 
@@ -356,6 +381,9 @@ def export_return_leg_tortuosity_excursion_bin_examples(
                     "tortuosity": float(record["tortuosity"]),
                     "metric_mode": mode,
                     "return_start_mode": str(record["return_start_mode"]),
+                    "exclude_wall_contact_frames": bool(
+                        record.get("exclude_wall_frames", False)
+                    ),
                     "image": out_path,
                 }
             )

--- a/src/exporting/return_leg_tortuosity_excursion_bin_sli_bundle.py
+++ b/src/exporting/return_leg_tortuosity_excursion_bin_sli_bundle.py
@@ -175,6 +175,46 @@ def _return_leg_start_mode(opts) -> str:
     return mode
 
 
+def _binning_mode(opts) -> str:
+    mode = str(
+        getattr(
+            opts,
+            "return_leg_tortuosity_excursion_bin_binning_mode",
+            "absolute_distance",
+        )
+        or "absolute_distance"
+    ).strip().lower()
+    if mode not in {"absolute_distance", "per_fly_quartile"}:
+        raise ValueError(
+            "Unknown return-leg tortuosity binning mode "
+            f"{mode!r}; expected 'absolute_distance' or 'per_fly_quartile'."
+        )
+    return mode
+
+
+def _validate_binning_options(opts, binning_mode: str) -> None:
+    if binning_mode != "per_fly_quartile":
+        return
+    absolute_options = (
+        "return_leg_tortuosity_excursion_bin_radii_mm",
+        "return_leg_tortuosity_excursion_bin_edges_mm",
+        "return_leg_tortuosity_excursion_bin_radius_pairs_mm",
+        "return_leg_tortuosity_excursion_bin_pairs_mm",
+    )
+    provided = [
+        name
+        for name in absolute_options
+        if getattr(opts, name, None) is not None
+        and str(getattr(opts, name)).strip()
+    ]
+    if provided:
+        flags = ", ".join("--" + name.replace("_", "-") for name in provided)
+        raise ValueError(
+            "Per-fly quartile binning cannot be combined with absolute-distance "
+            f"bin options: {flags}"
+        )
+
+
 def _post_last_wall_max_frame(
     *,
     traj,
@@ -495,7 +535,25 @@ def _top_fraction(opts) -> float:
         raise ValueError(
             "--return-leg-tortuosity-excursion-bin-top-fraction must be in (0, 1]."
         )
+    if _binning_mode(opts) == "per_fly_quartile" and fraction != 1.0:
+        raise ValueError(
+            "--return-leg-tortuosity-excursion-bin-top-fraction must be 1.0 "
+            "when --return-leg-tortuosity-excursion-bin-binning-mode is "
+            "per_fly_quartile."
+        )
     return fraction
+
+
+def _equal_count_bin_indices(distances, *, n_bins: int = 4) -> np.ndarray:
+    distances = np.asarray(distances, dtype=float).reshape(-1)
+    assignment = np.full(distances.shape, -1, dtype=int)
+    finite_idx = np.flatnonzero(np.isfinite(distances))
+    if finite_idx.size == 0:
+        return assignment
+    order = finite_idx[np.argsort(distances[finite_idx], kind="stable")]
+    for bin_idx, indices in enumerate(np.array_split(order, int(n_bins))):
+        assignment[indices] = int(bin_idx)
+    return assignment
 
 
 def _aggregate_records(
@@ -555,6 +613,76 @@ def _aggregate_records(
     )
 
 
+def _aggregate_quartile_records(
+    records,
+    *,
+    min_segments: int,
+    n_bins: int = 4,
+):
+    n_videos = len(records)
+    means = [
+        np.full((n_videos, n_bins), np.nan, dtype=float),
+        np.full((n_videos, n_bins), np.nan, dtype=float),
+    ]
+    counts = [
+        np.zeros((n_videos, n_bins), dtype=int),
+        np.zeros((n_videos, n_bins), dtype=int),
+    ]
+    distance_stats = {
+        stat: [
+            np.full((n_videos, n_bins), np.nan, dtype=float),
+            np.full((n_videos, n_bins), np.nan, dtype=float),
+        ]
+        for stat in ("min", "max", "mean", "median")
+    }
+
+    for vi, video_roles in enumerate(records):
+        for role_idx, role_records in enumerate(video_roles):
+            if not role_records:
+                continue
+            distances = np.asarray(
+                [radial for radial, _tortuosity in role_records], dtype=float
+            )
+            tortuosities = np.asarray(
+                [tortuosity for _radial, tortuosity in role_records], dtype=float
+            )
+            assignment = _equal_count_bin_indices(distances, n_bins=n_bins)
+            for bin_idx in range(n_bins):
+                in_bin = assignment == bin_idx
+                bin_distances = distances[in_bin]
+                bin_values = tortuosities[in_bin]
+                counts[role_idx][vi, bin_idx] = int(bin_values.size)
+                if bin_values.size:
+                    means[role_idx][vi, bin_idx] = float(np.mean(bin_values))
+                    distance_stats["min"][role_idx][vi, bin_idx] = float(
+                        np.min(bin_distances)
+                    )
+                    distance_stats["max"][role_idx][vi, bin_idx] = float(
+                        np.max(bin_distances)
+                    )
+                    distance_stats["mean"][role_idx][vi, bin_idx] = float(
+                        np.mean(bin_distances)
+                    )
+                    distance_stats["median"][role_idx][vi, bin_idx] = float(
+                        np.median(bin_distances)
+                    )
+            means[role_idx][vi] = mask_metric_by_min_between_reward_trajectories(
+                means[role_idx][vi],
+                counts[role_idx][vi],
+                max(1, int(min_segments)),
+            )
+
+    return (
+        means[0],
+        means[1],
+        counts[0],
+        counts[1],
+        counts[0].copy(),
+        counts[1].copy(),
+        distance_stats,
+    )
+
+
 def export_return_leg_tortuosity_excursion_bin_sli_bundle(vas, opts, gls, out_fn):
     if not out_fn.lower().endswith(".npz"):
         out_fn += ".npz"
@@ -564,9 +692,16 @@ def export_return_leg_tortuosity_excursion_bin_sli_bundle(vas, opts, gls, out_fn
         print(f"[export] No non-skipped VideoAnalysis instances; not writing {out_fn}")
         return
 
-    pair_spec = _parse_pairs(opts)
+    binning_mode = _binning_mode(opts)
+    _validate_binning_options(opts, binning_mode)
+    pair_spec = _parse_pairs(opts) if binning_mode == "absolute_distance" else None
     return_start_mode = _return_leg_start_mode(opts)
-    legacy_distances = pair_spec[2] if pair_spec is not None else _parse_edges(opts)[1]
+    if pair_spec is not None:
+        legacy_distances = pair_spec[2]
+    elif binning_mode == "absolute_distance":
+        legacy_distances = _parse_edges(opts)[1]
+    else:
+        legacy_distances = False
     selected_trainings = _selected_training_indices(vas_ok, opts)
     skip_first, keep_first = _effective_windowing(opts)
     records, windows_meta = _collect_records(
@@ -577,20 +712,47 @@ def export_return_leg_tortuosity_excursion_bin_sli_bundle(vas, opts, gls, out_fn
         keep_first=keep_first,
         legacy_distances=legacy_distances,
     )
-    lower, upper, resolved_edges, pair_mode, legacy_distances = _resolved_bins(
-        opts, records
-    )
     min_segments = min_between_reward_sync_bucket_trajectories(opts)
     top_fraction = _top_fraction(opts)
-    mean_exp, mean_ctrl, n_exp, n_ctrl, selected_n_exp, selected_n_ctrl = (
-        _aggregate_records(
+    distance_stats = None
+    if binning_mode == "per_fly_quartile":
+        percentile_edges = np.asarray([0.0, 25.0, 50.0, 75.0, 100.0])
+        lower = percentile_edges[:-1]
+        upper = percentile_edges[1:]
+        resolved_edges = percentile_edges
+        pair_mode = False
+        (
+            mean_exp,
+            mean_ctrl,
+            n_exp,
+            n_ctrl,
+            selected_n_exp,
+            selected_n_ctrl,
+            distance_stats,
+        ) = _aggregate_quartile_records(
             records,
-            lower,
-            upper,
             min_segments=min_segments,
-            top_fraction=top_fraction,
+            n_bins=4,
         )
-    )
+        requested = percentile_edges
+    else:
+        lower, upper, resolved_edges, pair_mode, legacy_distances = _resolved_bins(
+            opts, records
+        )
+        mean_exp, mean_ctrl, n_exp, n_ctrl, selected_n_exp, selected_n_ctrl = (
+            _aggregate_records(
+                records,
+                lower,
+                upper,
+                min_segments=min_segments,
+                top_fraction=top_fraction,
+            )
+        )
+        requested = (
+            np.asarray(resolved_edges, dtype=float)
+            if pair_mode
+            else _parse_edges(opts)[0]
+        )
 
     n_videos = len(vas_ok)
     try:
@@ -633,9 +795,6 @@ def export_return_leg_tortuosity_excursion_bin_sli_bundle(vas, opts, gls, out_fn
         dtype=str,
     )
 
-    requested = (
-        np.asarray(resolved_edges, dtype=float) if pair_mode else _parse_edges(opts)[0]
-    )
     payload = dict(
         sli=np.asarray(sli, dtype=float),
         sli_ts=np.asarray(sli_ts, dtype=float),
@@ -669,8 +828,13 @@ def export_return_leg_tortuosity_excursion_bin_sli_bundle(vas, opts, gls, out_fn
         return_leg_tortuosity_excursion_bin_aggregation=np.asarray(
             "mean" if top_fraction == 1.0 else "top_fraction_mean"
         ),
+        return_leg_tortuosity_excursion_bin_binning_mode=np.asarray(binning_mode),
         return_leg_tortuosity_excursion_bin_edges_mm=np.asarray(
             resolved_edges, dtype=float
+        ),
+        return_leg_tortuosity_excursion_bin_percentile_edges=np.asarray(
+            requested if binning_mode == "per_fly_quartile" else [],
+            dtype=float,
         ),
         return_leg_tortuosity_excursion_bin_requested_edges_mm=requested,
         return_leg_tortuosity_excursion_bin_pair_lower_mm=np.asarray(
@@ -765,8 +929,11 @@ def export_return_leg_tortuosity_excursion_bin_sli_bundle(vas, opts, gls, out_fn
         return_leg_tortuosity_excursion_bin_window_summary=window_summary,
         return_leg_tortuosity_excursion_bin_description=np.asarray(
             (
-                "Mean return-leg tortuosity of all between-reward trajectories "
-                "binned by maximum radial distance"
+                "Mean return-leg tortuosity in four per-fly equal-count maximum-"
+                "distance quartiles"
+                if binning_mode == "per_fly_quartile"
+                else "Mean return-leg tortuosity of all between-reward "
+                "trajectories binned by maximum radial distance"
                 if top_fraction == 1.0
                 else f"Mean of the top {100.0 * top_fraction:g}% return-leg "
                 "tortuosity values per fly and maximum-distance bin"
@@ -783,6 +950,14 @@ def export_return_leg_tortuosity_excursion_bin_sli_bundle(vas, opts, gls, out_fn
             vas_ok, opts, prefix="exp_target_sync_bucket_filter"
         ),
     )
+    if distance_stats is not None:
+        for stat, role_arrays in distance_stats.items():
+            payload[
+                f"return_leg_tortuosity_excursion_bin_distance_{stat}_mm_exp"
+            ] = role_arrays[0]
+            payload[
+                f"return_leg_tortuosity_excursion_bin_distance_{stat}_mm_ctrl"
+            ] = role_arrays[1]
 
     os.makedirs(os.path.dirname(out_fn) or ".", exist_ok=True)
     validate_sli_bundle(payload, path=out_fn)

--- a/src/exporting/return_leg_tortuosity_excursion_bin_sli_bundle.py
+++ b/src/exporting/return_leg_tortuosity_excursion_bin_sli_bundle.py
@@ -25,7 +25,11 @@ from src.plotting.between_reward_segment_binning import (
     sync_bucket_window,
     wall_contact_mask,
 )
-from src.plotting.between_reward_segment_metrics import tortuosity_metric_masked
+from src.plotting.between_reward_segment_metrics import (
+    dist_traveled_mm_masked,
+    max_radial_distance_mm_masked,
+    tortuosity_metric_masked,
+)
 from src.utils.parsers import parse_distances, parse_training_selector
 
 
@@ -175,6 +179,91 @@ def _return_leg_start_mode(opts) -> str:
     return mode
 
 
+def _exclude_wall_contact_frames(opts) -> bool:
+    return bool(
+        getattr(
+            opts,
+            "return_leg_tortuosity_excursion_bin_exclude_wall_contact_frames",
+            False,
+        )
+    )
+
+
+def _combined_exclusion_mask(
+    nonwalk_mask,
+    wall_mask,
+    *,
+    exclude_nonwalk: bool,
+    exclude_wall_frames: bool,
+):
+    masks = []
+    if exclude_nonwalk and nonwalk_mask is not None:
+        masks.append(np.asarray(nonwalk_mask, dtype=bool))
+    if exclude_wall_frames and wall_mask is not None:
+        masks.append(np.asarray(wall_mask, dtype=bool))
+    if not masks:
+        return None
+    n_frames = min(len(mask) for mask in masks)
+    combined = np.zeros((n_frames,), dtype=bool)
+    for mask in masks:
+        combined |= mask[:n_frames]
+    return combined
+
+
+def _off_wall_path_over_max_radius(
+    *,
+    traj,
+    s: int,
+    e: int,
+    fi: int,
+    wall_mask,
+    nonwalk_mask,
+    exclude_nonwalk: bool,
+    px_per_mm: float,
+    reward_center_xy: tuple[float, float],
+    min_keep_frames: int,
+    min_radius_mm: float,
+) -> float:
+    combined_mask = _combined_exclusion_mask(
+        nonwalk_mask,
+        wall_mask,
+        exclude_nonwalk=exclude_nonwalk,
+        exclude_wall_frames=True,
+    )
+    path_mm = dist_traveled_mm_masked(
+        traj=traj,
+        s=s,
+        e=e,
+        fi=fi,
+        nonwalk_mask=combined_mask,
+        exclude_nonwalk=True,
+        px_per_mm=px_per_mm,
+        min_keep_frames=min_keep_frames,
+    )
+    if not np.isfinite(path_mm) or path_mm <= 0:
+        return np.nan
+
+    radius_mm = max_radial_distance_mm_masked(
+        traj=traj,
+        s=s,
+        e=e,
+        fi=fi,
+        nonwalk_mask=nonwalk_mask,
+        exclude_nonwalk=exclude_nonwalk,
+        px_per_mm=px_per_mm,
+        center_xy=reward_center_xy,
+        min_keep_frames=min_keep_frames,
+    )
+    min_radius = float(min_radius_mm or 0.0)
+    if (
+        not np.isfinite(radius_mm)
+        or radius_mm <= 0
+        or radius_mm <= min_radius
+    ):
+        return np.nan
+    return float(path_mm / radius_mm)
+
+
 def _binning_mode(opts) -> str:
     mode = str(
         getattr(
@@ -284,14 +373,26 @@ def _collect_records(
     exclude_wall = bool(
         getattr(opts, "return_leg_tortuosity_excursion_bin_exclude_wall_contact", False)
     )
+    exclude_wall_frames = _exclude_wall_contact_frames(opts)
     return_start_mode = _return_leg_start_mode(opts)
-    if exclude_wall and return_start_mode == "post_last_wall_max":
-        raise ValueError(
-            "--return-leg-tortuosity-excursion-bin-exclude-wall-contact cannot be "
-            "combined with --return-leg-tortuosity-excursion-bin-return-start-mode "
-            "post_last_wall_max. Use one wall treatment at a time."
+    active_wall_modes = sum(
+        (
+            exclude_wall,
+            exclude_wall_frames,
+            return_start_mode == "post_last_wall_max",
         )
-    needs_wall_mask = exclude_wall or return_start_mode == "post_last_wall_max"
+    )
+    if active_wall_modes > 1:
+        raise ValueError(
+            "Whole-episode wall exclusion, frame-level wall exclusion, and "
+            "post-last-wall return starts are mutually exclusive. Use one wall "
+            "treatment at a time."
+        )
+    needs_wall_mask = (
+        exclude_wall
+        or exclude_wall_frames
+        or return_start_mode == "post_last_wall_max"
+    )
     exclude_nonwalk = bool(
         getattr(
             opts,
@@ -324,6 +425,12 @@ def _collect_records(
         )
         or "path_over_max_radius"
     )
+    if exclude_wall_frames and metric_mode != "path_over_max_radius":
+        raise ValueError(
+            "--return-leg-tortuosity-excursion-bin-exclude-wall-contact-frames "
+            "currently requires --return-leg-tortuosity-excursion-bin-metric-mode "
+            "path_over_max_radius."
+        )
     debug = bool(getattr(opts, "return_leg_tortuosity_excursion_bin_debug", False))
 
     records = [[[] for _ in range(2)] for _ in vas]
@@ -359,6 +466,11 @@ def _collect_records(
                 if n_buckets <= 0:
                     continue
                 n_frames = int(max(1, n_buckets * df))
+                mask_stop = min(
+                    min(len(traj.x), len(traj.y)),
+                    max(int(fi + n_frames), int(trn.stop)),
+                )
+                mask_n_frames = int(max(1, mask_stop - fi))
                 windows_meta[vi].append(
                     {
                         "role": "exp" if role_idx == 0 else "ctrl",
@@ -374,12 +486,19 @@ def _collect_records(
                     va,
                     f,
                     fi=fi,
-                    n_frames=n_frames,
+                    n_frames=mask_n_frames,
                     log_tag="return_leg_tortuosity_excursion_bin",
                     warned_missing_wc=warned_missing_wc,
                     enabled=needs_wall_mask,
                 )
-                nonwalk = _nonwalk_mask(opts, traj, fi=fi, n_frames=n_frames)
+                if needs_wall_mask and wc is None:
+                    continue
+                nonwalk = _nonwalk_mask(
+                    opts,
+                    traj,
+                    fi=fi,
+                    n_frames=mask_n_frames,
+                )
                 pxmm = _px_per_mm(va, traj)
                 if pxmm is None:
                     continue
@@ -435,20 +554,35 @@ def _collect_records(
                         metric_start = max(s, int(max_i))
                     if e <= metric_start:
                         continue
-                    tortuosity = tortuosity_metric_masked(
-                        traj=traj,
-                        s=metric_start,
-                        e=e,
-                        fi=fi,
-                        nonwalk_mask=nonwalk,
-                        exclude_nonwalk=exclude_nonwalk,
-                        px_per_mm=pxmm,
-                        mode=metric_mode,
-                        reward_center_xy=reward_center_xy,
-                        min_keep_frames=min_walk_frames,
-                        min_displacement_mm=min_displacement_mm,
-                        min_radius_mm=min_radius_mm,
-                    )
+                    if exclude_wall_frames:
+                        tortuosity = _off_wall_path_over_max_radius(
+                            traj=traj,
+                            s=metric_start,
+                            e=e,
+                            fi=fi,
+                            wall_mask=wc,
+                            nonwalk_mask=nonwalk,
+                            exclude_nonwalk=exclude_nonwalk,
+                            px_per_mm=pxmm,
+                            reward_center_xy=reward_center_xy,
+                            min_keep_frames=min_walk_frames,
+                            min_radius_mm=min_radius_mm,
+                        )
+                    else:
+                        tortuosity = tortuosity_metric_masked(
+                            traj=traj,
+                            s=metric_start,
+                            e=e,
+                            fi=fi,
+                            nonwalk_mask=nonwalk,
+                            exclude_nonwalk=exclude_nonwalk,
+                            px_per_mm=pxmm,
+                            mode=metric_mode,
+                            reward_center_xy=reward_center_xy,
+                            min_keep_frames=min_walk_frames,
+                            min_displacement_mm=min_displacement_mm,
+                            min_radius_mm=min_radius_mm,
+                        )
                     if np.isfinite(tortuosity):
                         records[vi][role_idx].append(
                             (float(radial_mm), float(tortuosity))
@@ -475,6 +609,9 @@ def _collect_records(
                                     "reward_center_xy": reward_center_xy,
                                     "reward_radius_mm": float(reward_radius_mm),
                                     "exclude_nonwalk": bool(exclude_nonwalk),
+                                    "exclude_wall_frames": bool(
+                                        exclude_wall_frames
+                                    ),
                                     "min_walk_frames": int(min_walk_frames),
                                     "metric_mode": metric_mode,
                                     "return_start_mode": return_start_mode,
@@ -870,6 +1007,10 @@ def export_return_leg_tortuosity_excursion_bin_sli_bundle(vas, opts, gls, out_fn
             ),
             dtype=bool,
         ),
+        return_leg_tortuosity_excursion_bin_exclude_wall_contact_frames=np.array(
+            _exclude_wall_contact_frames(opts),
+            dtype=bool,
+        ),
         return_leg_tortuosity_excursion_bin_exclude_nonwalking_frames=np.array(
             bool(
                 getattr(
@@ -943,6 +1084,11 @@ def export_return_leg_tortuosity_excursion_bin_sli_bundle(vas, opts, gls, out_fn
                 if return_start_mode == "global_max"
                 else "; return leg starts at the maximum distance after the "
                 "episode's final wall contact"
+            )
+            + (
+                "; path distance excludes steps touching wall-contact frames"
+                if _exclude_wall_contact_frames(opts)
+                else ""
             )
         ),
         btw_rwd_sync_bucket_min_trajectories=np.array(min_segments, dtype=int),

--- a/src/exporting/return_leg_tortuosity_excursion_bin_sli_bundle.py
+++ b/src/exporting/return_leg_tortuosity_excursion_bin_sli_bundle.py
@@ -239,6 +239,7 @@ def _collect_records(
     skip_first: int,
     keep_first: int,
     legacy_distances: bool,
+    episode_callback=None,
 ):
     exclude_wall = bool(
         getattr(opts, "return_leg_tortuosity_excursion_bin_exclude_wall_contact", False)
@@ -412,6 +413,34 @@ def _collect_records(
                         records[vi][role_idx].append(
                             (float(radial_mm), float(tortuosity))
                         )
+                        if episode_callback is not None:
+                            episode_callback(
+                                {
+                                    "va": va,
+                                    "video_index": int(vi),
+                                    "role_idx": int(role_idx),
+                                    "trajectory_index": int(f),
+                                    "traj": traj,
+                                    "training_idx": int(t_idx),
+                                    "segment_start": int(s),
+                                    "segment_stop": int(e),
+                                    "global_max_frame": int(max_i),
+                                    "metric_start": int(metric_start),
+                                    "radial_mm": float(radial_mm),
+                                    "tortuosity": float(tortuosity),
+                                    "window_start": int(fi),
+                                    "wall_mask": wc,
+                                    "nonwalk_mask": nonwalk,
+                                    "px_per_mm": float(pxmm),
+                                    "reward_center_xy": reward_center_xy,
+                                    "reward_radius_mm": float(reward_radius_mm),
+                                    "exclude_nonwalk": bool(exclude_nonwalk),
+                                    "min_walk_frames": int(min_walk_frames),
+                                    "metric_mode": metric_mode,
+                                    "return_start_mode": return_start_mode,
+                                    "legacy_distances": bool(legacy_distances),
+                                }
+                            )
 
         if debug:
             print(

--- a/src/exporting/return_leg_tortuosity_excursion_bin_sli_bundle.py
+++ b/src/exporting/return_leg_tortuosity_excursion_bin_sli_bundle.py
@@ -158,6 +158,79 @@ def _nonwalk_mask(opts, traj, *, fi: int, n_frames: int):
     return ~window
 
 
+def _return_leg_start_mode(opts) -> str:
+    mode = str(
+        getattr(
+            opts,
+            "return_leg_tortuosity_excursion_bin_return_start_mode",
+            "global_max",
+        )
+        or "global_max"
+    ).strip().lower()
+    if mode not in {"global_max", "post_last_wall_max"}:
+        raise ValueError(
+            "Unknown return-leg start mode "
+            f"{mode!r}; expected 'global_max' or 'post_last_wall_max'."
+        )
+    return mode
+
+
+def _post_last_wall_max_frame(
+    *,
+    traj,
+    s: int,
+    e: int,
+    fi: int,
+    wc,
+    nonwalk_mask,
+    exclude_nonwalk: bool,
+    fallback_max_i: int,
+    reward_center_xy: tuple[float, float],
+) -> int | None:
+    if wc is None:
+        return None
+
+    s = int(s)
+    e = int(e)
+    if e <= s:
+        return None
+
+    wc_start = max(0, min(s - int(fi), len(wc)))
+    wc_stop = max(0, min(e - int(fi), len(wc)))
+    wall_idx = np.flatnonzero(np.asarray(wc[wc_start:wc_stop], dtype=bool))
+    if wall_idx.size == 0:
+        return max(s, int(fallback_max_i))
+
+    search_start = int(fi) + wc_start + int(wall_idx[-1]) + 1
+    if search_start >= e:
+        return None
+
+    frames = np.arange(search_start, e, dtype=int)
+    max_frame = min(len(traj.x), len(traj.y))
+    frames = frames[(frames >= 0) & (frames < max_frame)]
+    if frames.size == 0:
+        return None
+
+    xs = np.asarray(traj.x[frames], dtype=float)
+    ys = np.asarray(traj.y[frames], dtype=float)
+    keep = np.isfinite(xs) & np.isfinite(ys)
+    if exclude_nonwalk and nonwalk_mask is not None:
+        offsets = frames - int(fi)
+        in_mask = (offsets >= 0) & (offsets < len(nonwalk_mask))
+        walking = np.zeros(frames.size, dtype=bool)
+        walking[in_mask] = ~np.asarray(nonwalk_mask, dtype=bool)[offsets[in_mask]]
+        keep &= walking
+    if not np.any(keep):
+        return None
+
+    kept_frames = frames[keep]
+    kept_x = xs[keep]
+    kept_y = ys[keep]
+    cx, cy = reward_center_xy
+    radial_sq = (kept_x - float(cx)) ** 2 + (kept_y - float(cy)) ** 2
+    return int(kept_frames[int(np.argmax(radial_sq))])
+
+
 def _collect_records(
     vas,
     opts,
@@ -170,6 +243,14 @@ def _collect_records(
     exclude_wall = bool(
         getattr(opts, "return_leg_tortuosity_excursion_bin_exclude_wall_contact", False)
     )
+    return_start_mode = _return_leg_start_mode(opts)
+    if exclude_wall and return_start_mode == "post_last_wall_max":
+        raise ValueError(
+            "--return-leg-tortuosity-excursion-bin-exclude-wall-contact cannot be "
+            "combined with --return-leg-tortuosity-excursion-bin-return-start-mode "
+            "post_last_wall_max. Use one wall treatment at a time."
+        )
+    needs_wall_mask = exclude_wall or return_start_mode == "post_last_wall_max"
     exclude_nonwalk = bool(
         getattr(
             opts,
@@ -255,7 +336,7 @@ def _collect_records(
                     n_frames=n_frames,
                     log_tag="return_leg_tortuosity_excursion_bin",
                     warned_missing_wc=warned_missing_wc,
-                    enabled=exclude_wall,
+                    enabled=needs_wall_mask,
                 )
                 nonwalk = _nonwalk_mask(opts, traj, fi=fi, n_frames=n_frames)
                 pxmm = _px_per_mm(va, traj)
@@ -295,7 +376,22 @@ def _collect_records(
                     if legacy_distances:
                         radial_mm = max(0.0, radial_mm - reward_radius_mm)
 
-                    metric_start = max(s, int(max_i))
+                    if return_start_mode == "post_last_wall_max":
+                        metric_start = _post_last_wall_max_frame(
+                            traj=traj,
+                            s=s,
+                            e=e,
+                            fi=fi,
+                            wc=wc,
+                            nonwalk_mask=nonwalk,
+                            exclude_nonwalk=exclude_nonwalk,
+                            fallback_max_i=int(max_i),
+                            reward_center_xy=reward_center_xy,
+                        )
+                        if metric_start is None:
+                            continue
+                    else:
+                        metric_start = max(s, int(max_i))
                     if e <= metric_start:
                         continue
                     tortuosity = tortuosity_metric_masked(
@@ -440,6 +536,7 @@ def export_return_leg_tortuosity_excursion_bin_sli_bundle(vas, opts, gls, out_fn
         return
 
     pair_spec = _parse_pairs(opts)
+    return_start_mode = _return_leg_start_mode(opts)
     legacy_distances = pair_spec[2] if pair_spec is not None else _parse_edges(opts)[1]
     selected_trainings = _selected_training_indices(vas_ok, opts)
     skip_first, keep_first = _effective_windowing(opts)
@@ -633,6 +730,9 @@ def export_return_leg_tortuosity_excursion_bin_sli_bundle(vas, opts, gls, out_fn
                 )
             )
         ),
+        return_leg_tortuosity_excursion_bin_return_start_mode=np.asarray(
+            return_start_mode
+        ),
         return_leg_tortuosity_excursion_bin_window_summary=window_summary,
         return_leg_tortuosity_excursion_bin_description=np.asarray(
             (
@@ -641,6 +741,12 @@ def export_return_leg_tortuosity_excursion_bin_sli_bundle(vas, opts, gls, out_fn
                 if top_fraction == 1.0
                 else f"Mean of the top {100.0 * top_fraction:g}% return-leg "
                 "tortuosity values per fly and maximum-distance bin"
+            )
+            + (
+                "; return leg starts at the full-episode maximum distance"
+                if return_start_mode == "global_max"
+                else "; return leg starts at the maximum distance after the "
+                "episode's final wall contact"
             )
         ),
         btw_rwd_sync_bucket_min_trajectories=np.array(min_segments, dtype=int),

--- a/src/exporting/return_leg_tortuosity_excursion_bin_sli_bundle.py
+++ b/src/exporting/return_leg_tortuosity_excursion_bin_sli_bundle.py
@@ -1,0 +1,602 @@
+from __future__ import annotations
+
+import os
+
+import numpy as np
+
+from src.analysis.between_reward_filters import (
+    mask_metric_by_min_between_reward_trajectories,
+    min_between_reward_sync_bucket_trajectories,
+)
+from src.analysis.sync_bucket_presence_filters import (
+    exp_target_sync_bucket_eligibility_mask,
+    exp_target_sync_bucket_filter_payload,
+    mask_by_exp_target_sync_bucket_filter,
+)
+from src.analysis.sli_bundle_utils import (
+    validate_return_leg_tortuosity_excursion_bin_bundle,
+    validate_sli_bundle,
+)
+from src.exporting.com_sli_bundle import (
+    _compute_sli_scalar_and_timeseries_from_rpid,
+    _safe_group_label,
+)
+from src.plotting.between_reward_segment_binning import (
+    sync_bucket_window,
+    wall_contact_mask,
+)
+from src.plotting.between_reward_segment_metrics import tortuosity_metric_masked
+from src.utils.parsers import parse_distances, parse_training_selector
+
+
+def _selected_training_indices(vas, opts) -> list[int]:
+    n_trn = len(getattr(vas[0], "trns", []) or []) if vas else 0
+    raw = getattr(opts, "return_leg_tortuosity_excursion_bin_trainings", None)
+    if not raw:
+        return list(range(n_trn))
+
+    selected = sorted(
+        {
+            int(idx1) - 1
+            for idx1 in parse_training_selector(raw)
+            if 0 <= int(idx1) - 1 < n_trn
+        }
+    )
+    if selected:
+        return selected
+    print(
+        "[export] WARNING: --return-leg-tortuosity-excursion-bin-trainings "
+        "selected no valid trainings; falling back to all trainings."
+    )
+    return list(range(n_trn))
+
+
+def _parse_edges(opts) -> tuple[np.ndarray, bool]:
+    raw_new = getattr(opts, "return_leg_tortuosity_excursion_bin_radii_mm", None)
+    raw_old = getattr(opts, "return_leg_tortuosity_excursion_bin_edges_mm", None)
+    legacy = not (raw_new is not None and str(raw_new).strip())
+    raw = raw_old if legacy else raw_new
+    if raw is None or not str(raw).strip():
+        raise ValueError(
+            "Provide --return-leg-tortuosity-excursion-bin-radii-mm, "
+            "--return-leg-tortuosity-excursion-bin-edges-mm, or a pair option."
+        )
+
+    edges = np.asarray(parse_distances(str(raw)), dtype=float)
+    if edges.size < 2:
+        raise ValueError("Return-leg tortuosity bin edges require at least two values.")
+    if np.any(np.isnan(edges)) or np.any(np.isneginf(edges)):
+        raise ValueError("Return-leg tortuosity bin edges must be numeric.")
+    if np.any(np.isposinf(edges[:-1])):
+        raise ValueError("'inf' may only be the final return-leg tortuosity bin edge.")
+    if np.any(np.diff(edges) <= 0):
+        raise ValueError("Return-leg tortuosity bin edges must be strictly increasing.")
+    return edges, legacy
+
+
+def _parse_pairs(opts) -> tuple[np.ndarray, np.ndarray, bool] | None:
+    raw_new = getattr(opts, "return_leg_tortuosity_excursion_bin_radius_pairs_mm", None)
+    raw_old = getattr(opts, "return_leg_tortuosity_excursion_bin_pairs_mm", None)
+    legacy = not (raw_new is not None and str(raw_new).strip())
+    raw = raw_old if legacy else raw_new
+    if raw is None or not str(raw).strip():
+        return None
+
+    lower: list[float] = []
+    upper: list[float] = []
+    for part in str(raw).split(","):
+        item = part.strip()
+        if not item:
+            continue
+        if ":" not in item:
+            raise ValueError(
+                "Return-leg tortuosity pair bins use lo:hi format, "
+                "e.g. '3:5,8:10,13:15'."
+            )
+        lo_raw, hi_raw = item.split(":", 1)
+        lo = float(parse_distances(lo_raw.strip())[0])
+        hi = float(parse_distances(hi_raw.strip())[0])
+        if not np.isfinite(lo) or not np.isfinite(hi):
+            raise ValueError("Return-leg tortuosity pair bounds must be finite.")
+        if lo < 0 or hi <= lo:
+            raise ValueError(
+                "Each return-leg tortuosity pair requires 0 <= lower < upper."
+            )
+        lower.append(lo)
+        upper.append(hi)
+
+    if not lower:
+        raise ValueError("At least one return-leg tortuosity pair bin is required.")
+    return np.asarray(lower, float), np.asarray(upper, float), legacy
+
+
+def _effective_windowing(opts) -> tuple[int, int]:
+    raw_skip = getattr(
+        opts, "return_leg_tortuosity_excursion_bin_skip_first_sync_buckets", None
+    )
+    raw_keep = getattr(
+        opts, "return_leg_tortuosity_excursion_bin_keep_first_sync_buckets", None
+    )
+    skip = getattr(opts, "skip_first_sync_buckets", 0) if raw_skip is None else raw_skip
+    keep = getattr(opts, "keep_first_sync_buckets", 0) if raw_keep is None else raw_keep
+    return max(0, int(skip or 0)), max(0, int(keep or 0))
+
+
+def _px_per_mm(va, traj) -> float | None:
+    for get_value in (
+        lambda: float(traj.pxPerMmFloor * va.xf.fctr),
+        lambda: float(va.xf.fctr * va.ct.pxPerMmFloor()),
+    ):
+        try:
+            value = get_value()
+        except Exception:
+            continue
+        if np.isfinite(value) and value > 0:
+            return value
+    return None
+
+
+def _nonwalk_mask(opts, traj, *, fi: int, n_frames: int):
+    enabled = bool(
+        getattr(
+            opts,
+            "return_leg_tortuosity_excursion_bin_exclude_nonwalking_frames",
+            False,
+        )
+    )
+    walking = getattr(traj, "walking", None)
+    if not enabled or walking is None:
+        return None
+
+    s0 = max(0, min(int(fi), len(walking)))
+    e0 = max(0, min(int(fi + n_frames), len(walking)))
+    window = np.zeros((int(max(1, n_frames)),), dtype=bool)
+    if e0 > s0:
+        values = np.asarray(walking[s0:e0], dtype=float)
+        values = np.where(np.isfinite(values), values, 0.0)
+        window[: len(values)] = values > 0
+    return ~window
+
+
+def _collect_records(
+    vas,
+    opts,
+    *,
+    selected_trainings: list[int],
+    skip_first: int,
+    keep_first: int,
+    legacy_distances: bool,
+):
+    exclude_wall = bool(
+        getattr(opts, "return_leg_tortuosity_excursion_bin_exclude_wall_contact", False)
+    )
+    exclude_nonwalk = bool(
+        getattr(
+            opts,
+            "return_leg_tortuosity_excursion_bin_exclude_nonwalking_frames",
+            False,
+        )
+    )
+    min_walk_frames = max(
+        2,
+        int(
+            getattr(opts, "return_leg_tortuosity_excursion_bin_min_walk_frames", 2) or 2
+        ),
+    )
+    min_radius_mm = float(
+        getattr(opts, "return_leg_tortuosity_excursion_bin_min_radius_mm", 0.0) or 0.0
+    )
+    min_displacement_mm = float(
+        getattr(
+            opts,
+            "return_leg_tortuosity_excursion_bin_min_displacement_mm",
+            0.0,
+        )
+        or 0.0
+    )
+    metric_mode = str(
+        getattr(
+            opts,
+            "return_leg_tortuosity_excursion_bin_metric_mode",
+            "path_over_max_radius",
+        )
+        or "path_over_max_radius"
+    )
+    debug = bool(getattr(opts, "return_leg_tortuosity_excursion_bin_debug", False))
+
+    records = [[[] for _ in range(2)] for _ in vas]
+    windows_meta = [[] for _ in vas]
+    warned_missing_wc = [False]
+
+    for vi, va in enumerate(vas):
+        for role_idx, f in enumerate((0, 1)):
+            if f >= len(getattr(va, "trx", [])):
+                continue
+            if role_idx == 1 and getattr(va, "noyc", False):
+                continue
+            traj = va.trx[f]
+            if traj is None or traj.bad():
+                continue
+
+            for t_idx in selected_trainings:
+                if t_idx >= len(getattr(va, "trns", [])):
+                    continue
+                trn = va.trns[t_idx]
+                if trn is None or not trn.isCircle():
+                    continue
+
+                fi, df, n_buckets, complete = sync_bucket_window(
+                    va,
+                    trn,
+                    t_idx=t_idx,
+                    f=f,
+                    skip_first=skip_first,
+                    keep_first=keep_first,
+                    use_exclusion_mask=False,
+                )
+                if n_buckets <= 0:
+                    continue
+                n_frames = int(max(1, n_buckets * df))
+                windows_meta[vi].append(
+                    {
+                        "role": "exp" if role_idx == 0 else "ctrl",
+                        "training_idx": int(t_idx),
+                        "training_name": trn.name(),
+                        "start": int(fi),
+                        "stop": int(fi + n_frames),
+                    }
+                )
+
+                wc = wall_contact_mask(
+                    opts,
+                    va,
+                    f,
+                    fi=fi,
+                    n_frames=n_frames,
+                    log_tag="return_leg_tortuosity_excursion_bin",
+                    warned_missing_wc=warned_missing_wc,
+                    enabled=exclude_wall,
+                )
+                nonwalk = _nonwalk_mask(opts, traj, fi=fi, n_frames=n_frames)
+                pxmm = _px_per_mm(va, traj)
+                if pxmm is None:
+                    continue
+                try:
+                    cx, cy, radius_px = trn.circles(f)[0]
+                except Exception:
+                    continue
+                reward_center_xy = (float(cx), float(cy))
+                reward_radius_mm = float(radius_px) / pxmm
+
+                for seg in va._iter_between_reward_segment_com(
+                    trn,
+                    f,
+                    fi=fi,
+                    df=df,
+                    n_buckets=n_buckets,
+                    complete=complete,
+                    relative_to_reward=True,
+                    per_segment_min_meddist_mm=0.0,
+                    exclude_wall=exclude_wall,
+                    wc=wc,
+                    exclude_nonwalk=exclude_nonwalk,
+                    nonwalk_mask=nonwalk,
+                    min_walk_frames=min_walk_frames,
+                    dist_stats=("max",),
+                    debug=False,
+                    yield_skips=False,
+                ):
+                    s = int(getattr(seg, "s", -1))
+                    e = int(getattr(seg, "e", -1))
+                    max_i = getattr(seg, "max_d_i", None)
+                    radial_mm = float(getattr(seg, "max_d_mm", np.nan))
+                    if max_i is None or e <= s + 1 or not np.isfinite(radial_mm):
+                        continue
+                    if legacy_distances:
+                        radial_mm = max(0.0, radial_mm - reward_radius_mm)
+
+                    metric_start = max(s, int(max_i))
+                    if e <= metric_start:
+                        continue
+                    tortuosity = tortuosity_metric_masked(
+                        traj=traj,
+                        s=metric_start,
+                        e=e,
+                        fi=fi,
+                        nonwalk_mask=nonwalk,
+                        exclude_nonwalk=exclude_nonwalk,
+                        px_per_mm=pxmm,
+                        mode=metric_mode,
+                        reward_center_xy=reward_center_xy,
+                        min_keep_frames=min_walk_frames,
+                        min_displacement_mm=min_displacement_mm,
+                        min_radius_mm=min_radius_mm,
+                    )
+                    if np.isfinite(tortuosity):
+                        records[vi][role_idx].append(
+                            (float(radial_mm), float(tortuosity))
+                        )
+
+        if debug:
+            print(
+                "[return_leg_tortuosity_excursion_bin] "
+                f"{getattr(va, 'fn', f'va_{vi}')}: "
+                f"exp_segments={len(records[vi][0])}, "
+                f"ctrl_segments={len(records[vi][1])}"
+            )
+    return records, windows_meta
+
+
+def _resolved_bins(
+    opts, records
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, bool, bool]:
+    pair_spec = _parse_pairs(opts)
+    if pair_spec is not None:
+        lower, upper, legacy = pair_spec
+        flattened = np.empty((2 * len(lower),), dtype=float)
+        flattened[0::2] = lower
+        flattened[1::2] = upper
+        return lower, upper, flattened, True, legacy
+
+    requested, legacy = _parse_edges(opts)
+    resolved = requested.copy()
+    open_ended = bool(np.isposinf(resolved[-1]))
+    if open_ended:
+        observed = [
+            radial
+            for video_roles in records
+            for role_records in video_roles
+            for radial, _tortuosity in role_records
+            if np.isfinite(radial)
+        ]
+        max_observed = float(np.max(observed)) if observed else np.nan
+        if not np.isfinite(max_observed) or max_observed <= float(resolved[-2]):
+            raise ValueError(
+                "The open-ended return-leg tortuosity bin has no observed value "
+                "above its lower edge."
+            )
+        resolved[-1] = max_observed
+    return resolved[:-1], resolved[1:], resolved, False, legacy
+
+
+def _aggregate_records(records, lower, upper, *, min_segments: int):
+    n_videos = len(records)
+    n_bins = len(lower)
+    means = [
+        np.full((n_videos, n_bins), np.nan, dtype=float),
+        np.full((n_videos, n_bins), np.nan, dtype=float),
+    ]
+    counts = [
+        np.zeros((n_videos, n_bins), dtype=int),
+        np.zeros((n_videos, n_bins), dtype=int),
+    ]
+
+    for vi, video_roles in enumerate(records):
+        for role_idx, role_records in enumerate(video_roles):
+            for bin_idx, (lo, hi) in enumerate(zip(lower, upper)):
+                values = np.asarray(
+                    [
+                        tort
+                        for radial, tort in role_records
+                        if float(lo) <= radial < float(hi)
+                    ],
+                    dtype=float,
+                )
+                counts[role_idx][vi, bin_idx] = int(values.size)
+                if values.size:
+                    means[role_idx][vi, bin_idx] = float(np.mean(values))
+            means[role_idx][vi] = mask_metric_by_min_between_reward_trajectories(
+                means[role_idx][vi],
+                counts[role_idx][vi],
+                max(1, int(min_segments)),
+            )
+    return means[0], means[1], counts[0], counts[1]
+
+
+def export_return_leg_tortuosity_excursion_bin_sli_bundle(vas, opts, gls, out_fn):
+    if not out_fn.lower().endswith(".npz"):
+        out_fn += ".npz"
+
+    vas_ok = [va for va in vas if not getattr(va, "_skipped", False)]
+    if not vas_ok:
+        print(f"[export] No non-skipped VideoAnalysis instances; not writing {out_fn}")
+        return
+
+    pair_spec = _parse_pairs(opts)
+    legacy_distances = pair_spec[2] if pair_spec is not None else _parse_edges(opts)[1]
+    selected_trainings = _selected_training_indices(vas_ok, opts)
+    skip_first, keep_first = _effective_windowing(opts)
+    records, windows_meta = _collect_records(
+        vas_ok,
+        opts,
+        selected_trainings=selected_trainings,
+        skip_first=skip_first,
+        keep_first=keep_first,
+        legacy_distances=legacy_distances,
+    )
+    lower, upper, resolved_edges, pair_mode, legacy_distances = _resolved_bins(
+        opts, records
+    )
+    min_segments = min_between_reward_sync_bucket_trajectories(opts)
+    mean_exp, mean_ctrl, n_exp, n_ctrl = _aggregate_records(
+        records, lower, upper, min_segments=min_segments
+    )
+
+    n_videos = len(vas_ok)
+    try:
+        sli, sli_ts = _compute_sli_scalar_and_timeseries_from_rpid(vas_ok, opts)
+    except Exception as exc:
+        print(
+            "[export] WARNING: failed to compute SLI for return-leg tortuosity "
+            f"excursion-bin bundle: {exc}"
+        )
+        sli = np.full((n_videos,), np.nan, dtype=float)
+        sli_ts = np.full(
+            (n_videos, len(getattr(vas_ok[0], "trns", []) or []), 0),
+            np.nan,
+        )
+
+    target_eligible = exp_target_sync_bucket_eligibility_mask(vas_ok, opts)
+    mean_exp = mask_by_exp_target_sync_bucket_filter(mean_exp, target_eligible)
+    sli = mask_by_exp_target_sync_bucket_filter(sli, target_eligible)
+    sli_ts = mask_by_exp_target_sync_bucket_filter(sli_ts, target_eligible)
+
+    try:
+        training_names = np.asarray([t.name() for t in vas_ok[0].trns], dtype=str)
+    except Exception:
+        training_names = np.asarray([], dtype=str)
+    video_fns = np.asarray([getattr(va, "fn", "") for va in vas_ok], dtype=str)
+    fly_ids = np.asarray([int(getattr(va, "f", -1)) for va in vas_ok], dtype=int)
+    video_ids = np.asarray(
+        [f"{fn}::f{fly_id}" for fn, fly_id in zip(video_fns, fly_ids)],
+        dtype=str,
+    )
+    window_summary = np.asarray(
+        [
+            "; ".join(
+                f"{w['role']} T{w['training_idx'] + 1} {w['training_name']}"
+                f"[{w['start']},{w['stop']})"
+                for w in video_windows
+            )
+            for video_windows in windows_meta
+        ],
+        dtype=str,
+    )
+
+    requested = (
+        np.asarray(resolved_edges, dtype=float) if pair_mode else _parse_edges(opts)[0]
+    )
+    payload = dict(
+        sli=np.asarray(sli, dtype=float),
+        sli_ts=np.asarray(sli_ts, dtype=float),
+        group_label=np.asarray(_safe_group_label(opts, gls)),
+        bucket_len_min=np.array(np.nan, dtype=float),
+        training_names=training_names,
+        video_ids=video_ids,
+        video_fns=video_fns,
+        fly_ids=fly_ids,
+        sli_training_idx=np.array(getattr(opts, "best_worst_trn", 1) - 1, dtype=int),
+        sli_use_training_mean=np.array(
+            bool(getattr(opts, "sli_use_training_mean", False))
+        ),
+        sli_select_skip_first_sync_buckets=np.array(
+            max(0, int(getattr(opts, "sli_select_skip_first_sync_buckets", 0) or 0)),
+            dtype=int,
+        ),
+        sli_select_keep_first_sync_buckets=np.array(
+            max(0, int(getattr(opts, "sli_select_keep_first_sync_buckets", 0) or 0)),
+            dtype=int,
+        ),
+        return_leg_tortuosity_excursion_bin_exp=mean_exp,
+        return_leg_tortuosity_excursion_bin_ctrl=mean_ctrl,
+        return_leg_tortuosity_excursion_binN_exp=n_exp,
+        return_leg_tortuosity_excursion_binN_ctrl=n_ctrl,
+        return_leg_tortuosity_excursion_bin_edges_mm=np.asarray(
+            resolved_edges, dtype=float
+        ),
+        return_leg_tortuosity_excursion_bin_requested_edges_mm=requested,
+        return_leg_tortuosity_excursion_bin_pair_lower_mm=np.asarray(
+            lower if pair_mode else [], dtype=float
+        ),
+        return_leg_tortuosity_excursion_bin_pair_upper_mm=np.asarray(
+            upper if pair_mode else [], dtype=float
+        ),
+        return_leg_tortuosity_excursion_bin_pair_mode=np.array(pair_mode, dtype=bool),
+        return_leg_tortuosity_excursion_bin_open_ended_upper_bin=np.array(
+            (not pair_mode) and bool(np.isposinf(requested[-1])),
+            dtype=bool,
+        ),
+        return_leg_tortuosity_excursion_bin_legacy_distance_from_circle=np.array(
+            legacy_distances, dtype=bool
+        ),
+        return_leg_tortuosity_excursion_bin_trainings=np.asarray(
+            selected_trainings, dtype=int
+        ),
+        return_leg_tortuosity_excursion_bin_skip_first_sync_buckets=np.array(
+            skip_first, dtype=int
+        ),
+        return_leg_tortuosity_excursion_bin_keep_first_sync_buckets=np.array(
+            keep_first, dtype=int
+        ),
+        return_leg_tortuosity_excursion_bin_exclude_wall_contact=np.array(
+            bool(
+                getattr(
+                    opts,
+                    "return_leg_tortuosity_excursion_bin_exclude_wall_contact",
+                    False,
+                )
+            ),
+            dtype=bool,
+        ),
+        return_leg_tortuosity_excursion_bin_exclude_nonwalking_frames=np.array(
+            bool(
+                getattr(
+                    opts,
+                    "return_leg_tortuosity_excursion_bin_exclude_nonwalking_frames",
+                    False,
+                )
+            ),
+            dtype=bool,
+        ),
+        return_leg_tortuosity_excursion_bin_min_walk_frames=np.array(
+            max(
+                2,
+                int(
+                    getattr(
+                        opts,
+                        "return_leg_tortuosity_excursion_bin_min_walk_frames",
+                        2,
+                    )
+                    or 2
+                ),
+            ),
+            dtype=int,
+        ),
+        return_leg_tortuosity_excursion_bin_min_radius_mm=np.array(
+            float(
+                getattr(
+                    opts,
+                    "return_leg_tortuosity_excursion_bin_min_radius_mm",
+                    0.0,
+                )
+                or 0.0
+            )
+        ),
+        return_leg_tortuosity_excursion_bin_min_displacement_mm=np.array(
+            float(
+                getattr(
+                    opts,
+                    "return_leg_tortuosity_excursion_bin_min_displacement_mm",
+                    0.0,
+                )
+                or 0.0
+            )
+        ),
+        return_leg_tortuosity_excursion_bin_metric_mode=np.asarray(
+            str(
+                getattr(
+                    opts,
+                    "return_leg_tortuosity_excursion_bin_metric_mode",
+                    "path_over_max_radius",
+                )
+            )
+        ),
+        return_leg_tortuosity_excursion_bin_window_summary=window_summary,
+        return_leg_tortuosity_excursion_bin_description=np.asarray(
+            "Mean return-leg tortuosity of between-reward trajectories binned by "
+            "maximum radial distance"
+        ),
+        btw_rwd_sync_bucket_min_trajectories=np.array(min_segments, dtype=int),
+        **exp_target_sync_bucket_filter_payload(
+            vas_ok, opts, prefix="exp_target_sync_bucket_filter"
+        ),
+    )
+
+    os.makedirs(os.path.dirname(out_fn) or ".", exist_ok=True)
+    validate_sli_bundle(payload, path=out_fn)
+    validate_return_leg_tortuosity_excursion_bin_bundle(payload, path=out_fn)
+    np.savez_compressed(out_fn, **payload)
+    print(
+        "[export] Wrote return-leg-tortuosity-excursion-bin+SLI bundle: "
+        f"{out_fn} (n={n_videos}, bins={len(lower)})"
+    )

--- a/src/exporting/return_leg_tortuosity_excursion_bin_sli_bundle.py
+++ b/src/exporting/return_leg_tortuosity_excursion_bin_sli_bundle.py
@@ -359,7 +359,28 @@ def _resolved_bins(
     return resolved[:-1], resolved[1:], resolved, False, legacy
 
 
-def _aggregate_records(records, lower, upper, *, min_segments: int):
+def _top_fraction(opts) -> float:
+    raw = getattr(
+        opts,
+        "return_leg_tortuosity_excursion_bin_top_fraction",
+        1.0,
+    )
+    fraction = 1.0 if raw is None else float(raw)
+    if not (0.0 < fraction <= 1.0):
+        raise ValueError(
+            "--return-leg-tortuosity-excursion-bin-top-fraction must be in (0, 1]."
+        )
+    return fraction
+
+
+def _aggregate_records(
+    records,
+    lower,
+    upper,
+    *,
+    min_segments: int,
+    top_fraction: float = 1.0,
+):
     n_videos = len(records)
     n_bins = len(lower)
     means = [
@@ -367,6 +388,10 @@ def _aggregate_records(records, lower, upper, *, min_segments: int):
         np.full((n_videos, n_bins), np.nan, dtype=float),
     ]
     counts = [
+        np.zeros((n_videos, n_bins), dtype=int),
+        np.zeros((n_videos, n_bins), dtype=int),
+    ]
+    selected_counts = [
         np.zeros((n_videos, n_bins), dtype=int),
         np.zeros((n_videos, n_bins), dtype=int),
     ]
@@ -384,13 +409,25 @@ def _aggregate_records(records, lower, upper, *, min_segments: int):
                 )
                 counts[role_idx][vi, bin_idx] = int(values.size)
                 if values.size:
-                    means[role_idx][vi, bin_idx] = float(np.mean(values))
+                    n_selected = max(
+                        1, int(np.ceil(float(top_fraction) * values.size))
+                    )
+                    selected = np.sort(values)[-n_selected:]
+                    selected_counts[role_idx][vi, bin_idx] = int(selected.size)
+                    means[role_idx][vi, bin_idx] = float(np.mean(selected))
             means[role_idx][vi] = mask_metric_by_min_between_reward_trajectories(
                 means[role_idx][vi],
                 counts[role_idx][vi],
                 max(1, int(min_segments)),
             )
-    return means[0], means[1], counts[0], counts[1]
+    return (
+        means[0],
+        means[1],
+        counts[0],
+        counts[1],
+        selected_counts[0],
+        selected_counts[1],
+    )
 
 
 def export_return_leg_tortuosity_excursion_bin_sli_bundle(vas, opts, gls, out_fn):
@@ -418,8 +455,15 @@ def export_return_leg_tortuosity_excursion_bin_sli_bundle(vas, opts, gls, out_fn
         opts, records
     )
     min_segments = min_between_reward_sync_bucket_trajectories(opts)
-    mean_exp, mean_ctrl, n_exp, n_ctrl = _aggregate_records(
-        records, lower, upper, min_segments=min_segments
+    top_fraction = _top_fraction(opts)
+    mean_exp, mean_ctrl, n_exp, n_ctrl, selected_n_exp, selected_n_ctrl = (
+        _aggregate_records(
+            records,
+            lower,
+            upper,
+            min_segments=min_segments,
+            top_fraction=top_fraction,
+        )
     )
 
     n_videos = len(vas_ok)
@@ -491,6 +535,14 @@ def export_return_leg_tortuosity_excursion_bin_sli_bundle(vas, opts, gls, out_fn
         return_leg_tortuosity_excursion_bin_ctrl=mean_ctrl,
         return_leg_tortuosity_excursion_binN_exp=n_exp,
         return_leg_tortuosity_excursion_binN_ctrl=n_ctrl,
+        return_leg_tortuosity_excursion_bin_selectedN_exp=selected_n_exp,
+        return_leg_tortuosity_excursion_bin_selectedN_ctrl=selected_n_ctrl,
+        return_leg_tortuosity_excursion_bin_top_fraction=np.array(
+            top_fraction, dtype=float
+        ),
+        return_leg_tortuosity_excursion_bin_aggregation=np.asarray(
+            "mean" if top_fraction == 1.0 else "top_fraction_mean"
+        ),
         return_leg_tortuosity_excursion_bin_edges_mm=np.asarray(
             resolved_edges, dtype=float
         ),
@@ -583,8 +635,13 @@ def export_return_leg_tortuosity_excursion_bin_sli_bundle(vas, opts, gls, out_fn
         ),
         return_leg_tortuosity_excursion_bin_window_summary=window_summary,
         return_leg_tortuosity_excursion_bin_description=np.asarray(
-            "Mean return-leg tortuosity of between-reward trajectories binned by "
-            "maximum radial distance"
+            (
+                "Mean return-leg tortuosity of all between-reward trajectories "
+                "binned by maximum radial distance"
+                if top_fraction == 1.0
+                else f"Mean of the top {100.0 * top_fraction:g}% return-leg "
+                "tortuosity values per fly and maximum-distance bin"
+            )
         ),
         btw_rwd_sync_bucket_min_trajectories=np.array(min_segments, dtype=int),
         **exp_target_sync_bucket_filter_payload(

--- a/src/plotting/event_chain_plotter.py
+++ b/src/plotting/event_chain_plotter.py
@@ -3989,6 +3989,9 @@ class EventChainPlotter:
         highlight_stop_frame: int | None = None,
         highlight_exclude_nonwalking: bool = False,
         highlight_label: str = "Highlighted segment",
+        comparison_line_start_xy: tuple[float, float] | None = None,
+        comparison_line_stop_xy: tuple[float, float] | None = None,
+        comparison_line_label: str = "Direct distance",
     ):
         """
         Plot exactly one between-reward trajectory segment for this fly, defined by
@@ -4044,6 +4047,10 @@ class EventChainPlotter:
             If True, highlight only steps whose endpoint frames are both walking.
         highlight_label : str
             Legend label for the highlighted interval.
+        comparison_line_start_xy, comparison_line_stop_xy : tuple | None
+            Optional endpoints for a dashed geometric reference segment.
+        comparison_line_label : str
+            Legend label for the geometric reference segment.
         """
 
         image_format = image_format or self.image_format
@@ -4387,6 +4394,24 @@ class EventChainPlotter:
                     linewidths=0.8,
                     zorder=6,
                     label=None if not label_pending else highlight_label,
+                )
+
+        if (
+            comparison_line_start_xy is not None
+            and comparison_line_stop_xy is not None
+        ):
+            x_start, y_start = (float(v) for v in comparison_line_start_xy)
+            x_stop, y_stop = (float(v) for v in comparison_line_stop_xy)
+            if np.all(np.isfinite([x_start, y_start, x_stop, y_stop])):
+                ax.plot(
+                    [x_start, x_stop],
+                    [y_start, y_stop],
+                    color="#2474a6",
+                    linewidth=2.0,
+                    linestyle="--",
+                    alpha=0.95,
+                    zorder=5,
+                    label=comparison_line_label,
                 )
 
         # Mark the two reward frames

--- a/src/plotting/event_chain_plotter.py
+++ b/src/plotting/event_chain_plotter.py
@@ -3988,6 +3988,8 @@ class EventChainPlotter:
         highlight_start_frame: int | None = None,
         highlight_stop_frame: int | None = None,
         highlight_exclude_nonwalking: bool = False,
+        highlight_excluded_frame_mask=None,
+        highlight_excluded_frame_mask_start: int = 0,
         highlight_label: str = "Highlighted segment",
         comparison_line_start_xy: tuple[float, float] | None = None,
         comparison_line_stop_xy: tuple[float, float] | None = None,
@@ -4045,6 +4047,10 @@ class EventChainPlotter:
             Optional absolute-frame half-open interval to draw over the full path.
         highlight_exclude_nonwalking : bool
             If True, highlight only steps whose endpoint frames are both walking.
+        highlight_excluded_frame_mask : array-like | None
+            Optional frame mask; highlighted steps touching a masked frame are omitted.
+        highlight_excluded_frame_mask_start : int
+            Absolute frame corresponding to mask index zero.
         highlight_label : str
             Legend label for the highlighted interval.
         comparison_line_start_xy, comparison_line_stop_xy : tuple | None
@@ -4355,7 +4361,15 @@ class EventChainPlotter:
             )
             label_pending = True
             walking = getattr(self.trj, "walking", None)
+            excluded = (
+                None
+                if highlight_excluded_frame_mask is None
+                else np.asarray(highlight_excluded_frame_mask, dtype=bool)
+            )
+            excluded_start = int(highlight_excluded_frame_mask_start)
             for i in range(hs, max(hs, hstop - 1)):
+                mask_i = i - excluded_start
+                mask_j = i + 1 - excluded_start
                 if (
                     not np.all(
                         np.isfinite(
@@ -4366,6 +4380,15 @@ class EventChainPlotter:
                         highlight_exclude_nonwalking
                         and walking is not None
                         and (not walking[i] or not walking[i + 1])
+                    )
+                    or (
+                        excluded is not None
+                        and (
+                            mask_i < 0
+                            or mask_j >= len(excluded)
+                            or excluded[mask_i]
+                            or excluded[mask_j]
+                        )
                     )
                 ):
                     continue

--- a/src/plotting/event_chain_plotter.py
+++ b/src/plotting/event_chain_plotter.py
@@ -3985,6 +3985,10 @@ class EventChainPlotter:
         annotation_location: str = "axes",
         annotation_wrap_width: int | None = None,
         minimal: bool = False,
+        highlight_start_frame: int | None = None,
+        highlight_stop_frame: int | None = None,
+        highlight_exclude_nonwalking: bool = False,
+        highlight_label: str = "Highlighted segment",
     ):
         """
         Plot exactly one between-reward trajectory segment for this fly, defined by
@@ -4034,6 +4038,12 @@ class EventChainPlotter:
         minimal : bool
             If True, render only the chamber boundary, sidewall contact shading,
             reward circle, trajectory path, and path endpoints.
+        highlight_start_frame, highlight_stop_frame : int | None
+            Optional absolute-frame half-open interval to draw over the full path.
+        highlight_exclude_nonwalking : bool
+            If True, highlight only steps whose endpoint frames are both walking.
+        highlight_label : str
+            Legend label for the highlighted interval.
         """
 
         image_format = image_format or self.image_format
@@ -4324,6 +4334,60 @@ class EventChainPlotter:
                 except Exception:
                     # if arrow helper isn't available / fails, just skip arrows
                     pass
+
+        if highlight_start_frame is not None:
+            hs = max(start_frame, sr, int(highlight_start_frame))
+            hstop = min(
+                end_frame + 1,
+                er + 1,
+                int(
+                    er + 1
+                    if highlight_stop_frame is None
+                    else highlight_stop_frame
+                ),
+            )
+            label_pending = True
+            walking = getattr(self.trj, "walking", None)
+            for i in range(hs, max(hs, hstop - 1)):
+                if (
+                    not np.all(
+                        np.isfinite(
+                            [self.x[i], self.y[i], self.x[i + 1], self.y[i + 1]]
+                        )
+                    )
+                    or (
+                        highlight_exclude_nonwalking
+                        and walking is not None
+                        and (not walking[i] or not walking[i + 1])
+                    )
+                ):
+                    continue
+                x_start = max(min(self.x[i], bottom_right[0]), top_left[0])
+                x_end = max(min(self.x[i + 1], bottom_right[0]), top_left[0])
+                ax.plot(
+                    [x_start, x_end],
+                    [self.y[i], self.y[i + 1]],
+                    color="#d65f0e",
+                    linewidth=2.8,
+                    alpha=0.98,
+                    zorder=5,
+                    solid_capstyle="round",
+                    label=highlight_label if label_pending else None,
+                )
+                label_pending = False
+            if 0 <= hs < n_frames and np.all(
+                np.isfinite([self.x[hs], self.y[hs]])
+            ):
+                ax.scatter(
+                    [self.x[hs]],
+                    [self.y[hs]],
+                    s=48,
+                    color="#d65f0e",
+                    edgecolors="white",
+                    linewidths=0.8,
+                    zorder=6,
+                    label=None if not label_pending else highlight_label,
+                )
 
         # Mark the two reward frames
         ax.plot(

--- a/src/plotting/palettes.py
+++ b/src/plotting/palettes.py
@@ -116,26 +116,31 @@ METRIC_TONED_GROUP_FAMILIES = (
         "turnback_ratio": "#E7CCD5",
         "return_probability": "#C67188",
         "between_reward_distance": "#8F4E66",
+        "between_reward_tortuosity": "#7C6A9F",
     },
     {
         "turnback_ratio": "#D9E1C9",
         "return_probability": "#90A76C",
         "between_reward_distance": "#5F7F3D",
+        "between_reward_tortuosity": "#4F7C68",
     },
     {
         "turnback_ratio": "#C9DCDD",
         "return_probability": "#67979B",
         "between_reward_distance": "#2F6E73",
+        "between_reward_tortuosity": "#3E6F9E",
     },
     {
         "turnback_ratio": "#E4D2B7",
         "return_probability": "#C66616",
         "between_reward_distance": "#8A5B2A",
+        "between_reward_tortuosity": "#9A6B47",
     },
     {
         "turnback_ratio": "#D9CDE8",
         "return_probability": "#874BB8",
         "between_reward_distance": "#6E5792",
+        "between_reward_tortuosity": "#9A607D",
     },
 )
 
@@ -148,6 +153,8 @@ METRIC_PALETTE_FAMILY_ALIASES = {
     "between_reward_dist": "between_reward_distance",
     "between_reward_return_leg_dist": "between_reward_distance",
     "return_leg_dist": "between_reward_distance",
+    "between_reward_tortuosity": "between_reward_tortuosity",
+    "return_leg_tortuosity_excursion_bin": "between_reward_tortuosity",
     "wall_contacts": "wall_contacts",
     "wall_contact": "wall_contacts",
 }

--- a/src/plotting/post_wall_departure_tortuosity_sli_bundle_plotter.py
+++ b/src/plotting/post_wall_departure_tortuosity_sli_bundle_plotter.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+
+from src.analysis.sli_bundle_utils import load_sli_bundle
+from src.plotting.overlay_training_metric_scalar_bars import (
+    ExportedTrainingScalarBars,
+    plot_overlays,
+)
+from src.plotting.return_prob_outer_radius_sli_bundle_plotter import (
+    _ci_triplet,
+    _selected_groups,
+)
+from src.utils.common import writeImage
+
+
+def _mode_values(bundle, mode: str) -> np.ndarray:
+    exp = np.asarray(bundle["post_wall_departure_tortuosity_exp"], dtype=float)
+    ctrl = np.asarray(bundle["post_wall_departure_tortuosity_ctrl"], dtype=float)
+    if mode == "exp":
+        return exp
+    if mode == "ctrl":
+        return ctrl
+    if mode == "exp_minus_ctrl":
+        return exp - ctrl
+    raise ValueError(f"Unknown mode={mode!r}")
+
+
+def _bundle_to_exported(
+    bundle,
+    *,
+    label: str,
+    mode: str,
+    sub_idx: np.ndarray,
+) -> ExportedTrainingScalarBars:
+    values = np.asarray(_mode_values(bundle, mode)[sub_idx, 0], dtype=float)
+    ids = np.asarray(bundle["video_ids"], dtype=object).reshape(-1)[sub_idx]
+    finite = np.isfinite(values)
+    samples = np.asarray(values[finite], dtype=float)
+    sample_ids = np.asarray(ids[finite], dtype=object)
+    mean, lo, hi, n = _ci_triplet(samples)
+    ylabel = (
+        "Post-wall departure tortuosity (exp - yok)"
+        if mode == "exp_minus_ctrl"
+        else "Post-wall departure tortuosity (yoked)"
+        if mode == "ctrl"
+        else "Post-wall departure tortuosity"
+    )
+    return ExportedTrainingScalarBars(
+        group=label,
+        panel_labels=["Wall-contact trajectories"],
+        per_unit_values_panel=np.asarray([samples], dtype=object),
+        per_unit_ids_panel=np.asarray([sample_ids], dtype=object),
+        mean=np.asarray([mean], dtype=float),
+        ci_lo=np.asarray([lo], dtype=float),
+        ci_hi=np.asarray([hi], dtype=float),
+        n_units_panel=np.asarray([n], dtype=int),
+        meta={
+            "y_label": ylabel,
+            "base_title": "Tortuosity after final wall departure",
+            "pool_trainings": False,
+            "ci_conf": 0.95,
+            "mode": mode,
+            "metric": "post_wall_departure_tortuosity",
+            "metric_palette_family": "between_reward_tortuosity",
+        },
+    )
+
+
+def plot_post_wall_departure_tortuosity_sli_bundles(
+    bundles,
+    out,
+    *,
+    labels: list[str] | None = None,
+    mode: str = "exp",
+    sli_extremes=None,
+    sli_fraction=None,
+    sli_top_fraction=None,
+    sli_bottom_fraction=None,
+    standalone_extreme_labels: bool = False,
+    title: str | None = None,
+    xlabel: str | None = None,
+    ylabel: str | None = None,
+    ymax: float | None = None,
+    stats: bool = False,
+    stats_alpha: float = 0.05,
+    stats_paired: bool = False,
+    debug: bool = False,
+    bar_alpha: float = 0.90,
+    opts=None,
+):
+    if opts is None:
+        opts = SimpleNamespace(imageFormat="png", fontSize=None, fontFamily=None)
+    loaded = [load_sli_bundle(path) for path in bundles]
+    if sli_top_fraction is None:
+        sli_top_fraction = sli_fraction
+    if sli_bottom_fraction is None:
+        sli_bottom_fraction = sli_fraction
+
+    exported = []
+    for idx, bundle in enumerate(loaded):
+        group_label = (
+            labels[idx]
+            if labels is not None and idx < len(labels)
+            else str(bundle["group_label"])
+        )
+        for subset_label, subset_idx in _selected_groups(
+            bundle,
+            group_label=group_label,
+            sli_extremes=sli_extremes,
+            sli_top_fraction=sli_top_fraction,
+            sli_bottom_fraction=sli_bottom_fraction,
+            standalone_extreme_labels=standalone_extreme_labels,
+        ):
+            exported.append(
+                _bundle_to_exported(
+                    bundle,
+                    label=subset_label,
+                    mode=mode,
+                    sub_idx=subset_idx,
+                )
+            )
+    if not exported:
+        raise ValueError("No non-empty plotted groups after SLI filtering.")
+
+    fig = plot_overlays(
+        exported,
+        title=title or "Tortuosity after final wall departure",
+        xlabel=xlabel or "Fly group",
+        ylabel=ylabel or exported[0].meta["y_label"],
+        ymax=ymax,
+        stats=bool(stats),
+        stats_alpha=float(stats_alpha),
+        stats_paired=bool(stats_paired),
+        debug=bool(debug),
+        bar_alpha=bar_alpha,
+        opts=opts,
+    )
+    writeImage(out, format=getattr(opts, "imageFormat", "png"))
+    return fig

--- a/src/plotting/return_leg_tortuosity_excursion_bin_sli_bundle_plotter.py
+++ b/src/plotting/return_leg_tortuosity_excursion_bin_sli_bundle_plotter.py
@@ -29,6 +29,19 @@ def _mode_values(bundle, mode: str) -> np.ndarray:
 
 
 def _panel_labels(bundle) -> list[str]:
+    binning_mode = str(
+        np.asarray(
+            bundle.get(
+                "return_leg_tortuosity_excursion_bin_binning_mode",
+                "absolute_distance",
+            )
+        )
+        .reshape(())
+        .item()
+    )
+    if binning_mode == "per_fly_quartile":
+        return ["Q1 (0-25%)", "Q2 (25-50%)", "Q3 (50-75%)", "Q4 (75-100%)"]
+
     pair_mode = bool(
         np.asarray(
             bundle.get("return_leg_tortuosity_excursion_bin_pair_mode", False)
@@ -111,6 +124,16 @@ def _bundle_to_exported(
         .reshape(())
         .item()
     )
+    binning_mode = str(
+        np.asarray(
+            bundle.get(
+                "return_leg_tortuosity_excursion_bin_binning_mode",
+                "absolute_distance",
+            )
+        )
+        .reshape(())
+        .item()
+    )
     tail_prefix = (
         ""
         if top_fraction == 1.0
@@ -141,7 +164,9 @@ def _bundle_to_exported(
         meta={
             "y_label": ylabel,
             "base_title": (
-                "Return-leg tortuosity by maximum distance bin"
+                "Return-leg tortuosity by per-fly maximum-distance quartile"
+                if binning_mode == "per_fly_quartile"
+                else "Return-leg tortuosity by maximum distance bin"
                 if top_fraction == 1.0 and return_start_mode == "global_max"
                 else f"{metric_label} by maximum distance bin"
             ),
@@ -152,6 +177,7 @@ def _bundle_to_exported(
             "metric_palette_family": "between_reward_tortuosity",
             "top_fraction": top_fraction,
             "return_start_mode": return_start_mode,
+            "binning_mode": binning_mode,
         },
     )
 
@@ -181,6 +207,25 @@ def plot_return_leg_tortuosity_excursion_bin_sli_bundles(
     if opts is None:
         opts = SimpleNamespace(imageFormat="png", fontSize=None, fontFamily=None)
     loaded = [load_sli_bundle(path) for path in bundles]
+    binning_modes = {
+        str(
+            np.asarray(
+                bundle.get(
+                    "return_leg_tortuosity_excursion_bin_binning_mode",
+                    "absolute_distance",
+                )
+            )
+            .reshape(())
+            .item()
+        )
+        for bundle in loaded
+    }
+    if len(binning_modes) != 1:
+        raise ValueError(
+            "Cannot overlay absolute-distance and per-fly-quartile bundles "
+            "in one plot."
+        )
+    binning_mode = next(iter(binning_modes))
     if sli_top_fraction is None:
         sli_top_fraction = sli_fraction
     if sli_bottom_fraction is None:
@@ -215,7 +260,12 @@ def plot_return_leg_tortuosity_excursion_bin_sli_bundles(
     fig = plot_overlays(
         exported,
         title=title,
-        xlabel=xlabel or "Maximum distance bin from reward circle (mm)",
+        xlabel=xlabel
+        or (
+            "Per-fly maximum-distance quartile"
+            if binning_mode == "per_fly_quartile"
+            else "Maximum distance bin from reward circle (mm)"
+        ),
         ylabel=ylabel or exported[0].meta["y_label"],
         ymax=ymax,
         stats=bool(stats),

--- a/src/plotting/return_leg_tortuosity_excursion_bin_sli_bundle_plotter.py
+++ b/src/plotting/return_leg_tortuosity_excursion_bin_sli_bundle_plotter.py
@@ -94,12 +94,24 @@ def _bundle_to_exported(
         ci_hi.append(hi)
         counts.append(n)
 
+    top_fraction = float(
+        np.asarray(
+            bundle.get("return_leg_tortuosity_excursion_bin_top_fraction", 1.0)
+        )
+        .reshape(())
+        .item()
+    )
+    tail_prefix = (
+        ""
+        if top_fraction == 1.0
+        else f"Top {100.0 * top_fraction:g}% mean "
+    )
     ylabel = (
-        "Return-leg tortuosity (exp - yok)"
+        f"{tail_prefix}return-leg tortuosity (exp - yok)"
         if mode == "exp_minus_ctrl"
-        else "Return-leg tortuosity (yoked)"
+        else f"{tail_prefix}return-leg tortuosity (yoked)"
         if mode == "ctrl"
-        else "Return-leg tortuosity"
+        else f"{tail_prefix}return-leg tortuosity"
     )
     return ExportedTrainingScalarBars(
         group=label,
@@ -112,12 +124,18 @@ def _bundle_to_exported(
         n_units_panel=np.asarray(counts, dtype=int),
         meta={
             "y_label": ylabel,
-            "base_title": "Return-leg tortuosity by maximum distance bin",
+            "base_title": (
+                "Return-leg tortuosity by maximum distance bin"
+                if top_fraction == 1.0
+                else f"Top {100.0 * top_fraction:g}% mean return-leg tortuosity "
+                "by maximum distance bin"
+            ),
             "pool_trainings": False,
             "ci_conf": 0.95,
             "mode": mode,
             "metric": "return_leg_tortuosity_excursion_bin",
             "metric_palette_family": "between_reward_tortuosity",
+            "top_fraction": top_fraction,
         },
     )
 

--- a/src/plotting/return_leg_tortuosity_excursion_bin_sli_bundle_plotter.py
+++ b/src/plotting/return_leg_tortuosity_excursion_bin_sli_bundle_plotter.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+
+from src.analysis.sli_bundle_utils import load_sli_bundle
+from src.plotting.overlay_training_metric_scalar_bars import (
+    ExportedTrainingScalarBars,
+    plot_overlays,
+)
+from src.plotting.return_prob_outer_radius_sli_bundle_plotter import (
+    _ci_triplet,
+    _selected_groups,
+)
+from src.utils.common import writeImage
+
+
+def _mode_values(bundle, mode: str) -> np.ndarray:
+    exp = np.asarray(bundle["return_leg_tortuosity_excursion_bin_exp"], dtype=float)
+    ctrl = np.asarray(bundle["return_leg_tortuosity_excursion_bin_ctrl"], dtype=float)
+    if mode == "exp":
+        return exp
+    if mode == "ctrl":
+        return ctrl
+    if mode == "exp_minus_ctrl":
+        return exp - ctrl
+    raise ValueError(f"Unknown mode={mode!r}")
+
+
+def _panel_labels(bundle) -> list[str]:
+    pair_mode = bool(
+        np.asarray(
+            bundle.get("return_leg_tortuosity_excursion_bin_pair_mode", False)
+        )
+        .reshape(())
+        .item()
+    )
+    if pair_mode:
+        lower = np.asarray(
+            bundle["return_leg_tortuosity_excursion_bin_pair_lower_mm"], dtype=float
+        ).reshape(-1)
+        upper = np.asarray(
+            bundle["return_leg_tortuosity_excursion_bin_pair_upper_mm"], dtype=float
+        ).reshape(-1)
+        return [f"[{lo:g}, {hi:g}) mm" for lo, hi in zip(lower, upper)]
+
+    edges = np.asarray(
+        bundle["return_leg_tortuosity_excursion_bin_edges_mm"], dtype=float
+    ).reshape(-1)
+    open_ended = bool(
+        np.asarray(
+            bundle.get(
+                "return_leg_tortuosity_excursion_bin_open_ended_upper_bin", False
+            )
+        )
+        .reshape(())
+        .item()
+    )
+    return [
+        f"{lo:g}+ mm"
+        if open_ended and idx == len(edges) - 2
+        else f"[{lo:g}, {hi:g}) mm"
+        for idx, (lo, hi) in enumerate(zip(edges[:-1], edges[1:]))
+    ]
+
+
+def _bundle_to_exported(
+    bundle,
+    *,
+    label: str,
+    mode: str,
+    sub_idx: np.ndarray,
+) -> ExportedTrainingScalarBars:
+    values = np.asarray(_mode_values(bundle, mode)[sub_idx, :], dtype=float)
+    ids = np.asarray(bundle["video_ids"], dtype=object).reshape(-1)[sub_idx]
+
+    samples_by_panel = []
+    ids_by_panel = []
+    means = []
+    ci_lo = []
+    ci_hi = []
+    counts = []
+    for panel_idx in range(values.shape[1]):
+        column = values[:, panel_idx]
+        finite = np.isfinite(column)
+        samples = np.asarray(column[finite], dtype=float)
+        sample_ids = np.asarray(ids[finite], dtype=object)
+        mean, lo, hi, n = _ci_triplet(samples)
+        samples_by_panel.append(samples)
+        ids_by_panel.append(sample_ids)
+        means.append(mean)
+        ci_lo.append(lo)
+        ci_hi.append(hi)
+        counts.append(n)
+
+    ylabel = (
+        "Return-leg tortuosity (exp - yok)"
+        if mode == "exp_minus_ctrl"
+        else "Return-leg tortuosity (yoked)"
+        if mode == "ctrl"
+        else "Return-leg tortuosity"
+    )
+    return ExportedTrainingScalarBars(
+        group=label,
+        panel_labels=_panel_labels(bundle),
+        per_unit_values_panel=np.asarray(samples_by_panel, dtype=object),
+        per_unit_ids_panel=np.asarray(ids_by_panel, dtype=object),
+        mean=np.asarray(means, dtype=float),
+        ci_lo=np.asarray(ci_lo, dtype=float),
+        ci_hi=np.asarray(ci_hi, dtype=float),
+        n_units_panel=np.asarray(counts, dtype=int),
+        meta={
+            "y_label": ylabel,
+            "base_title": "Return-leg tortuosity by maximum distance bin",
+            "pool_trainings": False,
+            "ci_conf": 0.95,
+            "mode": mode,
+            "metric": "return_leg_tortuosity_excursion_bin",
+            "metric_palette_family": "between_reward_tortuosity",
+        },
+    )
+
+
+def plot_return_leg_tortuosity_excursion_bin_sli_bundles(
+    bundles,
+    out,
+    *,
+    labels: list[str] | None = None,
+    mode: str = "exp",
+    sli_extremes=None,
+    sli_fraction=None,
+    sli_top_fraction=None,
+    sli_bottom_fraction=None,
+    standalone_extreme_labels: bool = False,
+    title: str | None = None,
+    xlabel: str | None = None,
+    ylabel: str | None = None,
+    ymax: float | None = None,
+    stats: bool = False,
+    stats_alpha: float = 0.05,
+    stats_paired: bool = False,
+    debug: bool = False,
+    bar_alpha: float = 0.90,
+    opts=None,
+):
+    if opts is None:
+        opts = SimpleNamespace(imageFormat="png", fontSize=None, fontFamily=None)
+    loaded = [load_sli_bundle(path) for path in bundles]
+    if sli_top_fraction is None:
+        sli_top_fraction = sli_fraction
+    if sli_bottom_fraction is None:
+        sli_bottom_fraction = sli_fraction
+
+    exported = []
+    for idx, bundle in enumerate(loaded):
+        group_label = (
+            labels[idx]
+            if labels is not None and idx < len(labels)
+            else str(bundle["group_label"])
+        )
+        for subset_label, subset_idx in _selected_groups(
+            bundle,
+            group_label=group_label,
+            sli_extremes=sli_extremes,
+            sli_top_fraction=sli_top_fraction,
+            sli_bottom_fraction=sli_bottom_fraction,
+            standalone_extreme_labels=standalone_extreme_labels,
+        ):
+            exported.append(
+                _bundle_to_exported(
+                    bundle,
+                    label=subset_label,
+                    mode=mode,
+                    sub_idx=subset_idx,
+                )
+            )
+    if not exported:
+        raise ValueError("No non-empty plotted groups after SLI filtering.")
+
+    fig = plot_overlays(
+        exported,
+        title=title,
+        xlabel=xlabel or "Maximum distance bin from reward circle (mm)",
+        ylabel=ylabel or exported[0].meta["y_label"],
+        ymax=ymax,
+        stats=bool(stats),
+        stats_alpha=float(stats_alpha),
+        stats_paired=bool(stats_paired),
+        debug=bool(debug),
+        bar_alpha=bar_alpha,
+        opts=opts,
+    )
+    writeImage(out, format=getattr(opts, "imageFormat", "png"))
+    return fig

--- a/src/plotting/return_leg_tortuosity_excursion_bin_sli_bundle_plotter.py
+++ b/src/plotting/return_leg_tortuosity_excursion_bin_sli_bundle_plotter.py
@@ -124,6 +124,16 @@ def _bundle_to_exported(
         .reshape(())
         .item()
     )
+    exclude_wall_frames = bool(
+        np.asarray(
+            bundle.get(
+                "return_leg_tortuosity_excursion_bin_exclude_wall_contact_frames",
+                False,
+            )
+        )
+        .reshape(())
+        .item()
+    )
     binning_mode = str(
         np.asarray(
             bundle.get(
@@ -144,7 +154,10 @@ def _bundle_to_exported(
         if return_start_mode == "global_max"
         else "Post-wall "
     )
-    metric_label = f"{tail_prefix}{start_prefix}return-leg tortuosity"
+    wall_prefix = "Off-wall " if exclude_wall_frames else ""
+    metric_label = (
+        f"{tail_prefix}{start_prefix}{wall_prefix}return-leg tortuosity"
+    )
     ylabel = (
         f"{metric_label} (exp - yok)"
         if mode == "exp_minus_ctrl"
@@ -177,6 +190,7 @@ def _bundle_to_exported(
             "metric_palette_family": "between_reward_tortuosity",
             "top_fraction": top_fraction,
             "return_start_mode": return_start_mode,
+            "exclude_wall_contact_frames": exclude_wall_frames,
             "binning_mode": binning_mode,
         },
     )

--- a/src/plotting/return_leg_tortuosity_excursion_bin_sli_bundle_plotter.py
+++ b/src/plotting/return_leg_tortuosity_excursion_bin_sli_bundle_plotter.py
@@ -101,17 +101,33 @@ def _bundle_to_exported(
         .reshape(())
         .item()
     )
+    return_start_mode = str(
+        np.asarray(
+            bundle.get(
+                "return_leg_tortuosity_excursion_bin_return_start_mode",
+                "global_max",
+            )
+        )
+        .reshape(())
+        .item()
+    )
     tail_prefix = (
         ""
         if top_fraction == 1.0
         else f"Top {100.0 * top_fraction:g}% mean "
     )
+    start_prefix = (
+        ""
+        if return_start_mode == "global_max"
+        else "Post-wall "
+    )
+    metric_label = f"{tail_prefix}{start_prefix}return-leg tortuosity"
     ylabel = (
-        f"{tail_prefix}return-leg tortuosity (exp - yok)"
+        f"{metric_label} (exp - yok)"
         if mode == "exp_minus_ctrl"
-        else f"{tail_prefix}return-leg tortuosity (yoked)"
+        else f"{metric_label} (yoked)"
         if mode == "ctrl"
-        else f"{tail_prefix}return-leg tortuosity"
+        else metric_label
     )
     return ExportedTrainingScalarBars(
         group=label,
@@ -126,9 +142,8 @@ def _bundle_to_exported(
             "y_label": ylabel,
             "base_title": (
                 "Return-leg tortuosity by maximum distance bin"
-                if top_fraction == 1.0
-                else f"Top {100.0 * top_fraction:g}% mean return-leg tortuosity "
-                "by maximum distance bin"
+                if top_fraction == 1.0 and return_start_mode == "global_max"
+                else f"{metric_label} by maximum distance bin"
             ),
             "pool_trainings": False,
             "ci_conf": 0.95,
@@ -136,6 +151,7 @@ def _bundle_to_exported(
             "metric": "return_leg_tortuosity_excursion_bin",
             "metric_palette_family": "between_reward_tortuosity",
             "top_fraction": top_fraction,
+            "return_start_mode": return_start_mode,
         },
     )
 

--- a/src/plotting/wall_contact_utils.py
+++ b/src/plotting/wall_contact_utils.py
@@ -60,7 +60,8 @@ def build_wall_contact_mask_for_window(
         if not warned_missing_wc[0]:
             print(
                 f"[{log_tag}] warning: can't load wall-contact data; "
-                "wall-contact exclusion will be ignored for some videos."
+                "wall-dependent filtering or metrics will be unavailable for "
+                "some videos."
             )
             warned_missing_wc[0] = True
 

--- a/test/test_post_wall_departure_tortuosity.py
+++ b/test/test_post_wall_departure_tortuosity.py
@@ -1,0 +1,238 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from src.analysis.sli_bundle_utils import (
+    normalize_sli_bundle,
+    validate_post_wall_departure_tortuosity_bundle,
+)
+from src.exporting import post_wall_departure_tortuosity_examples as examples
+from src.exporting import post_wall_departure_tortuosity_sli_bundle as exporter
+from src.exporting.post_wall_departure_tortuosity_sli_bundle import (
+    aggregate_post_wall_departure_tortuosity,
+    departure_distance_to_reward_circle_mm,
+    last_wall_departure_frame,
+)
+from src.plotting.post_wall_departure_tortuosity_sli_bundle_plotter import (
+    _bundle_to_exported,
+)
+
+
+def _bundle():
+    return {
+        "sli": np.asarray([0.1, 0.2]),
+        "group_label": np.asarray("control"),
+        "bucket_len_min": np.asarray(np.nan),
+        "training_names": np.asarray(["T1"]),
+        "video_ids": np.asarray(["fly-a", "fly-b"]),
+        "sli_training_idx": np.asarray(0),
+        "sli_use_training_mean": np.asarray(False),
+        "post_wall_departure_tortuosity_exp": np.asarray([[1.5], [2.0]]),
+        "post_wall_departure_tortuosity_ctrl": np.asarray([[1.2], [np.nan]]),
+        "post_wall_departure_tortuosityN_exp": np.asarray([[5], [7]]),
+        "post_wall_departure_tortuosityN_ctrl": np.asarray([[5], [2]]),
+        "btw_rwd_sync_bucket_min_trajectories": np.asarray(5),
+    }
+
+
+def test_last_wall_departure_uses_final_contact_and_absolute_frames():
+    wall = np.asarray([False, True, True, False, False, True, False])
+
+    assert last_wall_departure_frame(
+        wall,
+        segment_start=101,
+        segment_stop=107,
+        window_start=100,
+    ) == (105, 106)
+    assert (
+        last_wall_departure_frame(
+            np.zeros(7, dtype=bool),
+            segment_start=100,
+            segment_stop=107,
+            window_start=100,
+        )
+        is None
+    )
+    assert (
+        last_wall_departure_frame(
+            np.asarray([False, False, True]),
+            segment_start=100,
+            segment_stop=103,
+            window_start=100,
+        )
+        is None
+    )
+
+
+def test_departure_distance_targets_reward_circle_perimeter():
+    traj = SimpleNamespace(
+        x=np.asarray([10.0]),
+        y=np.asarray([0.0]),
+    )
+
+    direct_mm, edge = departure_distance_to_reward_circle_mm(
+        traj,
+        departure_frame=0,
+        reward_circle=(0.0, 0.0, 2.0),
+        px_per_mm=2.0,
+    )
+
+    assert direct_mm == pytest.approx(4.0)
+    assert edge == pytest.approx((2.0, 0.0))
+
+
+def test_aggregation_applies_minimum_to_each_fly_and_role():
+    records = [
+        [[1.0, 2.0, 3.0], [2.0]],
+        [[4.0], [3.0, 5.0, 7.0]],
+    ]
+
+    exp, ctrl, n_exp, n_ctrl = aggregate_post_wall_departure_tortuosity(
+        records,
+        min_episodes=3,
+    )
+
+    np.testing.assert_array_equal(n_exp, [[3], [1]])
+    np.testing.assert_array_equal(n_ctrl, [[1], [3]])
+    assert exp[0, 0] == pytest.approx(2.0)
+    assert np.isnan(exp[1, 0])
+    assert np.isnan(ctrl[0, 0])
+    assert ctrl[1, 0] == pytest.approx(5.0)
+
+
+def test_collector_measures_path_after_final_wall_departure(monkeypatch):
+    traj = SimpleNamespace(
+        x=np.asarray([1.0, 7.0, 6.0, 5.0, 3.0, 1.0]),
+        y=np.zeros(6),
+        d=np.asarray([6.0, 1.0, 1.0, 2.0, 2.0]),
+        pxPerMmFloor=1.0,
+        bad=lambda: False,
+    )
+    trn = SimpleNamespace(
+        stop=6,
+        isCircle=lambda: True,
+        circles=lambda _f: [(0.0, 0.0, 1.0)],
+        name=lambda: "T1",
+    )
+    va = SimpleNamespace(
+        trx=[traj],
+        trns=[trn],
+        noyc=True,
+        xf=SimpleNamespace(fctr=1.0),
+        _iter_between_reward_segment_com=lambda *_args, **_kwargs: iter(
+            [SimpleNamespace(s=0, e=5)]
+        ),
+    )
+    monkeypatch.setattr(
+        exporter,
+        "sync_bucket_window",
+        lambda *_args, **_kwargs: (0, 10, 1, [True]),
+    )
+    monkeypatch.setattr(
+        exporter,
+        "wall_contact_mask",
+        lambda *_args, **_kwargs: np.asarray(
+            [False, True, True, False, False, False]
+        ),
+    )
+
+    records, details, _windows = exporter.collect_post_wall_departure_tortuosity(
+        [va],
+        SimpleNamespace(
+            post_wall_departure_tortuosity_trainings=None,
+            post_wall_departure_tortuosity_skip_first_sync_buckets=0,
+            post_wall_departure_tortuosity_keep_first_sync_buckets=0,
+            post_wall_departure_tortuosity_exclude_nonwalking_frames=False,
+            post_wall_departure_tortuosity_min_walk_frames=2,
+            post_wall_departure_tortuosity_min_direct_distance_mm=0.0,
+        ),
+    )
+
+    assert records == [[[pytest.approx(1.0)], []]]
+    assert details[0]["last_wall_contact_frame"] == 2
+    assert details[0]["departure_frame"] == 3
+    assert details[0]["path_mm"] == pytest.approx(4.0)
+    assert details[0]["direct_mm"] == pytest.approx(4.0)
+
+
+def test_bundle_validation_and_scalar_plot_conversion():
+    bundle = _bundle()
+
+    validate_post_wall_departure_tortuosity_bundle(bundle)
+    normalized = normalize_sli_bundle(bundle)
+    exported = _bundle_to_exported(
+        normalized,
+        label="control",
+        mode="exp",
+        sub_idx=np.asarray([0, 1]),
+    )
+
+    assert exported.panel_labels == ["Wall-contact trajectories"]
+    assert exported.n_units_panel.tolist() == [2]
+    assert exported.mean[0] == pytest.approx(1.75)
+
+
+def test_example_export_ranks_and_draws_post_departure_path(monkeypatch, tmp_path):
+    va = SimpleNamespace(_skipped=False, trns=[object()], gidx=0, fn="fly.avi")
+    detail = {
+        "va": va,
+        "video_index": 0,
+        "role_idx": 0,
+        "trajectory_index": 0,
+        "traj": SimpleNamespace(),
+        "training_idx": 0,
+        "segment_start": 10,
+        "segment_stop": 30,
+        "last_wall_contact_frame": 19,
+        "departure_frame": 20,
+        "metric_stop": 31,
+        "path_mm": 8.0,
+        "direct_mm": 4.0,
+        "tortuosity": 2.0,
+        "reward_edge_xy": (1.0, 1.0),
+        "departure_xy": (5.0, 1.0),
+        "exclude_nonwalk": False,
+    }
+    monkeypatch.setattr(
+        examples,
+        "collect_post_wall_departure_tortuosity",
+        lambda _vas, _opts: ([[[2.0], []]], [detail], []),
+    )
+    monkeypatch.setattr(
+        examples, "min_between_reward_sync_bucket_trajectories", lambda _opts: 1
+    )
+    monkeypatch.setattr(
+        examples,
+        "exp_target_sync_bucket_eligibility_mask",
+        lambda _vas, _opts: [True],
+    )
+    plotted = []
+
+    class FakePlotter:
+        def __init__(self, **_kwargs):
+            pass
+
+        def plot_between_reward_interval(self, **kwargs):
+            plotted.append(kwargs)
+
+    monkeypatch.setattr(examples, "EventChainPlotter", FakePlotter)
+    opts = SimpleNamespace(
+        post_wall_departure_tortuosity_examples_role="exp",
+        post_wall_departure_tortuosity_examples_num=4,
+        post_wall_departure_tortuosity_examples_max_per_fly=1,
+        post_wall_departure_tortuosity_examples_zoom_radius_mm=None,
+        export_group_label="control",
+        imageFormat="png",
+    )
+
+    examples.export_post_wall_departure_tortuosity_examples(
+        [va], opts, ["control"], str(tmp_path)
+    )
+
+    assert len(plotted) == 1
+    assert plotted[0]["highlight_start_frame"] == 20
+    assert plotted[0]["highlight_stop_frame"] == 31
+    assert plotted[0]["comparison_line_start_xy"] == (5.0, 1.0)
+    assert plotted[0]["comparison_line_stop_xy"] == (1.0, 1.0)
+    assert "2.0" in (tmp_path / "manifest.csv").read_text()

--- a/test/test_return_leg_tortuosity_examples.py
+++ b/test/test_return_leg_tortuosity_examples.py
@@ -1,0 +1,117 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+from src.exporting import return_leg_tortuosity_excursion_bin_examples as examples
+
+
+def _record(va, video_index, score, frame):
+    return {
+        "va": va,
+        "video_index": video_index,
+        "role_idx": 0,
+        "trajectory_index": 0,
+        "traj": SimpleNamespace(),
+        "training_idx": 0,
+        "segment_start": frame,
+        "segment_stop": frame + 10,
+        "global_max_frame": frame + 2,
+        "metric_start": frame + 2,
+        "radial_mm": 4.0,
+        "tortuosity": float(score),
+        "window_start": 0,
+        "wall_mask": np.zeros(100, dtype=bool),
+        "nonwalk_mask": None,
+        "px_per_mm": 10.0,
+        "reward_center_xy": (0.0, 0.0),
+        "reward_radius_mm": 2.5,
+        "exclude_nonwalk": False,
+        "min_walk_frames": 2,
+        "metric_mode": "path_over_max_radius",
+        "return_start_mode": "global_max",
+        "legacy_distances": False,
+    }
+
+
+def test_example_export_matches_per_fly_tail_and_minimum(monkeypatch, tmp_path):
+    vas = [
+        SimpleNamespace(_skipped=False, trns=[object()], gidx=0, fn="fly_a.avi"),
+        SimpleNamespace(_skipped=False, trns=[object()], gidx=0, fn="fly_b.avi"),
+    ]
+    details = [
+        *[
+            _record(vas[0], 0, score, 10 + i * 20)
+            for i, score in enumerate((10, 9, 2, 1))
+        ],
+        *[
+            _record(vas[1], 1, score, 100 + i * 20)
+            for i, score in enumerate((8, 7, 6, 5))
+        ],
+    ]
+
+    def fake_collect(_vas, _opts, *, episode_callback, **_kwargs):
+        for record in details:
+            episode_callback(record)
+        records = [
+            [[(record["radial_mm"], record["tortuosity"]) for record in details[:4]], []],
+            [[(record["radial_mm"], record["tortuosity"]) for record in details[4:]], []],
+        ]
+        return records, []
+
+    plotted = []
+
+    class FakePlotter:
+        def __init__(self, **_kwargs):
+            pass
+
+        def plot_between_reward_interval(self, **kwargs):
+            plotted.append(kwargs)
+            open(kwargs["out_path"], "wb").close()
+
+    monkeypatch.setattr(examples, "_collect_records", fake_collect)
+    monkeypatch.setattr(
+        examples,
+        "exp_target_sync_bucket_eligibility_mask",
+        lambda _vas, _opts: [True, True],
+    )
+    monkeypatch.setattr(
+        examples, "min_between_reward_sync_bucket_trajectories", lambda _opts: 3
+    )
+    monkeypatch.setattr(examples, "_metric_components", lambda _record: (10.0, 4.0, 4.0))
+    monkeypatch.setattr(examples, "EventChainPlotter", FakePlotter)
+
+    opts = SimpleNamespace(
+        return_leg_tortuosity_excursion_bin_radius_pairs_mm="3:5",
+        return_leg_tortuosity_excursion_bin_pairs_mm=None,
+        return_leg_tortuosity_excursion_bin_trainings=None,
+        return_leg_tortuosity_excursion_bin_top_fraction=0.5,
+        return_leg_tortuosity_excursion_bin_examples_per_bin=3,
+        return_leg_tortuosity_excursion_bin_examples_max_per_fly=1,
+        return_leg_tortuosity_excursion_bin_examples_role="exp",
+        return_leg_tortuosity_excursion_bin_examples_zoom_radius_mm=None,
+        skip_first_sync_buckets=0,
+        keep_first_sync_buckets=0,
+        export_group_label="control",
+        imageFormat="png",
+    )
+
+    examples.export_return_leg_tortuosity_excursion_bin_examples(
+        vas, opts, ["control"], str(tmp_path)
+    )
+
+    assert len(plotted) == 2
+    assert [call["highlight_start_frame"] for call in plotted] == [12, 102]
+    manifest = (tmp_path / "manifest.csv").read_text()
+    assert ",10.0,path_over_max_radius," in manifest
+    assert ",8.0,path_over_max_radius," in manifest
+    assert ",9.0,path_over_max_radius," not in manifest
+
+
+def test_last_wall_frame_uses_absolute_window_coordinates():
+    record = {
+        "wall_mask": np.array([False, True, False, True, False]),
+        "window_start": 100,
+        "segment_start": 101,
+        "segment_stop": 105,
+    }
+    assert examples._last_wall_frame(record) == 103

--- a/test/test_return_leg_tortuosity_examples.py
+++ b/test/test_return_leg_tortuosity_examples.py
@@ -26,6 +26,7 @@ def _record(va, video_index, score, frame):
         "reward_center_xy": (0.0, 0.0),
         "reward_radius_mm": 2.5,
         "exclude_nonwalk": False,
+        "exclude_wall_frames": False,
         "min_walk_frames": 2,
         "metric_mode": "path_over_max_radius",
         "return_start_mode": "global_max",
@@ -48,6 +49,8 @@ def test_example_export_matches_per_fly_tail_and_minimum(monkeypatch, tmp_path):
             for i, score in enumerate((8, 7, 6, 5))
         ],
     ]
+    details[0]["exclude_wall_frames"] = True
+    details[0]["wall_mask"][12] = True
 
     def fake_collect(_vas, _opts, *, episode_callback, **_kwargs):
         for record in details:
@@ -101,6 +104,9 @@ def test_example_export_matches_per_fly_tail_and_minimum(monkeypatch, tmp_path):
 
     assert len(plotted) == 2
     assert [call["highlight_start_frame"] for call in plotted] == [12, 102]
+    assert plotted[0]["highlight_excluded_frame_mask"] is details[0]["wall_mask"]
+    assert plotted[0]["highlight_excluded_frame_mask_start"] == 0
+    assert plotted[1]["highlight_excluded_frame_mask"] is None
     manifest = (tmp_path / "manifest.csv").read_text()
     assert ",10.0,path_over_max_radius," in manifest
     assert ",8.0,path_over_max_radius," in manifest

--- a/test/test_return_leg_tortuosity_quartiles.py
+++ b/test/test_return_leg_tortuosity_quartiles.py
@@ -1,0 +1,164 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from src.analysis.sli_bundle_utils import (
+    validate_return_leg_tortuosity_excursion_bin_bundle,
+)
+from src.exporting.return_leg_tortuosity_excursion_bin_sli_bundle import (
+    _aggregate_quartile_records,
+    _binning_mode,
+    _equal_count_bin_indices,
+    _top_fraction,
+    _validate_binning_options,
+)
+from src.plotting.return_leg_tortuosity_excursion_bin_sli_bundle_plotter import (
+    _bundle_to_exported,
+    _panel_labels,
+)
+
+
+def test_equal_count_quartiles_are_rank_based_and_stable_with_ties():
+    distances = np.asarray([8, 1, 4, 4, 9, 2, 7, 6, 3, 5], dtype=float)
+
+    assignment = _equal_count_bin_indices(distances)
+
+    assert np.bincount(assignment, minlength=4).tolist() == [3, 3, 2, 2]
+    ordered = np.argsort(distances, kind="stable")
+    assert assignment[ordered].tolist() == [0, 0, 0, 1, 1, 1, 2, 2, 3, 3]
+
+    tied = _equal_count_bin_indices(np.ones(8, dtype=float))
+    assert tied.tolist() == [0, 0, 1, 1, 2, 2, 3, 3]
+
+
+def test_quartile_aggregation_exports_counts_means_and_physical_distance_stats():
+    exp_records = [(float(distance), float(distance * 10)) for distance in range(1, 9)]
+    records = [[exp_records, []]]
+
+    (
+        mean_exp,
+        mean_ctrl,
+        count_exp,
+        count_ctrl,
+        selected_exp,
+        selected_ctrl,
+        distance_stats,
+    ) = _aggregate_quartile_records(records, min_segments=2)
+
+    np.testing.assert_array_equal(count_exp, [[2, 2, 2, 2]])
+    np.testing.assert_array_equal(selected_exp, count_exp)
+    np.testing.assert_allclose(mean_exp, [[15, 35, 55, 75]])
+    np.testing.assert_allclose(distance_stats["min"][0], [[1, 3, 5, 7]])
+    np.testing.assert_allclose(distance_stats["max"][0], [[2, 4, 6, 8]])
+    np.testing.assert_allclose(distance_stats["mean"][0], [[1.5, 3.5, 5.5, 7.5]])
+    assert np.isnan(mean_ctrl).all()
+    assert not count_ctrl.any()
+    assert not selected_ctrl.any()
+
+
+def test_quartile_minimum_is_applied_separately_to_each_quartile():
+    records = [[[(float(i), 1.0) for i in range(19)], []]]
+
+    mean_exp, _mean_ctrl, count_exp, *_rest = _aggregate_quartile_records(
+        records, min_segments=5
+    )
+
+    np.testing.assert_array_equal(count_exp, [[5, 5, 5, 4]])
+    assert np.isfinite(mean_exp[0, :3]).all()
+    assert np.isnan(mean_exp[0, 3])
+
+
+def test_quartile_binning_rejects_tortuosity_top_fraction():
+    opts = SimpleNamespace(
+        return_leg_tortuosity_excursion_bin_binning_mode="per_fly_quartile",
+        return_leg_tortuosity_excursion_bin_top_fraction=0.25,
+    )
+
+    with pytest.raises(ValueError, match="must be 1.0"):
+        _top_fraction(opts)
+
+
+def test_quartile_binning_rejects_absolute_distance_options():
+    opts = SimpleNamespace(
+        return_leg_tortuosity_excursion_bin_binning_mode="per_fly_quartile",
+        return_leg_tortuosity_excursion_bin_radius_pairs_mm="3:5,8:10",
+    )
+
+    with pytest.raises(ValueError, match="cannot be combined"):
+        _validate_binning_options(opts, _binning_mode(opts))
+
+
+def test_quartile_panel_labels_are_percentile_ranges():
+    bundle = {
+        "return_leg_tortuosity_excursion_bin_binning_mode": np.asarray(
+            "per_fly_quartile"
+        )
+    }
+
+    assert _panel_labels(bundle) == [
+        "Q1 (0-25%)",
+        "Q2 (25-50%)",
+        "Q3 (50-75%)",
+        "Q4 (75-100%)",
+    ]
+
+
+def test_quartile_bundle_validation_accepts_distance_metadata():
+    counts = np.asarray([[2, 2, 2, 2], [3, 3, 3, 3]], dtype=int)
+    values = np.asarray([[1.0, 1.1, 1.2, 1.3], [1.4, 1.5, 1.6, 1.7]])
+    ctrl_counts = np.zeros_like(counts)
+    ctrl_values = np.full_like(values, np.nan)
+    percentile_edges = np.asarray([0.0, 25.0, 50.0, 75.0, 100.0])
+    bundle = {
+        "sli": np.asarray([0.1, 0.2]),
+        "return_leg_tortuosity_excursion_bin_exp": values,
+        "return_leg_tortuosity_excursion_bin_ctrl": ctrl_values,
+        "return_leg_tortuosity_excursion_binN_exp": counts,
+        "return_leg_tortuosity_excursion_binN_ctrl": ctrl_counts,
+        "return_leg_tortuosity_excursion_bin_selectedN_exp": counts.copy(),
+        "return_leg_tortuosity_excursion_bin_selectedN_ctrl": ctrl_counts.copy(),
+        "return_leg_tortuosity_excursion_bin_edges_mm": percentile_edges,
+        "return_leg_tortuosity_excursion_bin_requested_edges_mm": percentile_edges,
+        "return_leg_tortuosity_excursion_bin_percentile_edges": percentile_edges,
+        "return_leg_tortuosity_excursion_bin_pair_mode": np.asarray(False),
+        "return_leg_tortuosity_excursion_bin_binning_mode": np.asarray(
+            "per_fly_quartile"
+        ),
+        "return_leg_tortuosity_excursion_bin_top_fraction": np.asarray(1.0),
+        "return_leg_tortuosity_excursion_bin_return_start_mode": np.asarray(
+            "global_max"
+        ),
+        "return_leg_tortuosity_excursion_bin_exclude_wall_contact": np.asarray(False),
+        "btw_rwd_sync_bucket_min_trajectories": np.asarray(1),
+    }
+    for stat, stat_values in {
+        "min": [[1, 3, 5, 7], [2, 4, 6, 8]],
+        "max": [[2, 4, 6, 8], [3, 5, 7, 9]],
+        "mean": [[1.5, 3.5, 5.5, 7.5], [2.5, 4.5, 6.5, 8.5]],
+        "median": [[1.5, 3.5, 5.5, 7.5], [2.5, 4.5, 6.5, 8.5]],
+    }.items():
+        bundle[
+            f"return_leg_tortuosity_excursion_bin_distance_{stat}_mm_exp"
+        ] = np.asarray(stat_values, dtype=float)
+        bundle[
+            f"return_leg_tortuosity_excursion_bin_distance_{stat}_mm_ctrl"
+        ] = np.full((2, 4), np.nan)
+
+    validate_return_leg_tortuosity_excursion_bin_bundle(bundle)
+
+    bundle["video_ids"] = np.asarray(["fly-a", "fly-b"])
+    exported = _bundle_to_exported(
+        bundle,
+        label="control",
+        mode="exp",
+        sub_idx=np.asarray([0, 1]),
+    )
+    assert exported.panel_labels == [
+        "Q1 (0-25%)",
+        "Q2 (25-50%)",
+        "Q3 (50-75%)",
+        "Q4 (75-100%)",
+    ]
+    assert exported.meta["binning_mode"] == "per_fly_quartile"
+    assert "quartile" in exported.meta["base_title"].lower()

--- a/test/test_return_leg_tortuosity_quartiles.py
+++ b/test/test_return_leg_tortuosity_quartiles.py
@@ -10,6 +10,7 @@ from src.exporting.return_leg_tortuosity_excursion_bin_sli_bundle import (
     _aggregate_quartile_records,
     _binning_mode,
     _equal_count_bin_indices,
+    _off_wall_path_over_max_radius,
     _top_fraction,
     _validate_binning_options,
 )
@@ -104,6 +105,32 @@ def test_quartile_panel_labels_are_percentile_ranges():
     ]
 
 
+def test_off_wall_tortuosity_excludes_wall_steps_but_keeps_global_radius():
+    traj = SimpleNamespace(
+        x=np.asarray([10.0, 9.0, 8.0, 7.0, 6.0]),
+        y=np.zeros(5),
+        d=np.asarray([1.0, 1.0, 1.0, 1.0]),
+    )
+    wall_mask = np.asarray([False, True, True, False, False])
+
+    value = _off_wall_path_over_max_radius(
+        traj=traj,
+        s=0,
+        e=5,
+        fi=0,
+        wall_mask=wall_mask,
+        nonwalk_mask=None,
+        exclude_nonwalk=False,
+        px_per_mm=1.0,
+        reward_center_xy=(0.0, 0.0),
+        min_keep_frames=2,
+        min_radius_mm=0.0,
+    )
+
+    # Only the final 7 -> 6 step is wholly off-wall; denominator remains 10.
+    assert value == pytest.approx(0.1)
+
+
 def test_quartile_bundle_validation_accepts_distance_metadata():
     counts = np.asarray([[2, 2, 2, 2], [3, 3, 3, 3]], dtype=int)
     values = np.asarray([[1.0, 1.1, 1.2, 1.3], [1.4, 1.5, 1.6, 1.7]])
@@ -162,3 +189,49 @@ def test_quartile_bundle_validation_accepts_distance_metadata():
     ]
     assert exported.meta["binning_mode"] == "per_fly_quartile"
     assert "quartile" in exported.meta["base_title"].lower()
+
+
+def test_bundle_and_plotter_report_frame_level_wall_exclusion():
+    bundle = {
+        "sli": np.asarray([0.1]),
+        "video_ids": np.asarray(["fly-a"]),
+        "return_leg_tortuosity_excursion_bin_exp": np.asarray([[1.2]]),
+        "return_leg_tortuosity_excursion_bin_ctrl": np.asarray([[np.nan]]),
+        "return_leg_tortuosity_excursion_binN_exp": np.asarray([[5]]),
+        "return_leg_tortuosity_excursion_binN_ctrl": np.asarray([[0]]),
+        "return_leg_tortuosity_excursion_bin_selectedN_exp": np.asarray([[5]]),
+        "return_leg_tortuosity_excursion_bin_selectedN_ctrl": np.asarray([[0]]),
+        "return_leg_tortuosity_excursion_bin_edges_mm": np.asarray([3.0, 5.0]),
+        "return_leg_tortuosity_excursion_bin_requested_edges_mm": np.asarray(
+            [3.0, 5.0]
+        ),
+        "return_leg_tortuosity_excursion_bin_pair_mode": np.asarray(False),
+        "return_leg_tortuosity_excursion_bin_binning_mode": np.asarray(
+            "absolute_distance"
+        ),
+        "return_leg_tortuosity_excursion_bin_top_fraction": np.asarray(1.0),
+        "return_leg_tortuosity_excursion_bin_return_start_mode": np.asarray(
+            "global_max"
+        ),
+        "return_leg_tortuosity_excursion_bin_exclude_wall_contact": np.asarray(
+            False
+        ),
+        "return_leg_tortuosity_excursion_bin_exclude_wall_contact_frames": (
+            np.asarray(True)
+        ),
+        "return_leg_tortuosity_excursion_bin_metric_mode": np.asarray(
+            "path_over_max_radius"
+        ),
+        "btw_rwd_sync_bucket_min_trajectories": np.asarray(1),
+    }
+
+    validate_return_leg_tortuosity_excursion_bin_bundle(bundle)
+    exported = _bundle_to_exported(
+        bundle,
+        label="control",
+        mode="exp",
+        sub_idx=np.asarray([0]),
+    )
+
+    assert exported.meta["exclude_wall_contact_frames"] is True
+    assert "Off-wall" in exported.meta["y_label"]


### PR DESCRIPTION
## Summary

This PR adds infrastructure for analyzing return-leg tortuosity in between-reward trajectories, exporting reusable SLI bundles, comparing fly groups, and inspecting representative trajectories.

## Changes

- Add return-leg tortuosity grouped by absolute maximum-distance bins.
- Add per-fly equal-count maximum-distance quartiles.
- Support ordinary means and upper-tail means within each fly/bin.
- Add several wall-contact treatments:
  - exclude entire trajectories containing wall contact
  - start the return leg after the final wall contact
  - retain trajectories while excluding wall-contact steps from path distance
- Add a post-wall departure metric:
  - includes trajectories containing wall contact
  - measures path distance after final wall departure
  - normalizes by direct distance to the reward-circle perimeter
- Add SLI bundle exports and multi-group plotting/statistics scripts.
- Support top/bottom SLI learner subsets during bundle plotting.
- Add ranked trajectory galleries with highlighted measured paths, wall-aware masking, annotations, and CSV manifests.
- Preserve cached wall-contact detail when requested analyses need it.
- Extend `run_analysis_matrix.sh` with commands for the new analyses.

## Validation

- Added focused tests for:
  - maximum-distance quartile assignment and aggregation
  - frame-level wall exclusion semantics
  - post-wall departure geometry and aggregation
  - bundle validation and plotting conversion
  - ranked trajectory diagnostics
- Verified Python compilation and shell syntax.
- Focused test suite passes: `17 passed`.