### PR TITLE
Add turnback home-vector alignment analysis

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -129,6 +129,9 @@ from src.exporting.turnback_outer_radius_sli_bundle import (
     export_turnback_outer_radius_sli_bundle,
 )
 from src.exporting.turnback_sli_bundle import export_turnback_sli_bundle
+from src.exporting.turnback_home_vector_alignment_sli_bundle import (
+    export_turnback_home_vector_alignment_sli_bundle,
+)
 from src.exporting.wallpct_sli_bundle import export_wallpct_sli_bundle
 from src.exporting.wall_contacts_per_reward_interval import (
     save_wall_contacts_per_reward_interval_npz,
@@ -5487,6 +5490,15 @@ g.add_argument(
     ),
 )
 g.add_argument(
+    '--export-turnback-home-vector-alignment-sli-bundle',
+    type=str,
+    default=None,
+    help=(
+        "Write an .npz scalar-bar bundle with mean home-vector heading alignment "
+        "at successful turnback re-entry episodes for multi-group overlays/stats."
+    )
+)
+g.add_argument(
     "--turnback-outer-radius-trainings",
     type=str,
     default=None,
@@ -5539,6 +5551,25 @@ g.add_argument(
         "Trainings to include in turnback-excursion-bin exports, e.g. '2' or "
         "'2-3'. Default: all trainings."
     ),
+)
+g.add_argument(
+    "--turnback-home-vector-alignment-trainings",
+    type=str,
+    default=None,
+    help=(
+        "Trainings to include in turnback-home-vector-alignment exports, "
+        "e.g. '2' or '2-3'. Default: 2."
+    )
+)
+g.add_argument(
+    '--turnback-home-vector-alignment-sli-group',
+    choices=["all", "top", "bottom"],
+    default="all",
+    help=(
+        "Restrict turnback home-vector alignment export to all flies, top-SLI "
+        "flies, or bottom-SLI flies. Top/bottom groups are defined by the "
+        "standard best/worst SLI selection options."
+    )
 )
 g.add_argument(
     "--turnback-outer-radius-outer-radii-mm",
@@ -5693,6 +5724,65 @@ g.add_argument(
     ),
 )
 g.add_argument(
+    "--turnback-home-vector-alignment-inner-radius-mm",
+    type=float,
+    default=None,
+    help=(
+        "Optional absolute inner radius in mm for turnback-home-vector-alignment "
+        "episode geometry. Defaults to the shared turnback inner-radius setting, "
+        "or reward radius plus inner delta."
+    ),
+)
+g.add_argument(
+    "--turnback-home-vector-alignment-inner-delta-mm",
+    type=float,
+    default=None,
+    help=(
+        "Optional inner radius delta in mm relative to the reward circle for "
+        "turnback-home-vector-alignment episode geometry. Defaults to the shared "
+        "turnback inner delta, or 0."
+    ),
+)
+g.add_argument(
+    "--turnback-home-vector-alignment-outer-radius-mm",
+    type=float,
+    default=None,
+    help=(
+        "Optional absolute outer radius in mm for turnback-home-vector-alignment "
+        "episode geometry. Defaults to the shared turnback outer-radius setting, "
+        "if provided."
+    ),
+)
+g.add_argument(
+    "--turnback-home-vector-alignment-outer-delta-mm",
+    type=float,
+    default=None,
+    help=(
+        "Optional outer radius delta in mm relative to the reward circle for "
+        "turnback-home-vector-alignment episode geometry. Defaults to the shared "
+        "turnback outer delta, or 2."
+    ),
+)
+g.add_argument(
+    "--turnback-home-vector-alignment-border-width-mm",
+    type=float,
+    default=None,
+    help=(
+        "Border width in mm passed to the turnback episode detector for "
+        "turnback-home-vector-alignment. Defaults to the shared turnback border "
+        "width, or 0.1."
+    ),
+)
+g.add_argument(
+    "--turnback-home-vector-alignment-inner-radius-offset-px",
+    type=float,
+    default=None,
+    help=(
+        "Pixel offset applied to the inner radius for turnback-home-vector-alignment "
+        "episode geometry. Defaults to the shared turnback inner-radius offset, or 0."
+    ),
+)
+g.add_argument(
     "--turnback-outer-radius-skip-first-sync-buckets",
     type=int,
     default=None,
@@ -5744,6 +5834,15 @@ g.add_argument(
     help=(
         "Optional export-specific sync-bucket skip for turnback-excursion-bin "
         "bundles. Defaults to --skip-first-sync-buckets."
+    ),
+)
+g.add_argument(
+    "--turnback-home-vector-alignment-skip-first-sync-buckets",
+    type=int,
+    default=None,
+    help=(
+        "Optional export-specific sync-bucket skip for turnback-home-vector-alignment "
+        "bundles. Default: 1."
     ),
 )
 g.add_argument(
@@ -5801,6 +5900,15 @@ g.add_argument(
     ),
 )
 g.add_argument(
+    "--turnback-home-vector-alignment-keep-first-sync-buckets",
+    type=int,
+    default=None,
+    help=(
+        "Optional export-specific sync-bucket cap for turnback-home-vector-alignment "
+        "bundles. Default: 4."
+    ),
+)
+g.add_argument(
     "--turnback-outer-radius-last-sync-buckets",
     type=int,
     default=0,
@@ -5838,6 +5946,16 @@ g.add_argument(
         "After training selection and optional skip/keep trimming, keep only the "
         "last K sync buckets per training for turnback-excursion-bin bundles. "
         "Use 0 for no tail restriction."
+    ),
+)
+g.add_argument(
+    "--turnback-home-vector-alignment-last-sync-buckets",
+    type=int,
+    default=None,
+    help=(
+        "After training selection and optional skip/keep trimming, keep only the "
+        "last K sync buckets per training for turnback-home-vector-alignment bundles. "
+        "Default: 0, meaning no tail restriction."
     ),
 )
 g.add_argument(
@@ -6014,6 +6132,24 @@ g.add_argument(
     help=(
         "For turnback-excursion-bin exports, discard episodes whose frame span "
         "overlaps wall contact."
+    ),
+)
+g.add_argument(
+    "--turnback-home-vector-alignment-exclude-wall-contact",
+    action="store_true",
+    help=(
+        "For turnback-home-vector-alignment exports, discard successful re-entry "
+        "episodes whose frame span overlaps wall contact."
+    ),
+)
+g.add_argument(
+    "--turnback-home-vector-alignment-window-radius-frames",
+    type=int,
+    default=2,
+    help=(
+        "Symmetric frame radius used to estimate re-entry heading from x/y "
+        "displacement. Default 2 means position at/near event-2 to position "
+        "at/near event+2."
     ),
 )
 g.add_argument(
@@ -11078,6 +11214,119 @@ def _emit_default_between_reward_sli_plots(vas, gis, gls):
                 f"[postAnalyze] WARNING: failed to generate default {metric} bundle plot: {exc}"
             )
 
+def _turnback_home_vector_alignment_sli_fraction(opts, sli_group: str) -> float:
+    if sli_group == "top":
+        frac = getattr(opts, "top_sli_fraction", None)
+    elif sli_group == "bottom":
+        frac = getattr(opts, "bottom_sli_fraction", None)
+    else:
+        return 1.0
+
+    # For this metric, top/bottom-only exports default to 25% unless the caller
+    # explicitly provides --top-sli-fraction or --bottom-sli-fraction.
+    if frac is None:
+        return 0.25
+    return float(frac)
+
+def _select_turnback_home_vector_alignment_vas(vas):
+    sli_group = getattr(opts, "turnback_home_vector_alignment_sli_group", "all")
+    if sli_group == "all":
+        return vas
+
+    if not vas:
+        return vas
+
+    va0 = vas[0]
+    if getattr(va0, "noyc", False) or getattr(va0, "choice", False):
+        raise RuntimeError(
+            "--turnback-home-vector-alignment-sli-group requires ordinary "
+            "experimental/yoked SLI data; this run appears to be no-yoked-control "
+            "or choice-mode."
+        )
+    
+    sli_training_idx = int(getattr(opts, "best_worst_trn", 2)) - 1
+    use_training_mean = bool(getattr(opts, "sli_use_training_mean", False))
+
+    skip_k = _effective_skip_first_sync_buckets_opts_only(opts)
+    keep_k = _effective_keep_first_sync_buckets_opts_only(opts)
+
+    raw_sel_skip = getattr(opts, "sli_select_skip_first_sync_buckets", None)
+    raw_sel_keep = getattr(opts, "sli_select_keep_first_sync_buckets", None)
+    sel_skip_k = skip_k if raw_sel_skip is None else max(0, int(raw_sel_skip))
+    sel_keep_k = keep_k if raw_sel_keep is None else max(0, int(raw_sel_keep))
+
+    tp_sli, calc_sli = typeCalc("rpid")
+    trns_sli = trnsForType(va0, tp_sli)
+    if not trns_sli:
+        raise RuntimeError(
+            "Could not compute SLI subset for turnback home-vector alignment: "
+            "no SLI trainings were available."
+        )
+
+    a_sli = np.array([vaVarForType(va_, tp_sli, calc_sli) for va_ in vas])
+    a_sli = a_sli.reshape((len(vas), len(trns_sli), -1))
+
+    n_videos = len(vas)
+    n_trains = len(trns_sli)
+    n_flies = len(va0.flies)
+    nb_sli = a_sli.shape[2] // n_flies
+    raw_4 = a_sli.reshape((n_videos, n_trains, n_flies, nb_sli))
+
+    sel_bucket_idx = _resolve_sli_select_bucket_idx(
+        opts,
+        nb=nb_sli,
+        skip_first_sync_buckets=sel_skip_k,
+        keep_first_sync_buckets=sel_keep_k,
+        average_over_buckets=use_training_mean
+    )
+
+    sli_ser = compute_sli_per_fly(
+        raw_4,
+        sli_training_idx,
+        bucket_idx=sel_bucket_idx,
+        average_over_buckets=use_training_mean,
+        skip_first_sync_buckets=sel_skip_k,
+        keep_first_sync_buckets=sel_keep_k,
+    )
+
+    top_fraction = None
+    bottom_fraction = None
+    if sli_group == "top":
+        top_fraction = _turnback_home_vector_alignment_sli_fraction(opts, sli_group)
+    elif sli_group == "bottom":
+        bottom_fraction = _turnback_home_vector_alignment_sli_fraction(opts, sli_group)
+    else:
+        raise ValueError(
+            f"Unknown turnback_home_vector_alignment_sli_group: {sli_group!r}"
+        )
+    
+    saved_bottom, saved_top = select_fractional_groups(
+        sli_ser,
+        top_fraction=top_fraction,
+        bottom_fraction=bottom_fraction,
+    )
+
+    if sli_group == "top":
+        selected = [] if saved_top is None else list(saved_top)
+    else:
+        selected = [] if saved_bottom is None else list(saved_bottom)
+
+    if not selected:
+        raise RuntimeError(
+            "SLI subset selection for turnback home-vector alignment selected no flies "
+            f"(sli_group={sli_group!r}, top_fraction={top_fraction}, "
+            f"bottom_fraction={bottom_fraction})."
+        )
+
+    print(
+        "[turnback-home-vector-alignment] restricting export to "
+        f"{len(selected)} {sli_group}-SLI flies "
+        f"(top_fraction={top_fraction}, bottom_fraction={bottom_fraction}, "
+        f"T{int(sli_training_idx) + 1}, skip={sel_skip_k}, keep={sel_keep_k}, "
+        f"use_training_mean={use_training_mean})"
+    )
+
+    return [vas[i] for i in selected]
 
 def _export_post_analyze_bundles(vas, gls) -> int:
     num_exports = 0
@@ -11177,6 +11426,17 @@ def _export_post_analyze_bundles(vas, gls) -> int:
     if getattr(opts, "export_turnback_excursion_bin_sli_bundle", None):
         export_turnback_excursion_bin_sli_bundle(
             vas, opts, gls, opts.export_turnback_excursion_bin_sli_bundle
+        )
+        num_exports += 1
+
+    if getattr(opts, "export_turnback_home_vector_alignment_sli_bundle", None):
+        vas_for_home_vector = _select_turnback_home_vector_alignment_vas(vas)
+
+        export_turnback_home_vector_alignment_sli_bundle(
+            vas_for_home_vector,
+            opts,
+            gls,
+            opts.export_turnback_home_vector_alignment_sli_bundle,
         )
         num_exports += 1
 

--- a/scripts/run_analysis_matrix.sh
+++ b/scripts/run_analysis_matrix.sh
@@ -215,6 +215,176 @@ run_turnback_pairs() {
     --stats
 }
 
+run_turnback_home_vector_alignment() {
+  local pair_label="$1"
+  local inner_radius_mm="$2"
+  local outer_radius_mm="$3"
+  local filter_tag="$4"
+  local wall_tag="$5"
+
+  local filter_flags=()
+  case "$filter_tag" in
+    noFilt)
+      filter_flags=(--min-turnback-episodes 0)
+      ;;
+    minEpFilt)
+      filter_flags=()
+      ;;
+    minEpSb5Filt)
+      filter_flags=(--require-exp-target-sync-bucket)
+      ;;
+    minEpPiFilt)
+      filter_flags=(--require-exp-pi-threshold-bucket)
+      ;;
+    *)
+      echo "Unknown turnback home-vector alignment filter tag: $filter_tag" >&2
+      exit 1
+      ;;
+  esac
+
+  local wall_flags=()
+  case "$wall_tag" in
+    wall)
+      wall_flags=()
+      ;;
+    noWall)
+      wall_flags=(--turnback-home-vector-alignment-exclude-wall-contact)
+      ;;
+    *)
+      echo "Unknown wall tag: $wall_tag" >&2
+      exit 1
+      ;;
+  esac
+
+  local bundles=()
+
+  for i in "${!GROUP_VARS[@]}"; do
+    local var_name="${GROUP_VARS[$i]}"
+    local dataset="${!var_name}"
+    local group_slug="${GROUP_SLUGS[$i]}"
+    local group_label="${GROUP_LABELS[$i]}"
+    local bundle="exports/turnbackHomeVectorAlignment_${filter_tag}_${wall_tag}_${group_slug}_flatLgc_T2_p${pair_label}_sb2-5_${DATE_TAG}.npz"
+
+    bundles+=("$bundle")
+
+    run_cmd \
+      python analyze.py \
+      -v "$dataset" \
+      -f 0-1 \
+      --rCC 15 \
+      --export-turnback-home-vector-alignment-sli-bundle "$bundle" \
+      --turnback-home-vector-alignment-inner-radius-mm "$inner_radius_mm" \
+      --turnback-home-vector-alignment-outer-radius-mm "$outer_radius_mm" \
+      --turnback-home-vector-alignment-trainings 2 \
+      --turnback-home-vector-alignment-skip-first-sync-buckets 1 \
+      --turnback-home-vector-alignment-keep-first-sync-buckets 4 \
+      --turnback-home-vector-alignment-window-radius-frames 2 \
+      --best-worst-trn 2 \
+      --sli-use-training-mean \
+      --sli-select-skip-first-sync-buckets 1 \
+      --sli-select-keep-first-sync-buckets 4 \
+      --export-group-label "$group_label" \
+      "${filter_flags[@]}" \
+      "${wall_flags[@]}"
+  done
+
+  run_cmd \
+    python -m scripts.plot_overlay_training_metric_scalar_bars \
+    --input "Ctrl>Kir FLC=${bundles[0]}" \
+    --input "PFNd>Kir FLC=${bundles[1]}" \
+    --input "AR Ctrl>Kir FLC=${bundles[2]}" \
+    --out "exports/turnbackHomeVectorAlignment_${filter_tag}_${wall_tag}_flatLgc_T2_p${pair_label}_sb2-5_${DATE_TAG}.png" \
+    --title "Home-vector heading alignment at re-entry, ${inner_radius_mm}/${outer_radius_mm} mm" \
+    --ylabel "Home-vector heading alignment at re-entry" \
+    --stats
+}
+
+run_turnback_home_vector_alignment_top25() {
+  local pair_label="$1"
+  local inner_radius_mm="$2"
+  local outer_radius_mm="$3"
+  local filter_tag="$4"
+  local wall_tag="$5"
+
+  local filter_flags=()
+  case "$filter_tag" in
+    noFilt)
+      filter_flags=(--min-turnback-episodes 0)
+      ;;
+    minEpFilt)
+      filter_flags=()
+      ;;
+    minEpSb5Filt)
+      filter_flags=(--require-exp-target-sync-bucket)
+      ;;
+    minEpPiFilt)
+      filter_flags=(--require-exp-pi-threshold-bucket)
+      ;;
+    *)
+      echo "Unknown turnback home-vector alignment filter tag: $filter_tag" >&2
+      exit 1
+      ;;
+  esac
+
+  local wall_flags=()
+  case "$wall_tag" in
+    wall)
+      wall_flags=()
+      ;;
+    noWall)
+      wall_flags=(--turnback-home-vector-alignment-exclude-wall-contact)
+      ;;
+    *)
+      echo "Unknown wall tag: $wall_tag" >&2
+      exit 1
+      ;;
+  esac
+
+  local bundles=()
+
+  for i in "${!GROUP_VARS[@]}"; do
+    local var_name="${GROUP_VARS[$i]}"
+    local dataset="${!var_name}"
+    local group_slug="${GROUP_SLUGS[$i]}"
+    local group_label="${GROUP_LABELS[$i]}"
+    local bundle="exports/turnbackHomeVectorAlignment_top25_${filter_tag}_${wall_tag}_${group_slug}_flatLgc_T2_p${pair_label}_sliT2Sb2-5_${DATE_TAG}.npz"
+
+    bundles+=("$bundle")
+
+    run_cmd \
+      python analyze.py \
+      -v "$dataset" \
+      -f 0-1 \
+      --rCC 15 \
+      --export-turnback-home-vector-alignment-sli-bundle "$bundle" \
+      --turnback-home-vector-alignment-sli-group top \
+      --top-sli-fraction 0.25 \
+      --turnback-home-vector-alignment-inner-radius-mm "$inner_radius_mm" \
+      --turnback-home-vector-alignment-outer-radius-mm "$outer_radius_mm" \
+      --turnback-home-vector-alignment-trainings 2 \
+      --turnback-home-vector-alignment-skip-first-sync-buckets 1 \
+      --turnback-home-vector-alignment-keep-first-sync-buckets 4 \
+      --turnback-home-vector-alignment-window-radius-frames 2 \
+      --best-worst-trn 2 \
+      --sli-use-training-mean \
+      --sli-select-skip-first-sync-buckets 1 \
+      --sli-select-keep-first-sync-buckets 4 \
+      --export-group-label "$group_label" \
+      "${filter_flags[@]}" \
+      "${wall_flags[@]}"
+  done
+
+  run_cmd \
+    python -m scripts.plot_overlay_training_metric_scalar_bars \
+    --input "Ctrl>Kir FLC=${bundles[0]}" \
+    --input "PFNd>Kir FLC=${bundles[1]}" \
+    --input "AR Ctrl>Kir FLC=${bundles[2]}" \
+    --out "exports/turnbackHomeVectorAlignment_top25_${filter_tag}_${wall_tag}_flatLgc_T2_p${pair_label}_sliT2Sb2-5_${DATE_TAG}.png" \
+    --title "Top 25% SLI: home-vector heading alignment at re-entry, ${inner_radius_mm}/${outer_radius_mm} mm" \
+    --ylabel "Home-vector heading alignment at re-entry" \
+    --stats
+}
+
 run_return_leg_tortuosity_bins() {
   local bins_label="$1"
   local bins_arg="$2"
@@ -417,15 +587,15 @@ run_post_wall_departure_tortuosity() {
 # plot per cohort, ranked by mean T2 SLI over sync buckets 2-5.
 # ---------------------------------------------------------------------
 
-for filter_tag in noFilt minEpFilt minEpSb5Filt minEpPiFilt; do
-  for wall_tag in wall noWall; do
-    run_turnback_pairs \
-      "3-5_8-10_13-15" \
-      "3:5,8:10,13:15" \
-      "$filter_tag" \
-      "$wall_tag"
-  done
-done
+# for filter_tag in noFilt minEpFilt minEpSb5Filt minEpPiFilt; do
+#   for wall_tag in wall noWall; do
+#     run_turnback_pairs \
+#       "3-5_8-10_13-15" \
+#       "3:5,8:10,13:15" \
+#       "$filter_tag" \
+#       "$wall_tag"
+#   done
+# done
 
 # ---------------------------------------------------------------------
 # Turnback ratio
@@ -454,6 +624,42 @@ done
 #     minEpSb5Filt \
 #     "$wall_tag"
 # done
+
+# ---------------------------------------------------------------------
+# Turnback home-vector heading alignment at successful re-entry
+# Metric: cos(heading - home vector), using displacement-derived heading
+# around the re-entry event.
+# Default analysis window: Training 2, sync buckets 2 through 5.
+# Episode geometry: absolute inner/outer radii from reward-circle center,
+# matching turnback-ratio default pairs: 3/5, 8/10, 13/15 mm.
+# wall: include all successful re-entry episodes
+# noWall: discard successful re-entry episodes overlapping wall contact
+# ---------------------------------------------------------------------
+
+# for filter_tag in minEpSb5Filt noFilt minEpFilt minEpPiFilt; do
+#   for wall_tag in wall noWall; do
+#     run_turnback_home_vector_alignment "3-5" 3 5 "$filter_tag" "$wall_tag"
+#     run_turnback_home_vector_alignment "8-10" 8 10 "$filter_tag" "$wall_tag"
+#     run_turnback_home_vector_alignment "13-15" 13 15 "$filter_tag" "$wall_tag"
+#   done
+# done
+
+# ---------------------------------------------------------------------
+# Top-25% learner subset: turnback home-vector heading alignment
+# SLI ranking: Training 2, sync buckets 2 through 5.
+# Episode geometry: absolute inner/outer radii from reward-circle center,
+# matching turnback-ratio default pairs: 3/5, 8/10, 13/15 mm.
+# wall: include all successful re-entry episodes
+# noWall: discard successful re-entry episodes overlapping wall contact
+# ---------------------------------------------------------------------
+
+for filter_tag in minEpSb5Filt; do
+  for wall_tag in wall noWall; do
+    run_turnback_home_vector_alignment_top25 "3-5" 3 5 "$filter_tag" "$wall_tag"
+    run_turnback_home_vector_alignment_top25 "8-10" 8 10 "$filter_tag" "$wall_tag"
+    run_turnback_home_vector_alignment_top25 "13-15" 13 15 "$filter_tag" "$wall_tag"
+  done
+done
 
 # ---------------------------------------------------------------------
 # Top-25% mean return-leg tortuosity by max-distance bin

--- a/src/analysis/video_analysis.py
+++ b/src/analysis/video_analysis.py
@@ -680,6 +680,18 @@ class VideoAnalysis:
                     False,
                 )
             )
+            or (
+                getattr(
+                    self.opts,
+                    "export_turnback_home_vector_alignment_sli_bundle",
+                    None
+                )
+                and getattr(
+                    self.opts,
+                    "turnback_home_vector_alignment_exclude_wall_contact",
+                    False
+                )
+            )
         )
 
         keep_wall_regions_for_post_wall_departure_tortuosity = bool(

--- a/src/exporting/turnback_home_vector_alignment_sli_bundle.py
+++ b/src/exporting/turnback_home_vector_alignment_sli_bundle.py
@@ -1,0 +1,738 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+
+import numpy as np
+
+from src.analysis.episode_filters import (
+    EPISODE_TYPE_INNER_EXIT_REENTRY,
+    episode_filter_accounting_payload,
+    min_episode_count_for_type,
+)
+from src.exporting.com_sli_bundle import _safe_group_label
+from src.exporting.turnback_excursion_bin_sli_bundle import (
+    _frame_in_windows,
+    _selected_windows_for_va,
+)
+from src.exporting.wall_contact_episode_filter import (
+    episode_overlaps_wall_contact,
+    wall_contact_regions_for_trj,
+)
+from src.utils.parsers import parse_training_selector
+from src.utils.util import meanConfInt
+
+Y_LABEL = "Home-vector heading alignment at re-entry"
+BASE_TITLE = "Turnback home-vector heading alignment"
+
+
+def _selected_training_indices(vas, opts) -> list[int]:
+    """
+    Resolve selected trainings for this metric.
+
+    Defaults to Training 2, matching the common analysis window requested for
+    turnback home-vector alignment. Uses this metric's own CLI namespace rather
+    than the turnback-excursion-bin namespace.
+    """
+    vas_ok = [va for va in vas if not getattr(va, "_skipped", False)]
+    if not vas_ok:
+        return []
+
+    n_trn = len(getattr(vas_ok[0], "trns", []) or [])
+    raw = getattr(opts, "turnback_home_vector_alignment_trainings", None)
+    if raw is None or not str(raw).strip():
+        raw = "2"
+
+    selected = []
+    for idx1 in parse_training_selector(str(raw)):
+        idx0 = int(idx1) - 1
+        if 0 <= idx0 < n_trn:
+            selected.append(idx0)
+
+    selected = sorted(set(selected))
+    if selected:
+        return selected
+
+    print(
+        "[export] WARNING: --turnback-home-vector-alignment-trainings selected no "
+        "valid trainings; falling back to all trainings."
+    )
+    return list(range(n_trn))
+
+
+def _effective_windowing(opts) -> tuple[int, int, int]:
+    """
+    Resolve sync-bucket windowing for this metric.
+
+    Defaults to skip first sync bucket and keep the next four, i.e. sync buckets
+    2 through 5 for Training 2.
+    """
+    raw_skip = getattr(
+        opts, "turnback_home_vector_alignment_skip_first_sync_buckets", None
+    )
+    raw_keep = getattr(
+        opts, "turnback_home_vector_alignment_keep_first_sync_buckets", None
+    )
+    raw_last = getattr(opts, "turnback_home_vector_alignment_last_sync_buckets", None)
+
+    skip_first = 1 if raw_skip is None else raw_skip
+    keep_first = 4 if raw_keep is None else raw_keep
+    last_sync = 0 if raw_last is None else raw_last
+
+    return (
+        max(0, int(skip_first or 0)),
+        max(0, int(keep_first or 0)),
+        max(0, int(last_sync or 0)),
+    )
+
+
+def _sli_subset_label(opts) -> str | None:
+    sli_group = getattr(opts, "turnback_home_vector_alignment_sli_group", "all")
+    if sli_group == "all":
+        return None
+
+    if sli_group == "top":
+        frac = getattr(opts, "top_sli_fraction", None)
+        if frac is None:
+            frac = 0.25
+        return f"top {float(frac) * 100:g}% SLI flies"
+
+    if sli_group == "bottom":
+        frac = getattr(opts, "bottom_sli_fraction", None)
+        if frac is None:
+            frac = 0.25
+        return f"bottom {float(frac) * 100:g}% SLI flies"
+
+    return None
+
+
+def _sli_selection_meta(opts) -> dict:
+    return {
+        "sli_group": getattr(opts, "turnback_home_vector_alignment_sli_group", "all"),
+        "top_sli_fraction": getattr(opts, "top_sli_fraction", None),
+        "bottom_sli_fraction": getattr(opts, "bottom_sli_fraction", None),
+        "sli_selection": {
+            "training": getattr(opts, "best_worst_trn", None),
+            "use_training_mean": bool(getattr(opts, "sli_use_training_mean", False)),
+            "skip_first_sync_buckets": getattr(
+                opts, "sli_select_skip_first_sync_buckets", None
+            ),
+            "keep_first_sync_buckets": getattr(
+                opts, "sli_select_keep_first_sync_buckets", None
+            ),
+            "bucket": getattr(opts, "sli_select_bucket", None),
+        },
+    }
+
+
+def _panel_label(
+    selected_trainings, skip_first: int, keep_first: int, last_sync_buckets: int
+) -> str:
+    trn_txt = (
+        "Training " + ",".join(str(int(i) + 1) for i in selected_trainings)
+        if selected_trainings
+        else "Selected trainings"
+    )
+
+    if last_sync_buckets:
+        sb_txt = f"last {int(last_sync_buckets)} sync buckets"
+    elif keep_first:
+        first = int(skip_first) + 1
+        last = int(skip_first) + int(keep_first)
+        sb_txt = f"sync buckets {first}-{last}"
+    elif skip_first:
+        sb_txt = f"sync buckets after first {int(skip_first)} skipped"
+    else:
+        sb_txt = "all sync buckets"
+
+    return f"{trn_txt}, {sb_txt}"
+
+
+def _unit_id_for_va_fly(va, vi: int, fly_idx: int) -> str:
+    video_id = os.path.splitext(
+        os.path.basename(str(getattr(va, "fn", f"video_{vi}")))
+    )[0]
+    if getattr(va, "f", None) is not None:
+        return f"{video_id}:fly{int(getattr(va, 'f')) + int(getattr(va, 'nef', 0)) * int(fly_idx)}"
+    return f"{video_id}:fly{int(fly_idx)}"
+
+
+def _safe_finite_xy_at(trj, frame_idx: int) -> tuple[float, float] | None:
+    if frame_idx < 0:
+        return None
+    if frame_idx >= len(getattr(trj, "x", [])) or frame_idx >= len(
+        getattr(trj, "y", [])
+    ):
+        return None
+
+    x = float(trj.x[frame_idx])
+    y = float(trj.y[frame_idx])
+    if not (np.isfinite(x) and np.isfinite(y)):
+        return None
+    return x, y
+
+
+def _nearest_finite_xy(
+    trj,
+    target_idx: int,
+    *,
+    lo: int,
+    hi: int,
+    prefer: str,
+) -> tuple[int, float, float] | None:
+    """
+    Find a finite x/y sample inside [lo, hi], preferring a sample near target_idx.
+
+    prefer="before" searches target, target-1, ... then target+1, ...
+    prefer="after" searches target, target+1, ... then target-1, ...
+
+    The asymmetric preference keeps the heading window close to the intended
+    pre/post re-entry samples while still surviving short windows and sparse NaNs.
+    """
+    lo = max(0, int(lo))
+    hi = min(int(hi), len(getattr(trj, "x", [])) - 1, len(getattr(trj, "y", [])) - 1)
+    if hi < lo:
+        return None
+
+    target_idx = min(max(int(target_idx), lo), hi)
+
+    if prefer == "before":
+        order = list(range(target_idx, lo - 1, -1)) + list(
+            range(target_idx + 1, hi + 1)
+        )
+    elif prefer == "after":
+        order = list(range(target_idx, hi + 1)) + list(
+            range(target_idx - 1, lo - 1, -1)
+        )
+    else:
+        raise ValueError(f"unknown finite-sample preference: {prefer!r}")
+
+    seen = set()
+    for idx in order:
+        if idx in seen:
+            continue
+        seen.add(idx)
+        xy = _safe_finite_xy_at(trj, idx)
+        if xy is None:
+            continue
+        x, y = xy
+        return int(idx), float(x), float(y)
+
+    return None
+
+
+def heading_vector_at_reentry(
+    trj,
+    event_frame: int,
+    *,
+    window_radius_frames: int = 2,
+    training_start: int | None = None,
+    training_stop: int | None = None,
+) -> tuple[float, float] | None:
+    """
+    Estimate heading from local displacement around the re-entry event.
+
+    We intentionally use x/y displacement rather than Trajectory.theta here.
+    The default uses net displacement across a small symmetric frame window:
+    position_after - position_before.
+
+    NaNs, training bounds, and short windows are handled by choosing the nearest
+    finite sample on each side of the requested window. If no nonzero finite
+    displacement can be recovered, return None.
+    """
+    radius = max(0, int(window_radius_frames or 0))
+    event_frame = int(event_frame)
+
+    lo_bound = 0 if training_start is None else int(training_start)
+    hi_bound = len(getattr(trj, "x", [])) - 1
+    hi_bound = min(hi_bound, len(getattr(trj, "y", [])) - 1)
+    if training_stop is not None:
+        hi_bound = min(hi_bound, int(training_stop) - 1)
+
+    before_target = event_frame - radius
+    after_target = event_frame + radius
+
+    before = _nearest_finite_xy(
+        trj, before_target, lo=lo_bound, hi=event_frame, prefer="before"
+    )
+    after = _nearest_finite_xy(
+        trj, after_target, lo=event_frame, hi=hi_bound, prefer="after"
+    )
+
+    # Fallback for radius=0 or one-sided short windows: use the nearest distinct
+    # finite samples around the event. This is deliberately a fallback, not the
+    # main estimator.
+    if before is None or after is None or before[0] == after[0]:
+        before = _nearest_finite_xy(
+            trj,
+            event_frame - 1,
+            lo=lo_bound,
+            hi=max(lo_bound, event_frame - 1),
+            prefer="before",
+        )
+        after = _nearest_finite_xy(
+            trj,
+            event_frame + 1,
+            lo=min(hi_bound, event_frame + 1),
+            hi=hi_bound,
+            prefer="after",
+        )
+
+    if before is None or after is None or before[0] == after[0]:
+        return None
+
+    _bi, bx, by = before
+    _ai, ax, ay = after
+    hx = float(ax - bx)
+    hy = float(ay - by)
+    if not (np.isfinite(hx) and np.isfinite(hy)):
+        return None
+    if np.hypot(hx, hy) <= 0.0:
+        return None
+    return hx, hy
+
+
+def home_vector_from_reentry_to_center(
+    *,
+    cx: float,
+    cy: float,
+    radius_px: float,
+    x: float,
+    y: float,
+) -> tuple[float, float] | None:
+    """
+    Return perimeter_point -> reward_center for the re-entry radial line.
+
+    If re-entry is already on the perimeter, the perimeter point is effectively
+    the observed re-entry position. If the point is slightly inside/outside due
+    to thresholding, projecting to the perimeter keeps the home vector radial.
+    """
+    rx = float(x) - float(cx)
+    ry = float(y) - float(cy)
+    d = float(np.hypot(rx, ry))
+    if not np.isfinite(d) or d <= 0.0:
+        return None
+
+    perimeter_x = float(cx) + float(radius_px) * rx / d
+    perimeter_y = float(cy) + float(radius_px) * ry / d
+
+    hx = float(cx) - perimeter_x
+    hy = float(cy) - perimeter_y
+    if not (np.isfinite(hx) and np.isfinite(hy)):
+        return None
+    if np.hypot(hx, hy) <= 0.0:
+        return None
+    return hx, hy
+
+
+def cosine_alignment(heading_vec, home_vec) -> float:
+    hx, hy = map(float, heading_vec)
+    vx, vy = map(float, home_vec)
+
+    hnorm = float(np.hypot(hx, hy))
+    vnorm = float(np.hypot(vx, vy))
+    if hnorm <= 0.0 or vnorm <= 0.0:
+        return float("nan")
+
+    val = (hx * vx + hy * vy) / (hnorm * vnorm)
+    if not np.isfinite(val):
+        return float("nan")
+
+    # Retain the raw cosine scale [-1, 1], but clip tiny floating point spillover.
+    return float(np.clip(val, -1.0, 1.0))
+
+
+def episode_home_vector_alignment(
+    trj, trn, ep: dict, *, window_radius_frames: int = 2
+) -> float:
+    event_frame = int(ep["stop"]) - 1
+
+    event_xy = _safe_finite_xy_at(trj, event_frame)
+    if event_xy is None:
+        return float("nan")
+    x, y = event_xy
+
+    try:
+        cx, cy, reward_radius_px = trn.circles(getattr(trj, "f", 0))[0]
+    except Exception:
+        return float("nan")
+
+    inner_radius_px = ep.get("inner_radius_px", np.nan)
+    if not np.isfinite(inner_radius_px):
+        inner_radius_px = ep.get("effective_inner_radius_mm", np.nan)
+        px_per_mm = ep.get("px_per_mm", np.nan)
+        if np.isfinite(inner_radius_px) and np.isfinite(px_per_mm):
+            inner_radius_px = float(inner_radius_px) * float(px_per_mm)
+
+    if not np.isfinite(inner_radius_px):
+        inner_radius_px = float(reward_radius_px)
+
+    heading_vec = heading_vector_at_reentry(
+        trj,
+        event_frame,
+        window_radius_frames=window_radius_frames,
+        training_start=int(getattr(trn, "start", 0)),
+        training_stop=int(getattr(trn, "stop", len(getattr(trj, "x", [])))),
+    )
+    if heading_vec is None:
+        return float("nan")
+
+    home_vec = home_vector_from_reentry_to_center(
+        cx=float(cx),
+        cy=float(cy),
+        radius_px=float(inner_radius_px),
+        x=float(x),
+        y=float(y),
+    )
+
+    if home_vec is None:
+        return float("nan")
+
+    return cosine_alignment(heading_vec, home_vec)
+
+
+def _mean_ci(
+    vals: np.ndarray, *, ci_conf: float = 0.95
+) -> tuple[float, float, float, int]:
+    vals = np.asarray(vals, dtype=float)
+    vals = vals[np.isfinite(vals)]
+    if vals.size == 0:
+        return float("nan"), float("nan"), float("nan"), 0
+    m, lo, hi, n = meanConfInt(vals, conf=float(ci_conf))
+    return float(m), float(lo), float(hi), int(n)
+
+
+def _iter_successful_selected_episode_values_for_fly(
+    va,
+    trj,
+    fly_idx: int,
+    *,
+    selected_trainings: list[int],
+    skip_first: int,
+    keep_first: int,
+    last_sync_buckets: int,
+    exclude_wall_contact: bool,
+    window_radius_frames: int,
+    inner_radius_mm: float | None,
+    inner_delta_mm: float | None,
+    outer_radius_mm: float | None,
+    outer_delta_mm: float | None,
+    border_width_mm: float,
+    radius_offset_px: float,
+):
+    windows = _selected_windows_for_va(
+        va,
+        selected_trainings,
+        skip_first=skip_first,
+        keep_first=keep_first,
+        last_sync_buckets=last_sync_buckets,
+    )
+    if not windows:
+        return
+
+    windows_by_training: dict[int, list[dict]] = {}
+    for win in windows:
+        windows_by_training.setdefault(int(win["training_idx"]), []).append(win)
+
+    wall_regions = wall_contact_regions_for_trj(
+        trj,
+        enabled=bool(exclude_wall_contact),
+        warned_missing=[False],
+        log_tag="turnback-home-vector-alignment",
+    )
+
+    for t_idx in selected_trainings:
+        if t_idx >= len(getattr(va, "trns", [])):
+            continue
+        trn = va.trns[t_idx]
+        if trn is None or not trn.isCircle():
+            continue
+        if t_idx not in windows_by_training:
+            continue
+
+        episodes = trj.reward_turnback_dual_circle_episodes_for_training(
+            trn=trn,
+            inner_radius_mm=inner_radius_mm,
+            inner_delta_mm=inner_delta_mm,
+            outer_radius_mm=outer_radius_mm,
+            outer_delta_mm=outer_delta_mm,
+            border_width_mm=float(border_width_mm),
+            debug=False,
+            radius_offset_px=float(radius_offset_px),
+        )
+        if not episodes:
+            continue
+
+        for ep in episodes:
+            if not bool(ep.get("turns_back", False)):
+                continue
+            if ep.get("end_reason", "reenter_inner") != "reenter_inner":
+                continue
+            if episode_overlaps_wall_contact(ep, wall_regions):
+                continue
+
+            event_t = int(ep["stop"]) - 1
+            if not _frame_in_windows(event_t, windows_by_training[t_idx]):
+                continue
+
+            val = episode_home_vector_alignment(
+                trj, trn, ep, window_radius_frames=window_radius_frames
+            )
+            if np.isfinite(val):
+                yield float(val)
+
+
+def _collect_per_fly_values(
+    vas,
+    opts,
+    *,
+    selected_trainings: list[int],
+    skip_first,
+    keep_first,
+    last_sync_buckets: int,
+):
+    min_episodes = min_episode_count_for_type(opts, EPISODE_TYPE_INNER_EXIT_REENTRY)
+
+    inner_radius_mm = getattr(
+        opts, "turnback_home_vector_alignment_inner_radius_mm", None
+    )
+    inner_delta_mm = getattr(
+        opts, "turnback_home_vector_alignment_inner_delta_mm", None
+    )
+    outer_radius_mm = getattr(
+        opts, "turnback_home_vector_alignment_outer_radius_mm", None
+    )
+    outer_delta_mm = getattr(
+        opts, "turnback_home_vector_alignment_outer_delta_mm", None
+    )
+
+    # Default to the regular turnback geometry, but only successful inner re-entry
+    # episodes contribute values.
+    if inner_radius_mm is None:
+        inner_radius_mm = getattr(opts, "turnback_inner_radius_mm", None)
+    if inner_delta_mm is None:
+        inner_delta_mm = getattr(opts, "turnback_inner_delta_mm", None)
+    if outer_radius_mm is None:
+        outer_radius_mm = getattr(opts, "turnback_outer_radius_mm", None)
+    if outer_delta_mm is None:
+        outer_delta_mm = getattr(opts, "turnback_outer_delta_mm", None)
+
+    inner_radius_mm = None if inner_radius_mm is None else float(inner_radius_mm)
+    inner_delta_mm = 0.0 if inner_delta_mm is None else float(inner_delta_mm)
+    outer_radius_mm = None if outer_radius_mm is None else float(outer_radius_mm)
+    outer_delta_mm = 2.0 if outer_delta_mm is None else float(outer_delta_mm)
+
+    border_width_mm = float(
+        getattr(
+            opts,
+            "turnback_home_vector_alignment_border_width_mm",
+            getattr(opts, "turnback_border_width_mm", 0.1),
+        )
+        or 0.1
+    )
+    radius_offset_px = float(
+        getattr(
+            opts,
+            "turnback_home_vector_alignment_inner_radius_offset_px",
+            getattr(opts, "turnback_inner_radius_offset_px", 0.0),
+        )
+        or 0.0
+    )
+    exclude_wall_contact = bool(
+        getattr(opts, "turnback_home_vector_alignment_exclude_wall_contact", False)
+    )
+    window_radius_frames = max(
+        0,
+        int(
+            getattr(opts, "turnback_home_vector_alignment_window_radius_frames", 2) or 0
+        ),
+    )
+
+    per_unit_ids = []
+    per_unit_values = []
+    per_unit_episode_counts = []
+
+    for vi, va in enumerate(vas):
+        if getattr(va, "_skipped", False):
+            continue
+
+        for fly_idx, trj in enumerate(getattr(va, "trx", [])):
+            if fly_idx > 1:
+                continue
+            if fly_idx == 1 and getattr(va, "noyc", False):
+                continue
+            if fly_idx != 0:
+                # The currently targeted three-group plot is one scalar per experimental fly.
+                # Keeping this explicit avoids accidentally mixing yoked controls.
+                continue
+            if getattr(trj, "_bad", False):
+                continue
+
+            vals = np.asarray(
+                list(
+                    _iter_successful_selected_episode_values_for_fly(
+                        va,
+                        trj,
+                        fly_idx,
+                        selected_trainings=selected_trainings,
+                        skip_first=skip_first,
+                        keep_first=keep_first,
+                        last_sync_buckets=last_sync_buckets,
+                        exclude_wall_contact=exclude_wall_contact,
+                        window_radius_frames=window_radius_frames,
+                        inner_radius_mm=inner_radius_mm,
+                        inner_delta_mm=inner_delta_mm,
+                        outer_radius_mm=outer_radius_mm,
+                        outer_delta_mm=outer_delta_mm,
+                        border_width_mm=border_width_mm,
+                        radius_offset_px=radius_offset_px,
+                    )
+                ),
+                dtype=float,
+            )
+            vals = vals[np.isfinite(vals)]
+            n_ep = int(vals.size)
+            if n_ep < int(min_episodes):
+                continue
+
+            per_unit_ids.append(_unit_id_for_va_fly(va, vi, fly_idx))
+            per_unit_values.append(float(np.mean(vals)))
+            per_unit_episode_counts.append(n_ep)
+
+    return (
+        np.asarray(per_unit_ids, dtype=object),
+        np.asarray(per_unit_values, dtype=float),
+        np.asarray(per_unit_episode_counts, dtype=int),
+        {
+            "inner_radius_mm": (
+                np.nan if inner_radius_mm is None else float(inner_radius_mm)
+            ),
+            "inner_delta_mm": (
+                np.nan if inner_delta_mm is None else float(inner_delta_mm)
+            ),
+            "outer_radius_mm": (
+                np.nan if outer_radius_mm is None else float(outer_radius_mm)
+            ),
+            "outer_delta_mm": (
+                np.nan if outer_delta_mm is None else float(outer_delta_mm)
+            ),
+            "border_width_mm": float(border_width_mm),
+            "radius_offset_px": float(radius_offset_px),
+            "exclude_wall_contact": bool(exclude_wall_contact),
+            "window_radius_frames": int(window_radius_frames),
+            "min_turnback_episodes": int(min_episodes),
+        },
+    )
+
+
+def export_turnback_home_vector_alignment_sli_bundle(vas, opts, gls, out_fn):
+    """
+    Export one scalar per experimental fly:
+    mean cos(heading_at_reentry - home_vector) over successful re-entry episodes.
+
+    Output intentionally matches the scalar-bar NPZ schema consumed by
+    scripts/plot_overlay_training_metric_scalar_bars.py.
+    """
+    if not out_fn.lower().endswith(".npz"):
+        out_fn += ".npz"
+
+    vas_ok = [va for va in vas if not getattr(va, "_skipped", False)]
+    if len(vas_ok) == 0:
+        print(f"[export] No non-skipped VideoAnalysis instances; not writing {out_fn}")
+        return
+
+    selected_trainings = _selected_training_indices(vas_ok, opts)
+    skip_first, keep_first, last_sync_buckets = _effective_windowing(opts)
+
+    ids, values, episode_counts, metric_meta = _collect_per_fly_values(
+        vas_ok,
+        opts,
+        selected_trainings=selected_trainings,
+        skip_first=skip_first,
+        keep_first=keep_first,
+        last_sync_buckets=last_sync_buckets,
+    )
+
+    mean, ci_lo, ci_hi, n_units = _mean_ci(values, ci_conf=0.95)
+
+    meta = {
+        "log_tag": "turnback-home-vector-alignment",
+        "y_label": Y_LABEL,
+        "base_title": BASE_TITLE,
+        "pool_trainings": True,
+        "subset_label": _sli_subset_label(opts),
+        "ci": True,
+        "ci_conf": 0.95,
+        "skip_first_sync_buckets": int(skip_first),
+        "keep_first_sync_buckets": int(keep_first),
+        "last_sync_buckets": int(last_sync_buckets),
+        "training_selection": {
+            "trainings_user": getattr(
+                opts, "turnback_home_vector_alignment_trainings", None
+            ),
+            "trainings_effective": [int(i) + 1 for i in selected_trainings],
+        },
+        "generated_utc": datetime.now(timezone.utc).isoformat(),
+        "group_label": _safe_group_label(opts, gls),
+        "metric": "turnback_home_vector_alignment",
+        "heading_convention": (
+            "displacement-derived heading from local x/y trajectory window around "
+            "the re-entry event; does not use Trajectory.theta"
+        ),
+        **_sli_selection_meta(opts),
+        **metric_meta,
+    }
+
+    panel_label = _panel_label(
+        selected_trainings,
+        skip_first, keep_first, last_sync_buckets
+    )
+    subset_label = _sli_subset_label(opts)
+    if subset_label:
+        panel_label = f"{panel_label}; {subset_label}"
+
+    payload = {
+        "panel_labels": np.asarray([panel_label], dtype=object),
+        "per_unit_values_panel": np.asarray([values], dtype=object),
+        "per_unit_ids_panel": np.asarray([ids], dtype=object),
+        "mean": np.asarray([mean], dtype=float),
+        "ci_lo": np.asarray([ci_lo], dtype=float),
+        "ci_hi": np.asarray([ci_hi], dtype=float),
+        "n_units_panel": np.asarray([n_units], dtype=int),
+        "meta_json": json.dumps(meta, sort_keys=True),
+        # Extra diagnostics, ignored by the scalar-bar plotter but useful for audits.
+        "turnback_home_vector_alignment_episode_counts": episode_counts,
+        "turnback_home_vector_alignment_trainings": np.asarray(
+            selected_trainings, dtype=int
+        ),
+        "turnback_home_vector_alignment_skip_first_sync_buckets": np.array(
+            skip_first, dtype=int
+        ),
+        "turnback_home_vector_alignment_keep_first_sync_buckets": np.array(
+            keep_first, dtype=int
+        ),
+        "turnback_home_vector_alignment_last_sync_buckets": np.array(
+            last_sync_buckets, dtype=int
+        ),
+        "turnback_home_vector_alignment_window_radius_frames": np.array(
+            int(metric_meta["window_radius_frames"]), dtype=int
+        ),
+        "min_turnback_episodes": np.array(
+            int(metric_meta["min_turnback_episodes"]), dtype=int
+        ),
+        **episode_filter_accounting_payload(
+            "episode_filter_turnback_home_vector_alignment",
+            episode_counts,
+            int(metric_meta["min_turnback_episodes"]),
+            observed=np.ones_like(episode_counts, dtype=bool),
+        ),
+    }
+
+    os.makedirs(os.path.dirname(out_fn) or ".", exist_ok=True)
+    np.savez_compressed(out_fn, **payload)
+
+    print(
+        f"[export] Wrote turnback home-vector alignment scalar bundle: {out_fn} "
+        f"(n={int(n_units)})"
+    )

--- a/test/paper_metrics/test_turnback_home_vector_alignment_truth.py
+++ b/test/paper_metrics/test_turnback_home_vector_alignment_truth.py
@@ -1,0 +1,358 @@
+import json
+from types import SimpleNamespace
+
+import numpy as np
+
+from src.exporting.turnback_home_vector_alignment_sli_bundle import (
+    cosine_alignment,
+    episode_home_vector_alignment,
+    export_turnback_home_vector_alignment_sli_bundle,
+    heading_vector_at_reentry,
+    home_vector_from_reentry_to_center,
+)
+
+
+class _CircleTraining:
+    def __init__(self, *, start=0, stop=10, circle=True, radius_px=10.0, name="T1"):
+        self.start = int(start)
+        self.stop = int(stop)
+        self._circle = bool(circle)
+        self._radius_px = float(radius_px)
+        self._name = str(name)
+
+    def isCircle(self):
+        return self._circle
+
+    def circles(self, _fly_idx):
+        return [(0.0, 0.0, self._radius_px)]
+
+    def name(self):
+        return self._name
+
+    def sname(self):
+        return self.name()
+
+
+class _TrajectoryEpisodes:
+    def __init__(self, *, x, y, episodes, bad=False, fly_idx=0):
+        self.x = np.asarray(x, dtype=float)
+        self.y = np.asarray(y, dtype=float)
+        self._episodes = list(episodes)
+        self._bad = bool(bad)
+        self.f = int(fly_idx)
+        self.calls = []
+
+    def reward_turnback_dual_circle_episodes_for_training(self, **kwargs):
+        self.calls.append(kwargs)
+        return list(self._episodes)
+
+
+def _blank_xy(n):
+    x = np.full(int(n), np.nan, dtype=float)
+    y = np.full(int(n), np.nan, dtype=float)
+    return x, y
+
+
+def _set_xy(x, y, coords):
+    for idx, xy in coords.items():
+        x[int(idx)] = float(xy[0])
+        y[int(idx)] = float(xy[1])
+
+
+def _episode(
+    event_frame,
+    *,
+    start=None,
+    turns_back=True,
+    end_reason="reenter_inner",
+    inner_radius_px=10.0,
+):
+    event_frame = int(event_frame)
+    return {
+        "start": int(event_frame - 3 if start is None else start),
+        # Existing turnback episode convention: stop is one past outcome frame,
+        # so the re-entry frame is stop - 1.
+        "stop": int(event_frame + 1),
+        "turns_back": bool(turns_back),
+        "end_reason": str(end_reason),
+        "inner_radius_px": float(inner_radius_px),
+    }
+
+
+def _default_opts(**overrides):
+    opts = dict(
+        export_group_label="Synthetic Group",
+        min_turnback_episodes=1,
+        turnback_home_vector_alignment_trainings=None,
+        turnback_home_vector_alignment_skip_first_sync_buckets=None,
+        turnback_home_vector_alignment_keep_first_sync_buckets=None,
+        turnback_home_vector_alignment_last_sync_buckets=None,
+        turnback_home_vector_alignment_window_radius_frames=1,
+        turnback_home_vector_alignment_exclude_wall_contact=False,
+        turnback_home_vector_alignment_inner_radius_mm=None,
+        turnback_home_vector_alignment_inner_delta_mm=None,
+        turnback_home_vector_alignment_outer_radius_mm=None,
+        turnback_home_vector_alignment_outer_delta_mm=None,
+        turnback_home_vector_alignment_border_width_mm=None,
+        turnback_home_vector_alignment_inner_radius_offset_px=None,
+        turnback_inner_radius_mm=None,
+        turnback_inner_delta_mm=0.0,
+        turnback_outer_radius_mm=None,
+        turnback_outer_delta_mm=2.0,
+        turnback_border_width_mm=0.1,
+        turnback_inner_radius_offset_px=0.0,
+        turnback_home_vector_alignment_sli_group="all",
+        top_sli_fraction=None,
+        bottom_sli_fraction=None,
+        best_worst_trn=2,
+        sli_use_training_mean=False,
+        sli_select_skip_first_sync_buckets=None,
+        sli_select_keep_first_sync_buckets=None,
+        sli_select_bucket=None,
+    )
+    opts.update(overrides)
+    return SimpleNamespace(**opts)
+
+
+def _make_export_va(*, episodes, coords, sync_bucket_ranges=None, n_frames=140):
+    x, y = _blank_xy(n_frames)
+    _set_xy(x, y, coords)
+
+    trj = _TrajectoryEpisodes(x=x, y=y, episodes=episodes)
+    trns = [
+        _CircleTraining(start=0, stop=50, name="T1"),
+        _CircleTraining(start=100, stop=130, name="T2"),
+    ]
+
+    return SimpleNamespace(
+        fn="fake-video.avi",
+        _skipped=False,
+        noyc=True,
+        trns=trns,
+        trx=[trj],
+        sync_bucket_ranges=(
+            sync_bucket_ranges
+            if sync_bucket_ranges is not None
+            else [[], [(100, 110), (110, 120), (120, 130)]]
+        ),
+    )
+
+
+def test_home_vector_projects_reentry_point_to_perimeter_before_pointing_to_center():
+    # Re-entry point (3, 4) is inside a radius-10 circle but lies on the same
+    # radial line as perimeter point (6, 8). The home vector is therefore
+    # (6, 8) -> (0, 0) = (-6, -8).
+    home_vec = home_vector_from_reentry_to_center(
+        cx=0.0, cy=0.0, radius_px=10.0, x=3.0, y=4.0
+    )
+    np.testing.assert_allclose(home_vec, (-6.0, -8.0))
+
+
+def test_cosine_alignment_reports_homeward_tangent_and_away_cases():
+    np.testing.assert_allclose(cosine_alignment((-2.0, 0.0), (-10.0, 0.0)), 1.0)
+    np.testing.assert_allclose(cosine_alignment((0.0, 2.0), (-10.0, 0.0)), 0.0)
+    np.testing.assert_allclose(cosine_alignment((2.0, 0.0), (-10.0, 0.0)), -1.0)
+
+
+def test_heading_vector_uses_windowed_displacement_and_skips_nans():
+    x, y = _blank_xy(8)
+
+    # event_frame = 3, radius = 2
+    # preferred before target is frame 1 and after target is frame 5.
+    # The frame near the event is NaN, but the selected window endpoints are finite.
+    _set_xy(x, y, {1: (2.0, 0.0), 3: (0.0, 0.0), 4: (np.nan, np.nan), 5: (-2.0, 0.0)})
+    trj = SimpleNamespace(x=x, y=y)
+
+    heading = heading_vector_at_reentry(
+        trj, event_frame=3, window_radius_frames=2, training_start=0, training_stop=8
+    )
+
+    np.testing.assert_allclose(heading, (-4.0, 0.0))
+
+
+def test_heading_vector_radius_zero_falls_back_to_distinct_pre_and_post_samples():
+    x, y = _blank_xy(7)
+    _set_xy(x, y, {2: (2.0, 0.0), 3: (1.0, 0.0), 4: (-1.0, 0.0)})
+    trj = SimpleNamespace(x=x, y=y)
+
+    heading = heading_vector_at_reentry(
+        trj, event_frame=3, window_radius_frames=0, training_start=0, training_stop=7
+    )
+
+    np.testing.assert_allclose(heading, (-3.0, 0.0))
+
+
+def test_episode_home_vector_alignment_for_radial_and_tangent_reentry():
+    trn = _CircleTraining(start=0, stop=10, radius_px=10.0)
+
+    # Re-entry at right perimeter: home vector points left.
+    # Heading leftward across the event gives alignment 1.
+    x1, y1 = _blank_xy(10)
+    _set_xy(x1, y1, {4: (12.0, 0.0), 5: (10.0, 0.0), 6: (8.0, 0.0)})
+    trj_homeward = SimpleNamespace(x=x1, y=y1, f=0)
+    val_homeward = episode_home_vector_alignment(
+        trj_homeward, trn, _episode(5), window_radius_frames=1
+    )
+    np.testing.assert_allclose(val_homeward, 1.0)
+
+    # Same re-entry point, but heading upward across the event: targent, alignment 0.
+    x2, y2 = _blank_xy(10)
+    _set_xy(
+        x2,
+        y2,
+        {4: (10.0, -1.0), 5: (10.0, 0.0), 6: (10.0, 1.0)},
+    )
+    trj_tangent = SimpleNamespace(x=x2, y=y2, f=0)
+    val_tangent = episode_home_vector_alignment(
+        trj_tangent,
+        trn,
+        _episode(5),
+        window_radius_frames=1,
+    )
+    np.testing.assert_allclose(val_tangent, 0.0)
+
+
+def test_export_schema_uses_selected_successful_reentry_episodes_only(tmp_path):
+    episodes = [
+        # This success is in the first T2 sync bucket and should be skipped by
+        # the metric default: skip first sync bucket, keep next four.
+        _episode(105),
+        # Included: radially homeward at re-entry, value 1.
+        _episode(115),
+        # Ignored: failure episode, despite lying in selected window.
+        _episode(118, turns_back=False, end_reason="exit_outer"),
+        # Included: tangent at re-entry, value 0.
+        _episode(125),
+    ]
+
+    coords = {
+        # Skipped sync-bucket success.
+        104: (12.0, 0.0),
+        105: (10.0, 0.0),
+        106: (8.0, 0.0),
+        # Included homeward success.
+        114: (12.0, 0.0),
+        115: (10.0, 0.0),
+        116: (8.0, 0.0),
+        # Failure episode coordinates, should not contribute.
+        117: (12.0, 0.0),
+        118: (10.0, 0.0),
+        119: (8.0, 0.0),
+        # Included tangent success.
+        124: (10.0, -1.0),
+        125: (10.0, 0.0),
+        126: (10.0, 1.0),
+    }
+
+    va = _make_export_va(episodes=episodes, coords=coords)
+    opts = _default_opts(min_turnback_episodes=2)
+    out = tmp_path / "home_vector_alignment.npz"
+
+    export_turnback_home_vector_alignment_sli_bundle(
+        [va], opts, gls=None, out_fn=str(out)
+    )
+
+    with np.load(out, allow_pickle=True) as bundle:
+        for key in (
+            "panel_labels",
+            "per_unit_values_panel",
+            "per_unit_ids_panel",
+            "mean",
+            "ci_lo",
+            "ci_hi",
+            "n_units_panel",
+            "meta_json",
+        ):
+            assert key in bundle.files
+
+        values = bundle["per_unit_values_panel"][0]
+        ids = bundle["per_unit_ids_panel"][0]
+
+        values = np.asarray(bundle["per_unit_values_panel"][0], dtype=float)
+        np.testing.assert_allclose(values, [0.5])
+        np.testing.assert_allclose(bundle["mean"], [0.5])
+        np.testing.assert_array_equal(bundle["n_units_panel"], [1])
+        np.testing.assert_array_equal(ids, ["fake-video:fly0"])
+        np.testing.assert_array_equal(
+            bundle["turnback_home_vector_alignment_episode_counts"],
+            [2],
+        )
+
+        meta = json.loads(bundle["meta_json"].item())
+        assert meta["metric"] == "turnback_home_vector_alignment"
+        assert meta["training_selection"]["trainings_effective"] == [2]
+        assert meta["skip_first_sync_buckets"] == 1
+        assert meta["keep_first_sync_buckets"] == 4
+        assert meta["window_radius_frames"] == 1
+        assert "does not use Trajectory.theta" in meta["heading_convention"]
+
+        # The actual episode iterator should receive the same default turnback
+        # geometry used by the exporter.
+        trj = va.trx[0]
+        assert trj.calls[0]["inner_delta_mm"] == 0.0
+        assert trj.calls[0]["outer_delta_mm"] == 2.0
+
+
+def test_export_min_episode_filter_excludes_low_count_fly(tmp_path):
+    episodes = [
+        _episode(115),
+    ]
+    coords = {
+        114: (12.0, 0.0),
+        115: (10.0, 0.0),
+        116: (8.0, 0.0),
+    }
+
+    va = _make_export_va(episodes=episodes, coords=coords)
+    opts = _default_opts(min_turnback_episodes=2)
+    out = tmp_path / "home_vector_alignment_min_filter.npz"
+
+    export_turnback_home_vector_alignment_sli_bundle(
+        [va], opts, gls=None, out_fn=str(out)
+    )
+
+    with np.load(out, allow_pickle=True) as bundle:
+        assert bundle["per_unit_values_panel"][0].size == 0
+        assert bundle["per_unit_ids_panel"][0].size == 0
+        np.testing.assert_array_equal(bundle["n_units_panel"], [0])
+        assert np.isnan(bundle["mean"][0])
+
+
+def test_export_records_top_sli_subset_metadata(tmp_path):
+    episodes = [
+        _episode(115),
+        _episode(125),
+    ]
+    coords = {
+        114: (12.0, 0.0),
+        115: (10.0, 0.0),
+        116: (8.0, 0.0),
+        124: (10.0, -1.0),
+        125: (10.0, 0.0),
+        126: (10.0, 1.0),
+    }
+
+    va = _make_export_va(episodes=episodes, coords=coords)
+    opts = _default_opts(
+        turnback_home_vector_alignment_sli_group="top",
+        top_sli_fraction=0.25,
+        best_worst_trn=2,
+        sli_use_training_mean=True,
+        sli_select_skip_first_sync_buckets=1,
+        sli_select_keep_first_sync_buckets=4,
+    )
+    out = tmp_path / "home_vector_alignment_top25.npz"
+
+    export_turnback_home_vector_alignment_sli_bundle(
+        [va], opts, gls=None, out_fn=str(out)
+    )
+
+    with np.load(out, allow_pickle=True) as bundle:
+        meta = json.loads(bundle["meta_json"].item())
+        assert meta["sli_group"] == "top"
+        assert meta["top_sli_fraction"] == 0.25
+        assert meta["subset_label"] == "top 25% SLI flies"
+        assert meta["sli_selection"]["training"] == 2
+        assert meta["sli_selection"]["use_training_mean"] is True
+        assert meta["sli_selection"]["skip_first_sync_buckets"] == 1
+        assert meta["sli_selection"]["keep_first_sync_buckets"] == 4


### PR DESCRIPTION
## Summary

This PR adds a new turnback-derived metric for measuring heading alignment at successful re-entry events.

The metric computes the cosine alignment between:

- the fly's local displacement-derived heading around the re-entry frame, and
- the home vector from the relevant inner-circle perimeter point back to the reward-circle center.

This is intended to answer, for each turnback episode region, whether successful re-entry is accompanied by movement that is already oriented homeward, tangent to the reward circle, or directed away from the reward center.

## Main changes

- Add `turnback_home_vector_alignment_sli_bundle` export module.
- Compute per-episode heading from local x/y displacement rather than `Trajectory.theta`.
- Define home-vector alignment on the raw cosine scale `[-1, 1]`.
- Aggregate values as one scalar per experimental fly.
- Support:
  - Training/window selection, defaulting to Training 2, sync buckets 2-5.
  - Absolute inner/outer radius episode geometry, matching turnback-ratio regions such as `3/5`, `8/10`, and `13/15` mm.
  - Wall-contact episode exclusion.
  - Minimum successful re-entry episode filtering.
  - Top/bottom SLI subset exports, including top-25% learner runs based on T2 sync buckets 2-5.
- Wire the export into `analyze.py`.
- Add scalar-bar overlay plotting support through the existing generic scalar-bar plotting script.
- Update `run_analysis_matrix.sh` with all-fly and top-25% learner dispatchers.
- Add focused truth tests for:
  - home-vector geometry,
  - cosine alignment,
  - displacement-derived heading behavior,
  - synthetic successful re-entry episodes,
  - export schema,
  - min-episode filtering,
  - SLI subset metadata.

## Notes

The default home-vector exporter geometry remains available, but the analysis-matrix runs now explicitly pass absolute inner/outer radii so the episode definitions match the turnback-ratio regions.

For example, the `3/5` run defines episodes as exits from the 3 mm circle that re-enter the 3 mm circle before reaching the 5 mm circle, then computes heading alignment at the successful re-entry frame.

## Testing

- Added and passed focused pytest coverage for the new metric/export path:

```bash
pytest -q test/paper_metrics/test_turnback_home_vector_alignment_truth.py